### PR TITLE
Add support for inherited nullability from PHP

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -255,7 +255,26 @@ For development you should use an array cache like
 ``Symfony\Component\Cache\Adapter\ArrayAdapter``
 which only caches data on a per-request basis.
 
-SQL Logger (**Optional**)
+Nullability detection (**RECOMMENDED**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Since ORM 3.7.0
+
+.. code-block:: php
+
+    <?php
+    $driver = new \Doctrine\ORM\Mapping\Driver\AttributeDriver($paths, inferNullabilityFromPHPType: true);
+    $config->setMetadataDriverImpl($driver);
+
+Sets whether the mapping driver should infer columns nullability from PHP type declarations.
+This is a per-driver setting, which means different entity mappings can use different modes.
+
+You can always override the inferred nullability by specifying the
+``nullable`` option in the Column or JoinColumn definition.
+
+SQL Logger (**OPTIONAL**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -255,7 +255,24 @@ For development you should use an array cache like
 ``Symfony\Component\Cache\Adapter\ArrayAdapter``
 which only caches data on a per-request basis.
 
-SQL Logger (**Optional**)
+Nullability detection (**RECOMMENDED**)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Since ORM 3.6.0
+
+.. code-block:: php
+
+    <?php
+    $config->setInferNullabilityFromPHPType(true);
+
+Sets whether Doctrine should infer columns nullability from PHP types declarations.
+
+You can always override the inferred nullability by specifying the
+``nullable`` option in the Column or JoinColumn definition.
+
+SQL Logger (**OPTIONAL**)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: php

--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -908,9 +908,12 @@ join columns default to the simple, unqualified class name of the
 targeted class followed by "\_id". The referencedColumnName always
 defaults to "id", just as in one-to-one or many-to-one mappings.
 
-Additionally, when using typed properties with Doctrine 2.9 or newer
+Additionally, when using typed properties with ORM 2.9 or newer
 you can skip ``targetEntity`` in ``ManyToOne`` and ``OneToOne``
-associations as they will be set based on type. So that:
+associations as they will be set based on type. Also with ORM 3.7
+or newer, the ``nullable`` attribute on ``JoinColumn`` will be inferred
+from PHP type when using ``inferNullabilityFromPHPType: true`` in the
+mapping driver constructor. So that:
 
 .. configuration-block::
 

--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -901,9 +901,11 @@ join columns default to the simple, unqualified class name of the
 targeted class followed by "\_id". The referencedColumnName always
 defaults to "id", just as in one-to-one or many-to-one mappings.
 
-Additionally, when using typed properties with Doctrine 2.9 or newer
+Additionally, when using typed properties with ORM 2.9 or newer
 you can skip ``targetEntity`` in ``ManyToOne`` and ``OneToOne``
-associations as they will be set based on type. So that:
+associations as they will be set based on type. Also with ORM 3.6
+or newer, the ``nullable`` attribute on ``JoinColumn`` will be inferred
+from PHP type. So that:
 
 .. configuration-block::
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -181,6 +181,7 @@ Optional parameters:
 
 -  **nullable**: Determines if NULL values allowed for this column.
     If not specified, default value is ``false``.
+    Since ORM 3.7, default can be inferred from PHP type when using ``inferNullabilityFromPHPType: true`` in the mapping driver constructor.
 
 -  **insertable**: Boolean value to determine if the column should be
    included when inserting a new row into the underlying entities table.
@@ -684,6 +685,7 @@ Optional parameters:
 -  **deferrable**: Determines whether this relation constraint can be deferred. Defaults to false.
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
+   Since ORM 3.7, default can be inferred from PHP type when using ``inferNullabilityFromPHPType: true`` in the mapping driver constructor.
 -  **onDelete**: Cascade Action (Database-level)
 -  **columnDefinition**: DDL SQL snippet that starts after the column
    name and specifies the complete (non-portable!) column definition.

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -181,6 +181,7 @@ Optional parameters:
 
 -  **nullable**: Determines if NULL values allowed for this column.
     If not specified, default value is ``false``.
+    Since ORM 3.6, default can be inferred from PHP type when using ``$config->setInferNullabilityFromPHPType(true)``.
 
 -  **insertable**: Boolean value to determine if the column should be
    included when inserting a new row into the underlying entities table.
@@ -681,6 +682,7 @@ Optional parameters:
 -  **deferrable**: Determines whether this relation constraint can be deferred. Defaults to false.
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
+   Since ORM 3.6, default can be inferred from PHP type when using ``$config->setInferNullabilityFromPHPType(true)``.
 -  **onDelete**: Cascade Action (Database-level)
 -  **columnDefinition**: DDL SQL snippet that starts after the column
    name and specifies the complete (non-portable!) column definition.

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -258,7 +258,7 @@ Optional attributes:
 -  index - Should an index be created for this column? Defaults to
    false.
 -  nullable - Should this field allow NULL as a value? Defaults to
-   false.
+   false. Since ORM 3.7, default can be inferred from PHP type when using ``inferNullabilityFromPHPType: true`` in the mapping driver constructor.
 -  insertable - Should this field be inserted? Defaults to true.
 -  updatable - Should this field be updated? Defaults to true.
 -  generated - Enum of the values ALWAYS, INSERT, NEVER that determines if
@@ -721,6 +721,7 @@ Optional attributes:
    This makes sense for Many-To-Many join-columns only to simulate a
    one-to-many unidirectional using a join-table.
 -  nullable - should the join column be nullable, defaults to true.
+   Since ORM 3.7, default can be inferred from PHP type when using ``inferNullabilityFromPHPType: true`` in the mapping driver constructor.
 -  on-delete - Foreign Key Cascade action to perform when entity is
    deleted, defaults to NO ACTION/RESTRICT but can be set to
    "CASCADE".

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -257,7 +257,7 @@ Optional attributes:
 -  index - Should an index be created for this column? Defaults to
    false.
 -  nullable - Should this field allow NULL as a value? Defaults to
-   false.
+   false. Since ORM 3.6, default can be inferred from PHP type when using ``$config->setInferNullabilityFromPHPType(true)``.
 -  insertable - Should this field be inserted? Defaults to true.
 -  updatable - Should this field be updated? Defaults to true.
 -  generated - Enum of the values ALWAYS, INSERT, NEVER that determines if
@@ -718,6 +718,7 @@ Optional attributes:
    This makes sense for Many-To-Many join-columns only to simulate a
    one-to-many unidirectional using a join-table.
 -  nullable - should the join column be nullable, defaults to true.
+   Since ORM 3.6, default can be inferred from PHP type when using ``$config->setInferNullabilityFromPHPType(true)``.
 -  on-delete - Foreign Key Cascade action to perform when entity is
    deleted, defaults to NO ACTION/RESTRICT but can be set to
    "CASCADE".

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -973,7 +973,7 @@ parameters:
 			path: src/Mapping/ClassMetadata.php
 
 		-
-			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:validateAndCompleteTypedAssociationMapping\(\) expects array\{type\: 1\|2\|4\|8, fieldName\: string, targetEntity\?\: class\-string\}, non\-empty\-array\<string, mixed\> given\.$#'
+			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:validateAndCompleteTypedAssociationMapping\(\) expects array\{type\: 1\|2\|4\|8, fieldName\: string, targetEntity\?\: class\-string, joinColumns\: array\<int, array\<string, mixed\>\>\|null\}, non\-empty\-array\<string, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/ClassMetadata.php

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -723,4 +723,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         return $this->attributes['fetchModeSubselectBatchSize'] ?? 100;
     }
+
+    public function setInferNullabilityFromPHPType(bool $inferNullabilityFromPHPType): void
+    {
+        $this->attributes['inferNullabilityFromPHPType'] = $inferNullabilityFromPHPType;
+    }
+
+    public function isNullabilityInferredFromPHPType(): bool
+    {
+        return $this->attributes['inferNullabilityFromPHPType'] ?? false;
+    }
 }

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -26,6 +26,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
+use ReflectionType;
 use SortDirection;
 use Stringable;
 
@@ -566,6 +567,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
     private readonly TypedFieldMapper $typedFieldMapper;
 
+    public bool $inferNullabilityFromPHPType = false;
+
     /**
      * Initializes a new ClassMetadata instance that will hold the object-relational mapping
      * metadata of the class with the given name.
@@ -573,8 +576,11 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * @param string $name The name of the entity class the new instance is used for.
      * @phpstan-param class-string<T> $name
      */
-    public function __construct(public string $name, NamingStrategy|null $namingStrategy = null, TypedFieldMapper|null $typedFieldMapper = null)
-    {
+    public function __construct(
+        public string $name,
+        NamingStrategy|null $namingStrategy = null,
+        TypedFieldMapper|null $typedFieldMapper = null,
+    ) {
         $this->rootEntityName   = $name;
         $this->namingStrategy   = $namingStrategy ?? new DefaultNamingStrategy();
         $this->instantiator     = new Instantiator();
@@ -1177,14 +1183,17 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Validates & completes the basic mapping information based on typed property.
      *
-     * @param array{type: self::ONE_TO_ONE|self::MANY_TO_ONE|self::ONE_TO_MANY|self::MANY_TO_MANY, fieldName: string, targetEntity?: class-string} $mapping The mapping.
+     * @phpstan-param array{
+     *     type: self::ONE_TO_ONE|self::MANY_TO_ONE|self::ONE_TO_MANY|self::MANY_TO_MANY,
+     *     fieldName: string,
+     *     targetEntity?: class-string,
+     *     joinColumns: array<int, array<string, mixed>>|null,
+     * } $mapping The mapping.
      *
      * @return mixed[] The updated mapping.
      */
-    private function validateAndCompleteTypedAssociationMapping(array $mapping): array
+    private function validateAndCompleteTypedAssociationMapping(array $mapping, ReflectionType|null $type): array
     {
-        $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
-
         if ($type === null || ($mapping['type'] & self::TO_ONE) === 0) {
             return $mapping;
         }
@@ -1205,6 +1214,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     id?: bool,
      *     generated?: self::GENERATED_*,
      *     enumType?: class-string,
+     *     nullable?: bool|null,
      * } $mapping The field mapping to validate & complete.
      *
      * @return FieldMapping The updated mapping.
@@ -1218,8 +1228,15 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             throw MappingException::missingFieldName($this->name);
         }
 
+        $type = null;
         if ($this->isTypedProperty($mapping['fieldName'])) {
+            $type    = $this->reflClass->getProperty($mapping['fieldName'])->getType();
             $mapping = $this->validateAndCompleteTypedFieldMapping($mapping);
+        }
+
+        // Infer nullable from a type or reset null back to false if the type is missing, Id columns are ignored
+        if ($this->inferNullabilityFromPHPType && ! isset($mapping['nullable']) && ($mapping['id'] ?? false) !== true) {
+            $mapping['nullable'] = $type?->allowsNull() ?? false;
         }
 
         if (! isset($mapping['type'])) {
@@ -1329,8 +1346,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         // the sourceEntity.
         $mapping['sourceEntity'] = $this->name;
 
+        $type = null;
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
+            $type    = $this->reflClass->getProperty($mapping['fieldName'])->getType();
+            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping, $type);
         }
 
         if (isset($mapping['targetEntity'])) {
@@ -1397,6 +1416,25 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
         } else {
             $mapping['isOwningSide'] = false;
+        }
+
+        // Infer nullable from type or reset null back to true if type is missing, Id columns are ignored
+        if ($this->inferNullabilityFromPHPType && $mapping['type'] & self::TO_ONE && ($mapping['id'] ?? false) !== true) {
+            if (! empty($mapping['joinColumns'])) {
+                foreach ($mapping['joinColumns'] as $key => $data) {
+                    if (! isset($data['nullable'])) {
+                        $mapping['joinColumns'][$key]['nullable'] = $type?->allowsNull() ?? true;
+                    }
+                }
+            } elseif ($type !== null && ($mapping['type'] !== self::ONE_TO_ONE || $mapping['isOwningSide'])) { // Ignoring inverse side
+                $mapping['joinColumns'] = [
+                    [
+                        'fieldName' => $mapping['fieldName'],
+                        'nullable' => $type->allowsNull(),
+                        'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
+                    ],
+                ];
+            }
         }
 
         if (isset($mapping['id']) && $mapping['id'] === true && $mapping['type'] & self::TO_MANY) {

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -25,6 +25,7 @@ use LogicException;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
+use ReflectionType;
 use Stringable;
 
 use function array_column;
@@ -560,8 +561,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * @param string $name The name of the entity class the new instance is used for.
      * @phpstan-param class-string<T> $name
      */
-    public function __construct(public string $name, NamingStrategy|null $namingStrategy = null, TypedFieldMapper|null $typedFieldMapper = null)
-    {
+    public function __construct(
+        public string $name,
+        NamingStrategy|null $namingStrategy = null,
+        TypedFieldMapper|null $typedFieldMapper = null,
+        public readonly bool $inferNullabilityFromPHPType = false,
+    ) {
         $this->rootEntityName   = $name;
         $this->namingStrategy   = $namingStrategy ?? new DefaultNamingStrategy();
         $this->instantiator     = new Instantiator();
@@ -1163,14 +1168,17 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     /**
      * Validates & completes the basic mapping information based on typed property.
      *
-     * @param array{type: self::ONE_TO_ONE|self::MANY_TO_ONE|self::ONE_TO_MANY|self::MANY_TO_MANY, fieldName: string, targetEntity?: class-string} $mapping The mapping.
+     * @phpstan-param array{
+     *     type: self::ONE_TO_ONE|self::MANY_TO_ONE|self::ONE_TO_MANY|self::MANY_TO_MANY,
+     *     fieldName: string,
+     *     targetEntity?: class-string,
+     *     joinColumns: array<int, array<string, mixed>>|null,
+     * } $mapping The mapping.
      *
      * @return mixed[] The updated mapping.
      */
-    private function validateAndCompleteTypedAssociationMapping(array $mapping): array
+    private function validateAndCompleteTypedAssociationMapping(array $mapping, ReflectionType|null $type): array
     {
-        $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
-
         if ($type === null || ($mapping['type'] & self::TO_ONE) === 0) {
             return $mapping;
         }
@@ -1191,6 +1199,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     id?: bool,
      *     generated?: self::GENERATED_*,
      *     enumType?: class-string,
+     *     nullable?: bool|null,
      * } $mapping The field mapping to validate & complete.
      *
      * @return FieldMapping The updated mapping.
@@ -1204,8 +1213,15 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             throw MappingException::missingFieldName($this->name);
         }
 
+        $type = null;
         if ($this->isTypedProperty($mapping['fieldName'])) {
+            $type    = $this->reflClass->getProperty($mapping['fieldName'])->getType();
             $mapping = $this->validateAndCompleteTypedFieldMapping($mapping);
+        }
+
+        // Infer nullable from a type or reset null back to false if the type is missing, Id columns are ignored
+        if ($this->inferNullabilityFromPHPType && ! isset($mapping['nullable']) && ($mapping['id'] ?? false) !== true) {
+            $mapping['nullable'] = $type?->allowsNull() ?? false;
         }
 
         if (! isset($mapping['type'])) {
@@ -1315,8 +1331,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
         // the sourceEntity.
         $mapping['sourceEntity'] = $this->name;
 
+        $type = null;
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
+            $type    = $this->reflClass->getProperty($mapping['fieldName'])->getType();
+            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping, $type);
         }
 
         if (isset($mapping['targetEntity'])) {
@@ -1381,6 +1399,25 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
         } else {
             $mapping['isOwningSide'] = false;
+        }
+
+        // Infer nullable from type or reset null back to true if type is missing
+        if ($this->inferNullabilityFromPHPType && $mapping['type'] & self::TO_ONE) {
+            if (! empty($mapping['joinColumns'])) {
+                foreach ($mapping['joinColumns'] as $key => $data) {
+                    if (! isset($data['nullable'])) {
+                        $mapping['joinColumns'][$key]['nullable'] = $type?->allowsNull() ?? true;
+                    }
+                }
+            } elseif ($type !== null && ($mapping['type'] !== self::ONE_TO_ONE || $mapping['isOwningSide'])) { // Ignoring inverse side
+                $mapping['joinColumns'] = [
+                    [
+                        'fieldName' => $mapping['fieldName'],
+                        'nullable' => $type->allowsNull(),
+                        'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
+                    ],
+                ];
+            }
         }
 
         if (isset($mapping['id']) && $mapping['id'] === true && $mapping['type'] & self::TO_MANY) {

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -304,6 +304,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $className,
             $this->em->getConfiguration()->getNamingStrategy(),
             $this->em->getConfiguration()->getTypedFieldMapper(),
+            $this->em->getConfiguration()->isNullabilityInferredFromPHPType(),
         );
     }
 

--- a/src/Mapping/Column.php
+++ b/src/Mapping/Column.php
@@ -10,6 +10,9 @@ use BackedEnum;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Column implements MappingAttribute
 {
+    public readonly bool $nullable;
+    public readonly bool $nullableSet;
+
     /**
      * @param int|null                      $precision The precision for a decimal (exact numeric) column (Applies only for decimal column).
      * @param int|null                      $scale     The scale for a decimal (exact numeric) column (Applies only for decimal column).
@@ -24,7 +27,7 @@ final class Column implements MappingAttribute
         public readonly int|null $precision = null,
         public readonly int|null $scale = null,
         public readonly bool $unique = false,
-        public readonly bool $nullable = false,
+        bool|null $nullable = null,
         public readonly bool $insertable = true,
         public readonly bool $updatable = true,
         public readonly string|null $enumType = null,
@@ -33,5 +36,7 @@ final class Column implements MappingAttribute
         public readonly string|null $generated = null,
         public readonly bool $index = false,
     ) {
+        $this->nullable    = $nullable ?? false;
+        $this->nullableSet = $nullable !== null;
     }
 }

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -39,8 +39,11 @@ class AttributeDriver implements MappingDriver
      * @param string[]|ClassLocator $paths                     a ClassLocator, or an array of directories.
      * @param true                  $reportFieldsWhereDeclared no-op, to be removed in 4.0
      */
-    public function __construct(array|ClassLocator $paths, bool $reportFieldsWhereDeclared = true)
-    {
+    public function __construct(
+        array|ClassLocator $paths,
+        bool $reportFieldsWhereDeclared = true,
+        private readonly bool $inferNullabilityFromPHPType = false,
+    ) {
         if (! $reportFieldsWhereDeclared) {
             throw new InvalidArgumentException(sprintf(
                 'The $reportFieldsWhereDeclared argument is no longer supported, make sure to omit it when calling %s.',
@@ -81,6 +84,8 @@ class AttributeDriver implements MappingDriver
      */
     public function loadMetadataForClass(string $className, PersistenceClassMetadata $metadata): void
     {
+        $metadata->inferNullabilityFromPHPType = $this->inferNullabilityFromPHPType;
+
         $reflectionClass = $metadata->getReflectionClass()
             // this happens when running attribute driver in combination with
             // static reflection services. This is not the nicest fix
@@ -297,15 +302,6 @@ class AttributeDriver implements MappingDriver
                 );
             }
 
-            // Check for JoinColumn/JoinColumns attributes
-            $joinColumns = [];
-
-            $joinColumnAttributes = $this->reader->getPropertyAttributeCollection($property, Mapping\JoinColumn::class);
-
-            foreach ($joinColumnAttributes as $joinColumnAttribute) {
-                $joinColumns[] = $this->joinColumnToArray($joinColumnAttribute);
-            }
-
             // Field can only be attributed with one of:
             // Column, OneToOne, OneToMany, ManyToOne, ManyToMany, Embedded
             $columnAttribute     = $this->reader->getPropertyAttribute($property, Mapping\Column::class);
@@ -315,8 +311,18 @@ class AttributeDriver implements MappingDriver
             $manyToManyAttribute = $this->reader->getPropertyAttribute($property, Mapping\ManyToMany::class);
             $embeddedAttribute   = $this->reader->getPropertyAttribute($property, Mapping\Embedded::class);
 
+            // Check for JoinColumn/JoinColumns attributes
+            $joinColumns = [];
+
+            $joinColumnAttributes = $this->reader->getPropertyAttributeCollection($property, Mapping\JoinColumn::class);
+
+            foreach ($joinColumnAttributes as $joinColumnAttribute) {
+                $joinColumns[] = $this->joinColumnToArray($joinColumnAttribute, $this->inferNullabilityFromPHPType && (
+                    $oneToOneAttribute !== null || $manyToOneAttribute !== null));
+            }
+
             if ($columnAttribute !== null) {
-                $mapping = $this->columnToArray($property->name, $columnAttribute);
+                $mapping = $this->columnToArray($property->name, $columnAttribute, $this->inferNullabilityFromPHPType);
 
                 $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
                 if ($idAttribute !== null) {
@@ -484,10 +490,12 @@ class AttributeDriver implements MappingDriver
 
                 // Check for JoinColumn/JoinColumns attributes
                 if ($associationOverride->joinColumns) {
-                    $joinColumns = [];
+                    $inferNullabilityFromPHPType = $this->inferNullabilityFromPHPType && isset($metadata->associationMappings[$fieldName])
+                        && $metadata->associationMappings[$fieldName]['type'] & ClassMetadata::TO_ONE;
 
+                    $joinColumns = [];
                     foreach ($associationOverride->joinColumns as $joinColumn) {
-                        $joinColumns[] = $this->joinColumnToArray($joinColumn);
+                        $joinColumns[] = $this->joinColumnToArray($joinColumn, $inferNullabilityFromPHPType);
                     }
 
                     $override['joinColumns'] = $joinColumns;
@@ -541,7 +549,7 @@ class AttributeDriver implements MappingDriver
             $attributeOverridesAnnot = $classAttributes[Mapping\AttributeOverrides::class];
 
             foreach ($attributeOverridesAnnot->overrides as $attributeOverride) {
-                $mapping = $this->columnToArray($attributeOverride->name, $attributeOverride->column);
+                $mapping = $this->columnToArray($attributeOverride->name, $attributeOverride->column, $this->inferNullabilityFromPHPType);
 
                 $metadata->setAttributeOverride($attributeOverride->name, $mapping);
             }
@@ -684,24 +692,27 @@ class AttributeDriver implements MappingDriver
      * @phpstan-return array{
      *                   name: string|null,
      *                   unique: bool,
-     *                   nullable: bool,
+     *                   nullable?: bool,
      *                   onDelete: mixed,
      *                   columnDefinition: string|null,
      *                   referencedColumnName: string,
      *                   options?: array<string, mixed>
      *               }
      */
-    private function joinColumnToArray(Mapping\JoinColumn|Mapping\InverseJoinColumn $joinColumn): array
+    private function joinColumnToArray(Mapping\JoinColumn|Mapping\InverseJoinColumn $joinColumn, bool $inferNullabilityFromPHPType = false): array
     {
         $mapping = [
             'name' => $joinColumn->name,
             'deferrable' => $joinColumn->deferrable,
             'unique' => $joinColumn->unique,
-            'nullable' => $joinColumn->nullable,
             'onDelete' => $joinColumn->onDelete,
             'columnDefinition' => $joinColumn->columnDefinition,
             'referencedColumnName' => $joinColumn->referencedColumnName,
         ];
+
+        if (! $inferNullabilityFromPHPType || $joinColumn->nullable !== null) {
+            $mapping['nullable'] = $joinColumn->nullable;
+        }
 
         if ($joinColumn->options) {
             $mapping['options'] = $joinColumn->options;
@@ -720,7 +731,7 @@ class AttributeDriver implements MappingDriver
      *                   scale: int,
      *                   length: int,
      *                   unique: bool,
-     *                   nullable: bool,
+     *                   nullable?: bool|null,
      *                   index: bool,
      *                   precision: int,
      *                   enumType?: class-string,
@@ -729,7 +740,7 @@ class AttributeDriver implements MappingDriver
      *                   columnDefinition?: string
      *               }
      */
-    private function columnToArray(string $fieldName, Mapping\Column $column): array
+    private function columnToArray(string $fieldName, Mapping\Column $column, bool $inferNullabilityFromPHPType = false): array
     {
         $mapping = [
             'fieldName' => $fieldName,
@@ -737,10 +748,13 @@ class AttributeDriver implements MappingDriver
             'scale'     => $column->scale,
             'length'    => $column->length,
             'unique'    => $column->unique,
-            'nullable'  => $column->nullable,
             'index'     => $column->index,
             'precision' => $column->precision,
         ];
+
+        if (! $inferNullabilityFromPHPType || $column->nullableSet) {
+            $mapping['nullable'] = $column->nullable;
+        }
 
         if ($column->options) {
             $mapping['options'] = $column->options;

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -297,15 +297,6 @@ class AttributeDriver implements MappingDriver
                 );
             }
 
-            // Check for JoinColumn/JoinColumns attributes
-            $joinColumns = [];
-
-            $joinColumnAttributes = $this->reader->getPropertyAttributeCollection($property, Mapping\JoinColumn::class);
-
-            foreach ($joinColumnAttributes as $joinColumnAttribute) {
-                $joinColumns[] = $this->joinColumnToArray($joinColumnAttribute);
-            }
-
             // Field can only be attributed with one of:
             // Column, OneToOne, OneToMany, ManyToOne, ManyToMany, Embedded
             $columnAttribute     = $this->reader->getPropertyAttribute($property, Mapping\Column::class);
@@ -315,8 +306,18 @@ class AttributeDriver implements MappingDriver
             $manyToManyAttribute = $this->reader->getPropertyAttribute($property, Mapping\ManyToMany::class);
             $embeddedAttribute   = $this->reader->getPropertyAttribute($property, Mapping\Embedded::class);
 
+            // Check for JoinColumn/JoinColumns attributes
+            $joinColumns = [];
+
+            $joinColumnAttributes = $this->reader->getPropertyAttributeCollection($property, Mapping\JoinColumn::class);
+
+            foreach ($joinColumnAttributes as $joinColumnAttribute) {
+                $joinColumns[] = $this->joinColumnToArray($joinColumnAttribute, $metadata->inferNullabilityFromPHPType && (
+                    $oneToOneAttribute !== null || $manyToOneAttribute !== null));
+            }
+
             if ($columnAttribute !== null) {
-                $mapping = $this->columnToArray($property->name, $columnAttribute);
+                $mapping = $this->columnToArray($property->name, $columnAttribute, $metadata->inferNullabilityFromPHPType);
 
                 if ($this->reader->getPropertyAttribute($property, Mapping\Id::class)) {
                     $mapping['id'] = true;
@@ -479,10 +480,12 @@ class AttributeDriver implements MappingDriver
 
                 // Check for JoinColumn/JoinColumns attributes
                 if ($associationOverride->joinColumns) {
-                    $joinColumns = [];
+                    $inferNullabilityFromPHPType = $metadata->inferNullabilityFromPHPType && isset($metadata->associationMappings[$fieldName])
+                        && $metadata->associationMappings[$fieldName]['type'] & ClassMetadata::TO_ONE;
 
+                    $joinColumns = [];
                     foreach ($associationOverride->joinColumns as $joinColumn) {
-                        $joinColumns[] = $this->joinColumnToArray($joinColumn);
+                        $joinColumns[] = $this->joinColumnToArray($joinColumn, $inferNullabilityFromPHPType);
                     }
 
                     $override['joinColumns'] = $joinColumns;
@@ -536,7 +539,7 @@ class AttributeDriver implements MappingDriver
             $attributeOverridesAnnot = $classAttributes[Mapping\AttributeOverrides::class];
 
             foreach ($attributeOverridesAnnot->overrides as $attributeOverride) {
-                $mapping = $this->columnToArray($attributeOverride->name, $attributeOverride->column);
+                $mapping = $this->columnToArray($attributeOverride->name, $attributeOverride->column, $metadata->inferNullabilityFromPHPType);
 
                 $metadata->setAttributeOverride($attributeOverride->name, $mapping);
             }
@@ -679,24 +682,27 @@ class AttributeDriver implements MappingDriver
      * @phpstan-return array{
      *                   name: string|null,
      *                   unique: bool,
-     *                   nullable: bool,
+     *                   nullable?: bool,
      *                   onDelete: mixed,
      *                   columnDefinition: string|null,
      *                   referencedColumnName: string,
      *                   options?: array<string, mixed>
      *               }
      */
-    private function joinColumnToArray(Mapping\JoinColumn|Mapping\InverseJoinColumn $joinColumn): array
+    private function joinColumnToArray(Mapping\JoinColumn|Mapping\InverseJoinColumn $joinColumn, bool $inferNullabilityFromPHPType = false): array
     {
         $mapping = [
             'name' => $joinColumn->name,
             'deferrable' => $joinColumn->deferrable,
             'unique' => $joinColumn->unique,
-            'nullable' => $joinColumn->nullable,
             'onDelete' => $joinColumn->onDelete,
             'columnDefinition' => $joinColumn->columnDefinition,
             'referencedColumnName' => $joinColumn->referencedColumnName,
         ];
+
+        if (! $inferNullabilityFromPHPType || $joinColumn->nullable !== null) {
+            $mapping['nullable'] = $joinColumn->nullable;
+        }
 
         if ($joinColumn->options) {
             $mapping['options'] = $joinColumn->options;
@@ -715,7 +721,7 @@ class AttributeDriver implements MappingDriver
      *                   scale: int,
      *                   length: int,
      *                   unique: bool,
-     *                   nullable: bool,
+     *                   nullable?: bool|null,
      *                   index: bool,
      *                   precision: int,
      *                   enumType?: class-string,
@@ -724,7 +730,7 @@ class AttributeDriver implements MappingDriver
      *                   columnDefinition?: string
      *               }
      */
-    private function columnToArray(string $fieldName, Mapping\Column $column): array
+    private function columnToArray(string $fieldName, Mapping\Column $column, bool $inferNullabilityFromPHPType = false): array
     {
         $mapping = [
             'fieldName' => $fieldName,
@@ -732,10 +738,13 @@ class AttributeDriver implements MappingDriver
             'scale'     => $column->scale,
             'length'    => $column->length,
             'unique'    => $column->unique,
-            'nullable'  => $column->nullable,
             'index'     => $column->index,
             'precision' => $column->precision,
         ];
+
+        if (! $inferNullabilityFromPHPType || $column->nullableSet) {
+            $mapping['nullable'] = $column->nullable;
+        }
 
         if ($column->options) {
             $mapping['options'] = $column->options;

--- a/src/Mapping/Driver/SimplifiedXmlDriver.php
+++ b/src/Mapping/Driver/SimplifiedXmlDriver.php
@@ -16,10 +16,14 @@ class SimplifiedXmlDriver extends XmlDriver
     /**
      * {@inheritDoc}
      */
-    public function __construct($prefixes, $fileExtension = self::DEFAULT_FILE_EXTENSION, bool $isXsdValidationEnabled = true)
-    {
+    public function __construct(
+        $prefixes,
+        $fileExtension = self::DEFAULT_FILE_EXTENSION,
+        bool $isXsdValidationEnabled = true,
+        bool $inferNullabilityFromPHPType = false,
+    ) {
         $locator = new SymfonyFileLocator((array) $prefixes, $fileExtension);
 
-        parent::__construct($locator, $fileExtension, $isXsdValidationEnabled);
+        parent::__construct($locator, $fileExtension, $isXsdValidationEnabled, $inferNullabilityFromPHPType);
     }
 }

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -54,6 +54,7 @@ class XmlDriver extends FileDriver
         string|array|FileLocator $locator,
         string $fileExtension = self::DEFAULT_FILE_EXTENSION,
         private readonly bool $isXsdValidationEnabled = true,
+        private readonly bool $inferNullabilityFromPHPType = false,
     ) {
         if (! extension_loaded('simplexml')) {
             throw new LogicException(
@@ -81,6 +82,8 @@ class XmlDriver extends FileDriver
      */
     public function loadMetadataForClass($className, PersistenceClassMetadata $metadata): void
     {
+        $metadata->inferNullabilityFromPHPType = $this->inferNullabilityFromPHPType;
+
         $xmlRoot = $this->getElement($className);
 
         if ($xmlRoot->getName() === 'entity') {

--- a/src/ORMSetup.php
+++ b/src/ORMSetup.php
@@ -36,6 +36,7 @@ final class ORMSetup
         bool $isDevMode = false,
         string|null $proxyDir = null,
         CacheItemPoolInterface|null $cache = null,
+        bool $inferNullabilityFromPHPType = false,
     ): Configuration {
         if (PHP_VERSION_ID >= 80400) {
             Deprecation::trigger(
@@ -48,7 +49,7 @@ final class ORMSetup
         }
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
-        $config->setMetadataDriverImpl(new AttributeDriver($paths));
+        $config->setMetadataDriverImpl(new AttributeDriver($paths, inferNullabilityFromPHPType: $inferNullabilityFromPHPType));
 
         return $config;
     }
@@ -63,9 +64,10 @@ final class ORMSetup
         bool $isDevMode = false,
         string|null $cacheNamespaceSeed = null,
         CacheItemPoolInterface|null $cache = null,
+        bool $inferNullabilityFromPHPType = false,
     ): Configuration {
         $config = self::createConfig($isDevMode, $cacheNamespaceSeed, $cache);
-        $config->setMetadataDriverImpl(new AttributeDriver($paths));
+        $config->setMetadataDriverImpl(new AttributeDriver($paths, inferNullabilityFromPHPType: $inferNullabilityFromPHPType));
 
         return $config;
     }
@@ -81,6 +83,7 @@ final class ORMSetup
         string|null $proxyDir = null,
         CacheItemPoolInterface|null $cache = null,
         bool $isXsdValidationEnabled = true,
+        bool $inferNullabilityFromPHPType = false,
     ): Configuration {
         if (PHP_VERSION_ID >= 80400) {
             Deprecation::trigger(
@@ -93,7 +96,7 @@ final class ORMSetup
         }
 
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
-        $config->setMetadataDriverImpl(new XmlDriver($paths, XmlDriver::DEFAULT_FILE_EXTENSION, $isXsdValidationEnabled));
+        $config->setMetadataDriverImpl(new XmlDriver($paths, XmlDriver::DEFAULT_FILE_EXTENSION, $isXsdValidationEnabled, $inferNullabilityFromPHPType));
 
         return $config;
     }
@@ -109,12 +112,14 @@ final class ORMSetup
         string|null $cacheNamespaceSeed = null,
         CacheItemPoolInterface|null $cache = null,
         bool $isXsdValidationEnabled = true,
+        bool $inferNullabilityFromPHPType = false,
     ): Configuration {
         $config = self::createConfig($isDevMode, $cacheNamespaceSeed, $cache);
         $config->setMetadataDriverImpl(new XmlDriver(
             $paths,
             XmlDriver::DEFAULT_FILE_EXTENSION,
             $isXsdValidationEnabled,
+            $inferNullabilityFromPHPType,
         ));
 
         return $config;

--- a/tests/Tests/Mocks/AttributeDriverFactory.php
+++ b/tests/Tests/Mocks/AttributeDriverFactory.php
@@ -13,17 +13,19 @@ use function interface_exists;
 final class AttributeDriverFactory
 {
     /** @param list<string> $paths */
-    public static function createAttributeDriver(array $paths = []): AttributeDriver
-    {
+    public static function createAttributeDriver(
+        array $paths = [],
+        bool $inferNullabilityFromPHPType = false,
+    ): AttributeDriver {
         if (! self::isClassLocatorSupported()) {
             // Persistence < 4.1
-            return new AttributeDriver($paths);
+            return new AttributeDriver($paths, inferNullabilityFromPHPType: $inferNullabilityFromPHPType);
         }
 
         // Persistence >= 4.1
         $classLocator = FileClassLocator::createFromDirectories($paths);
 
-        return new AttributeDriver($classLocator);
+        return new AttributeDriver($classLocator, inferNullabilityFromPHPType: $inferNullabilityFromPHPType);
     }
 
     /** Supported since doctrine/persistence >= 4.1 */

--- a/tests/Tests/Models/InferredNullability/OptionalSelfReference.php
+++ b/tests/Tests/Models/InferredNullability/OptionalSelfReference.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\InferredNullability;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** The nullable PHP type keeps the join column nullable. */
+#[ORM\Entity]
+class OptionalSelfReference
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    public self|null $ref = null;
+}

--- a/tests/Tests/Models/InferredNullability/RequiredSelfReference.php
+++ b/tests/Tests/Models/InferredNullability/RequiredSelfReference.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\InferredNullability;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** The non-nullable PHP type makes the join column NOT NULL. */
+#[ORM\Entity]
+class RequiredSelfReference
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    public self $ref;
+}

--- a/tests/Tests/Models/TypedProperties/Contact.php
+++ b/tests/Tests/Models/TypedProperties/Contact.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\TypedProperties;
 
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
 
 #[ORM\Embeddable]
 class Contact
 {
     #[ORM\Column]
     public string|null $email = null;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapField(['fieldName' => 'email', 'type' => 'string']);
+    }
 }

--- a/tests/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Tests/Models/TypedProperties/UserTyped.php
@@ -19,13 +19,19 @@ class UserTyped
     #[ORM\Id]
     #[ORM\Column]
     #[ORM\GeneratedValue]
-    public int $id;
+    public int|null $id = null; // Intentional null, because of MappingDriverTestCase::testInferredNullability()
 
     #[ORM\Column(length: 50)]
     public string|null $status = null;
 
     #[ORM\Column(length: 255, unique: true)]
     public string $username;
+
+    #[ORM\Column(nullable: true)]
+    public string $firstName;
+
+    #[ORM\Column(nullable: false)]
+    public string|null $lastName = null;
 
     #[ORM\Column]
     public DateInterval $dateInterval;
@@ -49,8 +55,23 @@ class UserTyped
     #[ORM\JoinColumn]
     public CmsEmail $email;
 
+    #[ORM\OneToOne]
+    public CmsEmail|null $emailWithNoJoinColumn;
+
+    #[ORM\OneToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    public CmsEmail|null $emailOverride;
+
     #[ORM\ManyToOne]
-    public CmsEmail|null $mainEmail = null;
+    #[ORM\JoinColumn]
+    public CmsEmail $mainEmail;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: true)]
+    public CmsEmail $mainEmailOverride;
+
+    #[ORM\ManyToOne]
+    public CmsEmail|null $mainEmailWithNoJoinColumn = null;
 
     #[ORM\Embedded]
     public Contact|null $contact = null;
@@ -79,6 +100,7 @@ class UserTyped
                 'length' => 50,
             ],
         );
+
         $metadata->mapField(
             [
                 'fieldName' => 'username',
@@ -86,6 +108,21 @@ class UserTyped
                 'unique' => true,
             ],
         );
+
+        $metadata->mapField(
+            [
+                'fieldName' => 'firstName',
+                'nullable' => true,
+            ],
+        );
+
+        $metadata->mapField(
+            [
+                'fieldName' => 'lastName',
+                'nullable' => false,
+            ],
+        );
+
         $metadata->mapField(
             ['fieldName' => 'dateInterval'],
         );
@@ -119,8 +156,51 @@ class UserTyped
             ],
         );
 
+        $metadata->mapOneToOne(
+            ['fieldName' => 'emailWithNoJoinColumn'],
+        );
+
+        $metadata->mapOneToOne(
+            [
+                'fieldName' => 'emailOverride',
+                'joinColumns' =>
+                    [
+                        0 =>
+                            [
+                                'referencedColumnName' => 'id',
+                                'nullable' => false,
+                            ],
+                    ],
+            ],
+        );
+
         $metadata->mapManyToOne(
-            ['fieldName' => 'mainEmail'],
+            [
+                'fieldName' => 'mainEmail',
+                'joinColumns' =>
+                    [
+                        0 =>
+                            ['referencedColumnName' => 'id'],
+                    ],
+            ],
+        );
+
+        $metadata->mapManyToOne(
+            [
+                'fieldName' => 'mainEmailOverride',
+                'joinColumns' =>
+                    [
+                        0 =>
+                            [
+                                'referencedColumnName' => 'id',
+                                'nullable' => true,
+                            ],
+                    ],
+            ],
+        );
+
+        $metadata->mapManyToOne(
+            ['fieldName' => 'mainEmailWithNoJoinColumn'],
         );
 
         $metadata->mapEmbedded(['fieldName' => 'contact']);

--- a/tests/Tests/Models/TypedProperties/UserTypedWithIdAssociation.php
+++ b/tests/Tests/Models/TypedProperties/UserTypedWithIdAssociation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\TypedProperties;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Tests\Models\CMS\CmsEmail;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'cms_users_typed_id_association')]
+class UserTypedWithIdAssociation
+{
+    /** Nullable in PHP, but identifier join columns are always NOT NULL. */
+    #[ORM\Id]
+    #[ORM\ManyToOne]
+    public CmsEmail|null $nullableEmail = null;
+
+    #[ORM\Id]
+    #[ORM\ManyToOne]
+    public CmsEmail $nonNullableEmail;
+
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->mapManyToOne(
+            [
+                'fieldName' => 'nullableEmail',
+                'id' => true,
+            ],
+        );
+
+        $metadata->mapManyToOne(
+            [
+                'fieldName' => 'nonNullableEmail',
+                'id' => true,
+            ],
+        );
+    }
+}

--- a/tests/Tests/ORM/Functional/InferredNullabilityTest.php
+++ b/tests/Tests/ORM/Functional/InferredNullabilityTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Internal\TopologicalSort\CycleDetectedException;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\Mocks\AttributeDriverFactory;
+use Doctrine\Tests\Models\InferredNullability\OptionalSelfReference;
+use Doctrine\Tests\Models\InferredNullability\RequiredSelfReference;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\Tests\TestUtil;
+
+class InferredNullabilityTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if (! isset(static::$sharedConn)) {
+            static::$sharedConn = TestUtil::getConnection();
+        }
+
+        $this->_em = $this->getEntityManager(null, AttributeDriverFactory::createAttributeDriver(
+            [__DIR__ . '/../../Models/InferredNullability'],
+            true,
+        ));
+
+        $this->_schemaTool = new SchemaTool($this->_em);
+
+        parent::setUp();
+
+        $this->setUpEntitySchema([RequiredSelfReference::class, OptionalSelfReference::class]);
+    }
+
+    public function testNonNullablePHPTypeProducesANotNullForeignKeyColumn(): void
+    {
+        $class  = $this->_em->getClassMetadata(RequiredSelfReference::class);
+        $schema = $this->_schemaTool->getSchemaFromMetadata([$class]);
+        $column = $schema->getTable($class->getTableName())
+            ->getColumn($class->associationMappings['ref']->joinColumns[0]->name);
+
+        self::assertTrue($column->getNotnull());
+    }
+
+    /** A cycle can only be broken at a nullable join column, so this one never reaches the database. */
+    public function testCycleOfNonNullableAssociationsIsRejectedBeforeAnySqlIsExecuted(): void
+    {
+        $a      = new RequiredSelfReference();
+        $b      = new RequiredSelfReference();
+        $a->ref = $b;
+        $b->ref = $a;
+
+        $this->_em->persist($a);
+        $this->_em->persist($b);
+
+        $this->getQueryLog()->reset()->enable();
+
+        try {
+            $this->_em->flush();
+            self::fail('A cycle of NOT NULL join columns cannot be inserted.');
+        } catch (CycleDetectedException $exception) {
+            self::assertContains($a, $exception->getCycle());
+            self::assertContains($b, $exception->getCycle());
+        }
+
+        self::assertQueryCount(0);
+    }
+
+    /** A nullable PHP type keeps the join column nullable, so the cycle can still be broken. */
+    public function testCycleOfNullableAssociationsIsResolvedWithAnExtraUpdate(): void
+    {
+        $a      = new OptionalSelfReference();
+        $b      = new OptionalSelfReference();
+        $a->ref = $b;
+        $b->ref = $a;
+
+        $this->_em->persist($a);
+        $this->_em->persist($b);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reloaded = $this->_em->find(OptionalSelfReference::class, $a->id);
+
+        self::assertNotNull($reloaded);
+        self::assertSame($b->id, $reloaded->ref?->id);
+    }
+}

--- a/tests/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -21,9 +21,9 @@ use stdClass;
 
 class AttributeDriverTest extends MappingDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected function loadDriver(bool $inferNullabilityFromPHPType = false): MappingDriver
     {
-        return AttributeDriverFactory::createAttributeDriver();
+        return AttributeDriverFactory::createAttributeDriver(inferNullabilityFromPHPType: $inferNullabilityFromPHPType);
     }
 
     public function testDriverCanAcceptClassLocator(): void

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -62,10 +62,12 @@ use Doctrine\Tests\Models\GH10288\GH10288People;
 use Doctrine\Tests\Models\TypedProperties\Contact;
 use Doctrine\Tests\Models\TypedProperties\UserTyped;
 use Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField;
+use Doctrine\Tests\Models\TypedProperties\UserTypedWithIdAssociation;
 use Doctrine\Tests\Models\Upsertable\Insertable;
 use Doctrine\Tests\Models\Upsertable\Updatable;
 use Doctrine\Tests\ORM\Mapping\NamingStrategy\CustomPascalNamingStrategy;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use SortDirection;
@@ -82,17 +84,19 @@ abstract class MappingDriverTestCase extends OrmTestCase
 {
     use VerifyDeprecations;
 
-    abstract protected function loadDriver(): MappingDriver;
+    abstract protected function loadDriver(bool $inferNullabilityFromPHPType = false): MappingDriver;
 
     /** @param class-string<object> $entityClassName */
     public function createClassMetadata(
         string $entityClassName,
         NamingStrategy|null $namingStrategy = null,
         TypedFieldMapper|null $typedFieldMapper = null,
+        bool $inferNullabilityFromPHPType = false,
     ): ClassMetadata {
-        $mappingDriver = $this->loadDriver();
+        $mappingDriver = $this->loadDriver($inferNullabilityFromPHPType);
 
-        $class = new ClassMetadata($entityClassName, $namingStrategy, $typedFieldMapper);
+        $class                              = new ClassMetadata($entityClassName, $namingStrategy, $typedFieldMapper);
+        $class->inferNullabilityFromPHPType = $inferNullabilityFromPHPType;
         $class->initializeReflection(new RuntimeReflectionService());
         $mappingDriver->loadMetadataForClass($entityClassName, $class);
 
@@ -1009,6 +1013,105 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertEquals('id', $metadata->fieldNames['Id']);
         self::assertEquals('Id', $metadata->associationMappings['blogPost']->joinColumns[0]->referencedColumnName);
         self::assertFalse($metadata->associationMappings['blogPost']->joinColumns[0]->nullable);
+    }
+
+    private static function joinColumnNullability(ClassMetadata $metadata, string $fieldName): bool|null
+    {
+        $mapping = $metadata->getAssociationMapping($fieldName);
+        self::assertInstanceOf(ORM\ToOneOwningSideMapping::class, $mapping);
+
+        return $mapping->joinColumns[0]->nullable;
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function inferNullabilityFromPHPTypeProvider(): iterable
+    {
+        yield 'inference enabled' => [true];
+        yield 'inference disabled' => [false];
+    }
+
+    /** Without a PHP type there is nothing to infer from, so the old defaults must be kept. */
+    #[DataProvider('inferNullabilityFromPHPTypeProvider')]
+    public function testUntypedPropertiesKeepTheirDefaultNullability(bool $inferNullabilityFromPHPType): void
+    {
+        $metadata = $this->createClassMetadata(User::class, inferNullabilityFromPHPType: $inferNullabilityFromPHPType);
+
+        self::assertTrue($metadata->isNullable('name')); // Explicit
+        self::assertFalse($metadata->isNullable('email')); // Default for fields
+        self::assertTrue(self::joinColumnNullability($metadata, 'address')); // Default for join columns
+    }
+
+    public function testFieldNullabilityIsInferredFromPHPType(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+
+        self::assertTrue($metadata->isNullable('status')); // string|null
+        self::assertFalse($metadata->isNullable('username')); // string
+    }
+
+    public function testExplicitFieldNullabilityWins(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+
+        self::assertTrue($metadata->isNullable('firstName')); // string, but nullable: true
+        self::assertFalse($metadata->isNullable('lastName')); // string|null, but nullable: false
+    }
+
+    /** An uninitialized identifier is a common pattern, so identifiers never inherit nullability. */
+    public function testIdentifierFieldNullabilityIsNotInferred(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+
+        self::assertFalse($metadata->isNullable('id'));
+    }
+
+    public function testAssociationNullabilityIsInferredFromPHPType(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+
+        // Non-nullable PHP type, with and without an explicitly declared join column
+        self::assertFalse(self::joinColumnNullability($metadata, 'email'));
+        self::assertFalse(self::joinColumnNullability($metadata, 'mainEmail'));
+
+        // Nullable PHP type, with and without an explicitly declared join column
+        self::assertTrue(self::joinColumnNullability($metadata, 'emailWithNoJoinColumn'));
+        self::assertTrue(self::joinColumnNullability($metadata, 'mainEmailWithNoJoinColumn'));
+    }
+
+    public function testExplicitJoinColumnNullabilityWins(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+
+        self::assertFalse(self::joinColumnNullability($metadata, 'emailOverride')); // CmsEmail|null, but nullable: false
+        self::assertTrue(self::joinColumnNullability($metadata, 'mainEmailOverride')); // CmsEmail, but nullable: true
+    }
+
+    /** Join columns of Id associations are always NOT NULL, and setting "nullable" for them is deprecated. */
+    public function testIdentifierAssociationNullabilityIsNotInferred(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12126');
+
+        $metadata = $this->createClassMetadata(UserTypedWithIdAssociation::class, inferNullabilityFromPHPType: true);
+
+        self::assertFalse(self::joinColumnNullability($metadata, 'nullableEmail'));
+        self::assertFalse(self::joinColumnNullability($metadata, 'nonNullableEmail'));
+    }
+
+    public function testNullabilityIsNotInferredWhenDisabled(): void
+    {
+        $metadata = $this->createClassMetadata(UserTyped::class);
+
+        self::assertFalse($metadata->isNullable('id'));
+        self::assertFalse($metadata->isNullable('status'));
+        self::assertFalse($metadata->isNullable('username'));
+        self::assertTrue($metadata->isNullable('firstName')); // Explicit
+        self::assertFalse($metadata->isNullable('lastName')); // Explicit
+
+        foreach (['email', 'mainEmail', 'mainEmailOverride', 'emailWithNoJoinColumn', 'mainEmailWithNoJoinColumn'] as $fieldName) {
+            self::assertTrue(self::joinColumnNullability($metadata, $fieldName));
+        }
+
+        self::assertFalse(self::joinColumnNullability($metadata, 'emailOverride')); // Explicit
     }
 }
 

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -83,10 +83,11 @@ abstract class MappingDriverTestCase extends OrmTestCase
         string $entityClassName,
         NamingStrategy|null $namingStrategy = null,
         TypedFieldMapper|null $typedFieldMapper = null,
+        bool $inferNullabilityFromPHPType = false,
     ): ClassMetadata {
         $mappingDriver = $this->loadDriver();
 
-        $class = new ClassMetadata($entityClassName, $namingStrategy, $typedFieldMapper);
+        $class = new ClassMetadata($entityClassName, $namingStrategy, $typedFieldMapper, $inferNullabilityFromPHPType);
         $class->initializeReflection(new RuntimeReflectionService());
         $mappingDriver->loadMetadataForClass($entityClassName, $class);
 
@@ -958,6 +959,58 @@ abstract class MappingDriverTestCase extends OrmTestCase
         self::assertEquals('id', $metadata->fieldNames['Id']);
         self::assertEquals('Id', $metadata->associationMappings['blogPost']->joinColumns[0]->referencedColumnName);
         self::assertFalse($metadata->associationMappings['blogPost']->joinColumns[0]->nullable);
+    }
+
+    public function testInferredNullability(): void
+    {
+        $getNullabilityFromAssociation = function (ClassMetadata $entity, string $fieldName): bool|null {
+            $mapping = $entity->getAssociationMapping($fieldName);
+            $this->assertInstanceof(ORM\ToOneOwningSideMapping::class, $mapping);
+
+            return $mapping->joinColumns[0]->nullable;
+        };
+
+        // Missing types
+        foreach ([true, false] as $infer) {
+            $untyped = $this->createClassMetadata(User::class, inferNullabilityFromPHPType: $infer);
+            $this->assertTrue($untyped->isNullable('name')); // Explicit with missing type
+            $this->assertFalse($untyped->isNullable('email')); // Default with missing type
+            $this->assertTrue($getNullabilityFromAssociation($untyped, 'address')); // Default with missing type
+        }
+
+        // Typed with enabled inference
+        $typed = $this->createClassMetadata(UserTyped::class, inferNullabilityFromPHPType: true);
+        $this->assertFalse($typed->isNullable('id')); // Id column should not inherit nullability
+        $this->assertTrue($typed->isNullable('status')); // Infers from PHP type
+        $this->assertFalse($typed->isNullable('username')); // Infers from PHP type
+        $this->assertTrue($typed->isNullable('firstName')); // By definition
+        $this->assertFalse($typed->isNullable('lastName')); // By definition
+
+        foreach (['email', 'mainEmail', 'emailOverride'] as $value) {
+            $this->assertFalse($getNullabilityFromAssociation($typed, $value));
+        }
+
+        foreach (['emailWithNoJoinColumn', 'mainEmailWithNoJoinColumn', 'mainEmailOverride'] as $value) {
+            $this->assertTrue($getNullabilityFromAssociation($typed, $value));
+        }
+
+        // Typed with disabled inference
+        $typed = $this->createClassMetadata(UserTyped::class);
+        $this->assertFalse($typed->isNullable('id')); // Default
+        $this->assertFalse($typed->isNullable('status')); // Default
+        $this->assertFalse($typed->isNullable('username')); // Default
+        $this->assertTrue($typed->isNullable('firstName')); // Explicit
+        $this->assertFalse($typed->isNullable('lastName')); // Explicit
+
+        foreach (['email', 'mainEmail', 'mainEmailOverride'] as $value) {
+            $this->assertTrue($getNullabilityFromAssociation($typed, $value));
+        }
+
+        foreach (['emailWithNoJoinColumn', 'mainEmailWithNoJoinColumn'] as $value) {
+            $this->assertTrue($getNullabilityFromAssociation($typed, $value));
+        }
+
+        $this->assertFalse($getNullabilityFromAssociation($typed, 'emailOverride'));
     }
 }
 

--- a/tests/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -14,7 +14,7 @@ use const DIRECTORY_SEPARATOR;
 
 class StaticPHPMappingDriverTest extends MappingDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected function loadDriver(bool $inferNullabilityFromPHPType = false): MappingDriver
     {
         return new StaticPHPDriver(__DIR__ . DIRECTORY_SEPARATOR . 'php');
     }

--- a/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -40,12 +40,13 @@ use const DIRECTORY_SEPARATOR;
 
 class XmlMappingDriverTest extends MappingDriverTestCase
 {
-    protected function loadDriver(): MappingDriver
+    protected function loadDriver(bool $inferNullabilityFromPHPType = false): MappingDriver
     {
         return new XmlDriver(
             __DIR__ . DIRECTORY_SEPARATOR . 'xml',
             XmlDriver::DEFAULT_FILE_EXTENSION,
             true,
+            $inferNullabilityFromPHPType,
         );
     }
 

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.Contact.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.Contact.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <embeddable name="Doctrine\Tests\Models\TypedProperties\Contact">
+        <field name="email" type="string" />
+    </embeddable>
+</doctrine-mapping>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
@@ -12,6 +12,8 @@
 
     <field name="status" length="50"/>
     <field name="username" length="255" unique="true"/>
+    <field name="firstName" nullable="true"/>
+    <field name="lastName" nullable="false"/>
     <field name="dateInterval"/>
     <field name="dateTime"/>
     <field name="dateTimeImmutable"/>
@@ -24,7 +26,24 @@
       <join-column/>
     </one-to-one>
 
-    <many-to-one field="mainEmail"/>
+    <one-to-one field="emailWithNoJoinColumn" orphan-removal="true">
+      <cascade><cascade-persist /></cascade>
+    </one-to-one>
+
+    <one-to-one field="emailOverride" orphan-removal="true">
+      <cascade><cascade-persist /></cascade>
+      <join-column nullable="false" />
+    </one-to-one>
+
+    <many-to-one field="mainEmail">
+      <join-column/>
+    </many-to-one>
+
+    <many-to-one field="mainEmailOverride">
+      <join-column nullable="true" />
+    </many-to-one>
+    
+    <many-to-one field="mainEmailWithNoJoinColumn"/>
 
     <embedded name="contact" />
   </entity>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithIdAssociation.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTypedWithIdAssociation.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\Models\TypedProperties\UserTypedWithIdAssociation" table="cms_users_typed_id_association">
+    <id name="nullableEmail" association-key="true"/>
+    <id name="nonNullableEmail" association-key="true"/>
+
+    <many-to-one field="nullableEmail"/>
+    <many-to-one field="nonNullableEmail"/>
+  </entity>
+</doctrine-mapping>


### PR DESCRIPTION
Closes https://github.com/doctrine/orm/issues/9744 and https://github.com/doctrine/orm/issues/11797, relates to https://github.com/doctrine/orm/issues/11620.

It's made as opt-in feature so we don't cause BC break, it can be enabled per mapping driver:

```php
$driver = new AttributeDriver($paths, inferNullabilityFromPHPType: true);
```

In Symfony:
```yaml
doctrine:
    orm:
        mappings:
            App:
                type: attribute
                infer_nullability_from_php_type: true
```

In Nette:
```neon
doctrine.orm:
    managers:
        default:
            mapping:
                App:
                    inferNullabilityFromPHPType: true
```

Example code before:
```php
#[Column(nullable: true)]
private ?string $property = null;

#[ManyToOne]
#[JoinColumn(nullable: false)]
private Entity $entity;

#[OneToOne] // db = nullable, php = not nullable
private Entity $test;
```

Example code after:
```php
#[Column] 
private ?string $property = null;

#[ManyToOne] 
private Entity $entity;

#[OneToOne]
#[JoinColumn(nullable: true)] // to keep previous behavior
private Entity $test;
```

I have already tested it also on mid-sized project and new generated migration was ok (I already migrated it, ~25 queries), with default configuration. It helped me discover few database rows with null where should not be null, and it would cause app error if those entities were loaded.

I'm not sure how to treat properties without type, maybe we should make them nullable as well when this feature is enabled, since null is valid value for them. For now I kept original behavior for untyped properties but I think it would be better to make them nullable by default (JoinColumn already is, just Column is not) when this feature is enabled.