### PR TITLE
Fix no-op for initializeObject() and isUnitializedObject() when object is not a mapped entity

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -51,6 +51,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use Stringable;
 use Symfony\Component\VarExporter\Hydrator;
+use Throwable;
 use UnexpectedValueException;
 
 use function array_chunk;
@@ -3054,8 +3055,12 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled()) {
-            $reflection = $this->em->getClassMetadata($obj::class)->getReflectionClass();
-            $reflection->initializeLazyObject($obj);
+            try {
+                $reflection = $this->em->getClassMetadata($obj::class)->getReflectionClass();
+                $reflection->initializeLazyObject($obj);
+            } catch (Throwable) {
+                // No-op for non-Doctrine entities according to the ObjectManager::initializeObject() interface documentation.
+            }
         }
     }
 
@@ -3063,7 +3068,11 @@ class UnitOfWork implements PropertyChangedListener
     public function isUninitializedObject(mixed $obj): bool
     {
         if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled() && ! ($obj instanceof Collection) && is_object($obj)) {
-            return $this->em->getClassMetadata($obj::class)->reflClass->isUninitializedLazyObject($obj);
+            try {
+                return $this->em->getClassMetadata($obj::class)->reflClass->isUninitializedLazyObject($obj);
+            } catch (Throwable) {
+                return false;
+            }
         }
 
         return $obj instanceof InternalProxy && ! $obj->__isInitialized();

--- a/tests/Tests/ORM/Functional/Ticket/GH12172Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12172Test.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTime;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use stdClass;
+
+#[Group('GH12172')]
+class GH12172Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(CmsUser::class);
+    }
+
+    public function testInitializeObjectNoOpForNonManagedObjects(): void
+    {
+        $nonEntity               = new stdClass();
+        $nonEntity->someProperty = 'test';
+
+        $this->expectNotToPerformAssertions();
+        $this->_em->initializeObject($nonEntity);
+    }
+
+    public function testInitializeObjectNoOpForCustomNonEntityClass(): void
+    {
+        $nonEntity       = new GH12172TestClass();
+        $nonEntity->data = 'some data';
+
+        $this->expectNotToPerformAssertions();
+        $this->_em->initializeObject($nonEntity);
+    }
+
+    public function testIsUninitializedObjectNoExceptionForNonManagedObjects(): void
+    {
+        $nonEntity = new stdClass();
+
+        $result = $this->_em->isUninitializedObject($nonEntity);
+
+        self::assertFalse($result, 'Non-managed objects should be considered initialized (not uninitialized)');
+    }
+
+    public function testInitializeObjectWithValidEntityClassDoesNotBreakMetadataLoading(): void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Test User';
+        $user->username = 'testuser';
+        $user->status   = 'active';
+
+        $this->expectNotToPerformAssertions();
+        $this->_em->initializeObject($user);
+    }
+
+    public function testInitializeObjectWithDifferentTypesOfObjectsConsistentBehavior(): void
+    {
+        $testObjects = [
+            new stdClass(),
+            new GH12172TestClass(),
+            new DateTime(),
+            (object) ['prop' => 'value'],
+        ];
+
+        foreach ($testObjects as $object) {
+            $this->_em->initializeObject($object);
+
+            $result = $this->_em->isUninitializedObject($object);
+            self::assertFalse($result, 'Non-entity objects should not be considered uninitialized');
+        }
+
+        $this->addToAssertionCount(1);
+    }
+}
+
+class GH12172TestClass
+{
+    public string $data = '';
+}


### PR DESCRIPTION
Fix initializeObject() and isUnitializedObject() to be no-op for non-managed objects with native lazy objects

This fix wraps `getClassMetadata()` calls in try/catch blocks to handle non-entity objects gracefully while preserving functionality for valid Doctrine entities (including detached ones after `clear()`).

I went with the try/catch approach since `isInIdentityMap()` also internally calls `getClassMetadata()`, but I'm open to better solutions if there are any.

**Changes:**
- `UnitOfWork::initializeObject()`: Add try/catch around metadata access
- `UnitOfWork::isUninitializedObject()`: Add try/catch around metadata access

Fixes #12172