### PR TITLE
Fix false positive changes for generated columns by updating snapshop

### DIFF
--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -288,11 +288,14 @@ class BasicEntityPersister implements EntityPersister
     protected function assignDefaultVersionAndUpsertableValues(object $entity, array $id): void
     {
         $values = $this->fetchVersionAndNotUpsertableValues($this->class, $id);
+        $uow    = $this->em->getUnitOfWork();
+        $oid    = spl_object_id($entity);
 
         foreach ($values as $field => $value) {
             $value = Type::getType($this->class->fieldMappings[$field]->type)->convertToPHPValue($value, $this->platform);
 
             $this->class->setFieldValue($entity, $field, $value);
+            $uow->setOriginalEntityProperty($oid, $field, $value);
         }
     }
 

--- a/src/Persisters/Entity/JoinedSubclassPersister.php
+++ b/src/Persisters/Entity/JoinedSubclassPersister.php
@@ -19,6 +19,7 @@ use function array_combine;
 use function array_keys;
 use function array_values;
 use function implode;
+use function spl_object_id;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -509,11 +510,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     protected function assignDefaultVersionAndUpsertableValues(object $entity, array $id): void
     {
         $values = $this->fetchVersionAndNotUpsertableValues($this->getVersionedClassMetadata(), $id);
+        $uow    = $this->em->getUnitOfWork();
+        $oid    = spl_object_id($entity);
 
         foreach ($values as $field => $value) {
             $value = Type::getType($this->class->fieldMappings[$field]->type)->convertToPHPValue($value, $this->platform);
 
             $this->class->setFieldValue($entity, $field, $value);
+            $uow->setOriginalEntityProperty($oid, $field, $value);
         }
     }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH12017SubClassTest.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12017SubClassTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12017SubClassTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH12017ParentEntity::class, GH12017ChildEntity::class);
+    }
+
+    public function testGeneratedFieldFromChildShouldNotBeDetectedAsChangeAfterInsert(): void
+    {
+        $entity = new GH12017ChildEntity();
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated field was refreshed from the DB',
+        );
+    }
+
+    public function testGeneratedStringFieldShouldNotBeDetectedAsChangeAfterInsert(): void
+    {
+        $entity = new GH12017ChildEntity();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated string field was refreshed from the DB',
+        );
+    }
+
+    public function testGeneratedFieldShouldNotBeDetectedAsChangeAfterUpdate(): void
+    {
+        $entity = new GH12017ChildEntity();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $entity->other = 1;
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated field was refreshed from the DB',
+        );
+    }
+}
+
+#[ORM\MappedSuperclass]
+#[InheritanceType('JOINED')]
+#[DiscriminatorColumn(name: 'discr', type: 'string')]
+#[DiscriminatorMap(['child' => GH12017ChildEntity::class])]
+#[ORM\Entity]
+#[ORM\Table(name: 'gh12017_parent')]
+class GH12017ParentEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public int $id;
+
+    #[ORM\Column(
+        type: Types::INTEGER,
+        nullable: false,
+        options: ['default' => 0],
+    )]
+    public int $other = 0;
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gh12017_child')]
+class GH12017ChildEntity extends GH12017ParentEntity
+{
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        insertable: false,
+        updatable: false,
+        options: ['default' => 'CURRENT_TIMESTAMP'],
+        generated: 'ALWAYS',
+    )]
+    public DateTimeImmutable|null $tested = null;
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12017Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12017Test.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH12017Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH12017Entity::class, GH12017EntityWithStringField::class);
+    }
+
+    public function testGeneratedFieldShouldNotBeDetectedAsChangeAfterFlush(): void
+    {
+        $entity = new GH12017Entity();
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated field was refreshed from the DB',
+        );
+    }
+
+    public function testGeneratedStringFieldShouldNotBeDetectedAsChangeAfterFlush(): void
+    {
+        $entity = new GH12017EntityWithStringField();
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated string field was refreshed from the DB',
+        );
+    }
+
+    public function testGeneratedFieldShouldNotBeDetectedAsChangeAfterUpdate(): void
+    {
+        $entity = new GH12017Entity();
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity        = $this->_em->find(GH12017Entity::class, $entity->id);
+        $entity->other = 1;
+        $this->_em->flush();
+
+        $uow = $this->_em->getUnitOfWork();
+        $uow->computeChangeSets();
+        self::assertFalse(
+            $uow->isScheduledForUpdate($entity),
+            'Entity should not be scheduled for update after a generated field was refreshed from the DB',
+        );
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gh12017')]
+class GH12017Entity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public int|null $id = null;
+
+    #[ORM\Column(
+        type: Types::DATETIME_IMMUTABLE,
+        nullable: false,
+        insertable: false,
+        updatable: false,
+        options: ['default' => 'CURRENT_TIMESTAMP'],
+        generated: 'ALWAYS',
+    )]
+    public DateTimeImmutable|null $tested = null;
+
+    #[ORM\Column(
+        type: Types::INTEGER,
+        nullable: false,
+        options: ['default' => 0],
+    )]
+    public int $other = 0;
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'gh12017_string')]
+class GH12017EntityWithStringField
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public int|null $id = null;
+
+    #[ORM\Column(
+        type: Types::STRING,
+        insertable: false,
+        updatable: false,
+        options: ['default' => 'generated'],
+        generated: 'ALWAYS',
+    )]
+    public string|null $tested = null;
+}


### PR DESCRIPTION
After persisting or updating an entity having columns with the configuration `generate: 'ALWAYS'`, the persister was updating the data on the entity but not notifying the UnitOfWork. This led the entity to be considered dirty in subsequent flushes, triggering lifecycle events. This was especially noticeable when the database field was mapped to a `DateTime`

This PR makes the persister update the UnitOfWork with the new values from the database. By doing this, `UnitOfWork::computeChangeSet` does not consider these fields as different from the ones in the database. 

Note that if the user does something like `$entity->nonUpdatableField = 'new value'`, the unit of work will again consider the entity as dirty and the field appear in the changeSet. This problem is addressed in https://github.com/doctrine/orm/pull/12385

Fixes https://github.com/doctrine/orm/issues/12017