### PR TITLE
Add regression test for STI duplicate foreign key deduplication

### DIFF
--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -18,9 +18,13 @@ use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\MappingException;
@@ -581,6 +585,41 @@ class SchemaToolTest extends OrmTestCase
 
         return false;
     }
+
+    public function testSingleTableInheritanceWithSameForeignKeyInChildrenDoesNotTriggerDeprecation(): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $schema = $schemaTool->getSchemaFromMetadata([
+            $em->getClassMetadata(STIBox::class),
+            $em->getClassMetadata(STILocation::class),
+            $em->getClassMetadata(STIBoxContainer::class),
+            $em->getClassMetadata(STIPackedBoxContainer::class),
+        ]);
+
+        self::assertTrue($schema->hasTable('sti_location'));
+
+        $table = $schema->getTable('sti_location');
+
+        self::assertCount(1, $table->getForeignKeys());
+
+        $foreignKeys = $table->getForeignKeys();
+        $foreignKey  = current($foreignKeys);
+
+        if (! class_exists(ForeignKeyConstraintEditor::class)) {
+            self::assertSame('sti_box', $foreignKey->getForeignTableName());
+            self::assertSame(['box_id'], $foreignKey->getLocalColumns());
+
+            return;
+        }
+
+        self::assertSame('sti_box', $foreignKey->getReferencedTableName()->toString());
+        self::assertSame(['box_id'], array_map(
+            static fn (UnqualifiedName $name) => $name->toString(),
+            $foreignKey->getReferencingColumnNames(),
+        ));
+    }
 }
 
 #[Table(options: ['foo' => 'bar', 'baz' => ['key' => 'val']])]
@@ -815,4 +854,43 @@ class QuotedEntity
 
     #[Column(name: '`quoted-name`')]
     public string $name = '';
+}
+
+#[Entity]
+#[Table(name: 'sti_box')]
+class STIBox
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int|null $id = null;
+}
+
+#[Entity]
+#[Table(name: 'sti_location')]
+#[InheritanceType('SINGLE_TABLE')]
+#[DiscriminatorColumn(name: 'type', type: 'string')]
+#[DiscriminatorMap(['box_container' => STIBoxContainer::class, 'packed_box_container' => STIPackedBoxContainer::class])]
+abstract class STILocation
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int|null $id = null;
+}
+
+#[Entity]
+class STIBoxContainer extends STILocation
+{
+    #[ManyToOne(targetEntity: STIBox::class)]
+    #[JoinColumn(name: 'box_id', referencedColumnName: 'id')]
+    public STIBox|null $box = null;
+}
+
+#[Entity]
+class STIPackedBoxContainer extends STILocation
+{
+    #[ManyToOne(targetEntity: STIBox::class)]
+    #[JoinColumn(name: 'box_id', referencedColumnName: 'id')]
+    public STIBox|null $box = null;
 }


### PR DESCRIPTION
When multiple STI child entities have a `ManyToOne` relation to the same target entity using the same join column, `SchemaTool` called `addForeignKeyConstraint` twice with the same constraint name, triggering a DBAL deprecation ("Overwriting an existing foreign key constraint").

The fix skips the redundant `addForeignKeyConstraint` call when an identical FK (same local columns, same foreign table, same foreign columns) was already added.

See https://github.com/doctrine/dbal/pull/7125

---

**EDIT (after rebase):** The production fix has since landed in `3.6.x` via #12477 ("Avoid adding the same foreign key twice for STI"), which implements the same deduplication more thoroughly (it also compares FK options). Rebasing dropped the now-redundant `SchemaTool` change, so this PR now **only adds the regression test** — upstream merged the fix without one, and this test guards the STI same-join-column scenario going forward.
