### PR TITLE
Fix false positive inheritance deprecation for embeddable subclasses

### DIFF
--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -161,7 +161,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         if (! $class->isMappedSuperclass) {
-            if ($rootEntityFound && $class->isInheritanceTypeNone()) {
+            if ($rootEntityFound && $class->isInheritanceTypeNone() && ! $class->isEmbeddedClass) {
                 Deprecation::trigger(
                     'doctrine/orm',
                     'https://github.com/doctrine/orm/pull/10431',

--- a/tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Index;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\Embeddable;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToOne;
@@ -219,6 +220,13 @@ class BasicInheritanceMappingTest extends OrmTestCase
 
         yield 'complex example (Entity Root -> Mapped Superclass -> transient class -> Entity)'
             => [InvalidComplexRoot::class, InvalidComplexEntity::class];
+    }
+
+    public function testEmbeddableSubclassDoesNotTriggerInheritanceDeprecation(): void
+    {
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/10431');
+
+        $this->cmf->getMetadataFor(EmbeddableSubclass::class);
     }
 
     /** @group DDC-964 */
@@ -541,4 +549,18 @@ class InvalidComplexTransientClass extends InvalidComplexMappedSuperclass
 /** @Entity */
 class InvalidComplexEntity extends InvalidComplexTransientClass
 {
+}
+
+/** @Embeddable */
+class EmbeddableBase
+{
+    /** @Column(type="string") */
+    public $value;
+}
+
+/** @Embeddable */
+class EmbeddableSubclass extends EmbeddableBase
+{
+    /** @Column(type="string") */
+    public $extraValue;
 }


### PR DESCRIPTION
## What

When an embeddable class extends another embeddable class, `ClassMetadataFactory` incorrectly triggers a deprecation warning about a missing inheritance mapping type declaration.

## Why

The check at line 164 of `ClassMetadataFactory::doLoadMetadata()` only guards against `isMappedSuperclass`, but does not exclude embedded classes. Since embeddable classes cannot have inheritance mapping types, the deprecation should not fire for them.

## Fix

Added `&& ! $class->isEmbeddedClass` to the condition so the deprecation is only triggered for regular entity classes, not embeddables.

## How to reproduce

```php
/** @Embeddable */
class Timeframe {
    public function __construct(
        protected readonly ?\DateTimeImmutable $from,
        protected readonly ?\DateTimeImmutable $to,
    ) {}
}

/** @Embeddable */
class BoundedTimeframe extends Timeframe {
    public function __construct(\DateTimeImmutable $from, \DateTimeImmutable $to) {
        parent::__construct($from, $to);
    }
}
```

Before this fix, loading metadata for `BoundedTimeframe` triggers:

> Entity class 'BoundedTimeframe' is a subclass of the root entity class 'Timeframe', but no inheritance mapping type was declared. This is a misconfiguration and will be an error in Doctrine ORM 3.0.

After this fix, no deprecation is triggered.

Fixes #11843