### PR TITLE
[RFC] add HydrationFactory as extension point for tracking hydrations

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -9,6 +9,8 @@ use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Internal\Hydration\DefaultHydratorFactory;
+use Doctrine\ORM\Internal\Hydration\HydratorFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\DefaultEntityListenerResolver;
@@ -46,6 +48,16 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /** @phpstan-var array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> */
     private $identityGenerationPreferences = [];
+
+    public function setHydratorFactory(HydratorFactory $factory): void
+    {
+        $this->attributes['hydratorFactory'] = $factory;
+    }
+
+    public function getHydratorFactory(): HydratorFactory
+    {
+        return $this->attributes['hydratorFactory'] ?? new DefaultHydratorFactory();
+    }
 
     /** @phpstan-param array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> $value */
     public function setIdentityGenerationPreferences(array $value): void

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -10,12 +10,12 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Exception\EntityManagerClosed;
-use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;
 use Doctrine\ORM\Exception\MissingMappingDriverImplementation;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnrecognizedIdentifierFields;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Internal\Hydration\HydratorFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
@@ -105,6 +105,11 @@ class EntityManager implements EntityManagerInterface
     private Cache|null $cache = null;
 
     /**
+     * The hydrator factory to use.
+     */
+    private HydratorFactory $hydratorFactory;
+
+    /**
      * Creates a new EntityManager that operates on the given database connection
      * and uses the given Configuration and EventManager implementations.
      *
@@ -150,6 +155,8 @@ class EntityManager implements EntityManagerInterface
             $cacheFactory = $cacheConfig->getCacheFactory();
             $this->cache  = $cacheFactory->createCache($this);
         }
+
+        $this->hydratorFactory = $this->config->getHydratorFactory();
     }
 
     public function getConnection(): Connection
@@ -545,15 +552,7 @@ class EntityManager implements EntityManagerInterface
 
     public function newHydrator(string|int $hydrationMode): AbstractHydrator
     {
-        return match ($hydrationMode) {
-            Query::HYDRATE_OBJECT => new Internal\Hydration\ObjectHydrator($this),
-            Query::HYDRATE_ARRAY => new Internal\Hydration\ArrayHydrator($this),
-            Query::HYDRATE_SCALAR => new Internal\Hydration\ScalarHydrator($this),
-            Query::HYDRATE_SINGLE_SCALAR => new Internal\Hydration\SingleScalarHydrator($this),
-            Query::HYDRATE_SIMPLEOBJECT => new Internal\Hydration\SimpleObjectHydrator($this),
-            Query::HYDRATE_SCALAR_COLUMN => new Internal\Hydration\ScalarColumnHydrator($this),
-            default => $this->createCustomHydrator((string) $hydrationMode),
-        };
+        return $this->hydratorFactory->create($this, $this->config, $hydrationMode);
     }
 
     public function getProxyFactory(): ProxyFactory
@@ -620,16 +619,5 @@ class EntityManager implements EntityManagerInterface
         }
 
         $this->metadataFactory->setCache($metadataCache);
-    }
-
-    private function createCustomHydrator(string $hydrationMode): AbstractHydrator
-    {
-        $class = $this->config->getCustomHydrationMode($hydrationMode);
-
-        if ($class !== null) {
-            return new $class($this);
-        }
-
-        throw InvalidHydrationMode::fromMode($hydrationMode);
     }
 }

--- a/src/Internal/Hydration/DefaultHydratorFactory.php
+++ b/src/Internal/Hydration/DefaultHydratorFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\InvalidHydrationMode;
+use Doctrine\ORM\Query;
+
+final class DefaultHydratorFactory implements HydratorFactory
+{
+    public function create(EntityManagerInterface $em, Configuration $config, string|int $hydrationMode): AbstractHydrator
+    {
+        return match ($hydrationMode) {
+            Query::HYDRATE_OBJECT => new ObjectHydrator($em),
+            Query::HYDRATE_ARRAY => new ArrayHydrator($em),
+            Query::HYDRATE_SCALAR => new ScalarHydrator($em),
+            Query::HYDRATE_SINGLE_SCALAR => new SingleScalarHydrator($em),
+            Query::HYDRATE_SIMPLEOBJECT => new SimpleObjectHydrator($em),
+            Query::HYDRATE_SCALAR_COLUMN => new ScalarColumnHydrator($em),
+            default => $this->createCustomHydrator((string) $hydrationMode, $em, $config),
+        };
+    }
+
+    private function createCustomHydrator(string $hydrationMode, EntityManagerInterface $em, Configuration $config): AbstractHydrator
+    {
+        $class = $config->getCustomHydrationMode($hydrationMode);
+
+        if ($class !== null) {
+            return new $class($em);
+        }
+
+        throw InvalidHydrationMode::fromMode($hydrationMode);
+    }
+}

--- a/src/Internal/Hydration/HydratorFactory.php
+++ b/src/Internal/Hydration/HydratorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+
+interface HydratorFactory
+{
+    /**
+     * Create a new instance for the given hydration mode.
+     *
+     * @psalm-param string|AbstractQuery::HYDRATE_* $hydrationMode
+     */
+    public function create(EntityManagerInterface $em, Configuration $config, string|int $hydrationMode): AbstractHydrator;
+}


### PR DESCRIPTION
_(Continuation of #12059)_

This is a proposed extension point to help solve https://github.com/doctrine/DoctrineBundle/issues/109. I'm thinking a `HydratorInterface` that `AbstractHydrator` implements should be added but wanted to get some feedback/input before going further.

The doctrine bundle could use this to add hydration times to the timeline:
![Symfony-Profiler](https://user-images.githubusercontent.com/127811/155747034-dfd7c399-3016-49ef-a270-939132cffd91.png)

The doctrine bundle could add something similar to https://github.com/debesha/DoctrineProfileExtraBundle#screenshots to the profiler panel.

You can see an example of how this could be used in DoctrineBundle here: https://github.com/kbond/symfony-reproducer/tree/hydration-profiler-poc (specifically https://github.com/kbond/symfony-reproducer/commit/9a4e91b783bbc653457d6d22410068e00b679eed).

I don't think this causes any performance problems for hydration (when using the `DefaultHydratorFactory`).