### PR TITLE
Skip setting initialized readonly properties during refresh (#9505)

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2429,7 +2429,18 @@ class UnitOfWork implements PropertyChangedListener
 
         foreach ($data as $field => $value) {
             if (isset($class->fieldMappings[$field])) {
-                $class->propertyAccessors[$field]->setValue($entity, $value);
+                $accessor = $class->propertyAccessors[$field];
+
+                // During refresh, skip already-initialized readonly properties.
+                if (
+                    isset($hints[Query::HINT_REFRESH])
+                    && $accessor instanceof ReadonlyAccessor
+                    && $accessor->getUnderlyingReflector()->isInitialized($entity)
+                ) {
+                    continue;
+                }
+
+                $accessor->setValue($entity, $value);
             }
         }
 

--- a/tests/Tests/ORM/Functional/GH9505Test.php
+++ b/tests/Tests/ORM/Functional/GH9505Test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH9505Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH9505ReadonlyDateEntity::class);
+    }
+
+    public function testRefreshDoesNotThrowOnReadonlyObjectProperty(): void
+    {
+        $entity = new GH9505ReadonlyDateEntity(new DateTimeImmutable('2022-01-01'));
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->refresh($entity);
+
+        $this->assertSame('2022-01-01', $entity->date->format('Y-m-d'));
+    }
+}
+
+#[ORM\Entity]
+class GH9505ReadonlyDateEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public readonly int $id;
+
+    public function __construct(
+        #[ORM\Column(type: 'datetime_immutable', nullable: false)]
+        public readonly DateTimeImmutable $date,
+    ) {
+    }
+}


### PR DESCRIPTION
Fixes #9505

### Problem
`$em->refresh($entity)` crashes with `LogicException` when entity has readonly properties typed as objects (e.g., `DateTimeImmutable`). During hydration, `ReadonlyAccessor::setValue()` compares old and new values by identity (`!==`). Different PHP object instances of the same logical value trigger the comparison and throw.

### Fix
In `UnitOfWork::createEntity()`, skip calling `setValue()` for fields whose accessor is `ReadonlyAccessor` and whose property is already initialized on the entity during refresh.

### Testing
- All 1591 functional tests pass (0 failures)
- All 40 UnitOfWork unit tests pass
- All 7 Readonly functional tests pass