### PR TITLE
Transfer result cache to count query.

### DIFF
--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Tools\Pagination;
 use ArrayIterator;
 use Countable;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Cache\CacheException;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
@@ -247,6 +248,17 @@ class Paginator implements Countable, IteratorAggregate
 
         if (! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
             $countQuery->setHint(CountWalker::HINT_DISTINCT, true);
+        }
+
+        $qcp = $this->query->getQueryCacheProfile();
+        if ($qcp !== null) {
+            try {
+                $countQuery->setResultCacheId($qcp->getCacheKey());
+            } catch (CacheException $cacheException) {
+                // Continue without the cache key if one was not set.
+            }
+
+            $countQuery->setResultCacheLifetime($qcp->getLifetime());
         }
 
         if ($this->useOutputWalker($countQuery)) {

--- a/tests/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
+use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Result;
@@ -83,6 +84,43 @@ class PaginatorTest extends OrmTestCase
             [$paramInWhere],
             [$paramInSubSelect, $paramInWhere, $returnedIds],
         ], $receivedParams);
+    }
+
+    public function testPaginatorCountWillUseCacheFromOriginalQuery(): void
+    {
+        $paramInWhere   = 1;
+        $returnedCounts = [50];
+
+        $this->hydrator->method('hydrateAll')->willReturn([$returnedCounts]);
+
+        $lifetime = 10;
+        $key      = 'the-key';
+
+        $query = new Query($this->em);
+        $query->setDQL(
+            'SELECT u
+            FROM Doctrine\\Tests\\Models\\CMS\\CmsUser u
+            WHERE u.id = :paramInWhere'
+        );
+        $query->setParameters(['paramInWhere' => $paramInWhere]);
+        $query->setMaxResults(1);
+        $query->enableResultCache($lifetime, $key);
+        $queryCacheProfile = $query->getQueryCacheProfile();
+        $paginator         = (new Paginator($query, true))->setUseOutputWalkers(false);
+
+        $resultStub = $this->createStub(Result::class);
+        $this->connection
+            ->method('executeQuery')
+            ->willReturnCallback(static function (string $sql, array $params, array $types, ?QueryCacheProfile $qcp) use ($key, $lifetime, $queryCacheProfile, $resultStub): Result {
+                self::assertNotNull($qcp);
+                self::assertNotSame($queryCacheProfile, $qcp);
+                self::assertSame($lifetime, $qcp->getLifetime());
+                self::assertSame($key, $qcp->getCacheKey());
+
+                return $resultStub;
+            });
+
+        $paginator->count();
     }
 
     public function testPaginatorNotCaringAboutExtraParametersWithoutOutputWalkers(): void


### PR DESCRIPTION
In the PR #12183 the count query was changed from clone to a new query, and now there is no way to use result cache for count queries.
For projects that heavily rely on caching this means the connection to the database (and queries), instead of the already opened connection to caching layer.