### PR TITLE
Migrate call to IndexEditor API

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3166,12 +3166,6 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addIndex\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Tools/SchemaTool.php
-
-		-
 			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addUniqueIndex\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -96,6 +96,8 @@ parameters:
         - '~^Class Doctrine\\DBAL\\Platforms\\SQLitePlatform not found\.$~'
 
         - '~^Class Doctrine\\DBAL\\Schema\\NamedObject not found\.$~'
+        - '~^Class Doctrine\\DBAL\\Schema\\Name\\Parsers not found\.$~'
+        - '~^Call to an undefined static method Doctrine\\DBAL\\Schema\\Index\:\:editor\(\)\.$~'
 
         -
             message: '~sort~'

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -114,6 +114,8 @@ parameters:
         - '~^Class Doctrine\\DBAL\\Platforms\\SQLitePlatform not found\.$~'
 
         - '~^Class Doctrine\\DBAL\\Schema\\NamedObject not found\.$~'
+        - '~^Class Doctrine\\DBAL\\Schema\\Name\\Parsers not found\.$~'
+        - '~^Call to an undefined static method Doctrine\\DBAL\\Schema\\Index\:\:editor\(\)\.$~'
 
         -
             message: '~sort~'

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -409,12 +410,39 @@ class SchemaTool
                         $indexData['flags'] = [];
                     }
 
-                    $table->addIndex(
-                        $this->getIndexColumns($class, $indexData),
-                        is_numeric($indexName) ? null : $indexName,
-                        (array) $indexData['flags'],
-                        $indexData['options'] ?? [],
-                    );
+                    /** @phpstan-ignore function.impossibleType (Parsers::parseUnqualifiedName() is unreleased) */
+                    if (method_exists(Parsers::class, 'parseUnqualifiedName')) {
+                        $indexEditor = Index::editor();
+
+                        foreach ($this->getIndexColumns($class, $indexData) as $columnName) {
+                            $indexEditor->addColumn(new IndexedColumn(
+                                Parsers::parseUnqualifiedName($columnName),
+                                null,
+                            ));
+                        }
+
+                        if (isset($indexData['flags']['clustered'])) {
+                            $indexEditor->setIsClustered($indexData['flags']['clustered']);
+                        }
+
+                        if (isset($indexData['options']['where'])) {
+                            $indexEditor->setPredicate($indexData['options']['where']);
+                        }
+
+                        if (! is_numeric($indexName)) {
+                            $indexEditor->setName(Parsers::parseUnqualifiedName($indexName));
+                        }
+
+                        /** @phpstan-ignore method.notFound (IndexEditor::addToTable() is unreleased) */
+                        $indexEditor->addToTable($table);
+                    } else {
+                        $table->addIndex(
+                            $this->getIndexColumns($class, $indexData),
+                            is_numeric($indexName) ? null : $indexName,
+                            (array) $indexData['flags'],
+                            $indexData['options'] ?? [],
+                        );
+                    }
                 }
             }
 

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -18,6 +18,7 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\Parsers;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\NamedObject;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -723,12 +724,31 @@ class SchemaTool
                         $indexData['flags'] = [];
                     }
 
-                    $table->addIndex(
-                        $this->getIndexColumns($class, $indexData),
-                        is_numeric($indexName) ? null : $indexName,
-                        (array) $indexData['flags'],
-                        $indexData['options'] ?? [],
-                    );
+                    $indexEditor = Index::editor();
+
+                    foreach ($this->getIndexColumns($class, $indexData) as $columnName) {
+                        $indexEditor->addColumn(new IndexedColumn(
+                            /** @phpstan-ignore staticMethod.notFound (Parsers::parseUnqualifiedName() is unreleased) */
+                            Parsers::parseUnqualifiedName($columnName),
+                            null,
+                        ));
+                    }
+
+                    if (isset($indexData['flags']['clustered'])) {
+                        $indexEditor->setIsClustered($indexData['flags']['clustered']);
+                    }
+
+                    if (isset($indexData['options']['where'])) {
+                        $indexEditor->setPredicate($indexData['options']['where']);
+                    }
+
+                    if (! is_numeric($indexName)) {
+                        /** @phpstan-ignore staticMethod.notFound (Parsers::parseUnqualifiedName() is unreleased) */
+                        $indexEditor->setName(Parsers::parseUnqualifiedName($indexName));
+                    }
+
+                    /** @phpstan-ignore method.notFound (IndexEditor::addToTable() is unreleased) */
+                    $indexEditor->addToTable($table);
                 }
             }
 

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table as DbalTable;
+use Doctrine\DBAL\Schema\TableEditor;
 use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -61,6 +62,7 @@ use function count;
 use function current;
 use function enum_exists;
 use function method_exists;
+use function str_contains;
 
 class SchemaToolTest extends OrmTestCase
 {
@@ -482,7 +484,21 @@ class SchemaToolTest extends OrmTestCase
 
         $table = $schema->getTable('quoted-table');
 
-        self::assertTrue($table->hasIndex('IDX_AA2790FB50D14D90'));
+        $foundIndex = false;
+        if (class_exists(TableEditor::class)) {
+            foreach ($table->getIndexes() as $index) {
+                foreach ($index->getIndexedColumns() as $column) {
+                    if (str_contains($column->getColumnName()->toString(), 'quoted-name')) {
+                        $foundIndex = true;
+                        break 2;
+                    }
+                }
+            }
+        } elseif ($table->hasIndex('IDX_AA2790FB50D14D90')) {
+            $foundIndex = true;
+        }
+
+        self::assertTrue($foundIndex, 'Index on quoted-name should exist.');
 
         // DBAL < 4.3
         if (! class_exists(PrimaryKeyConstraint::class)) {

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -9,11 +9,14 @@ use Doctrine\DBAL\Schema\ForeignKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Index as DbalIndex;
 use Doctrine\DBAL\Schema\Index\IndexedColumn;
 use Doctrine\DBAL\Schema\Index\IndexType;
+use Doctrine\DBAL\Schema\Name\Identifier;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table as DbalTable;
+use Doctrine\DBAL\Schema\TableEditor;
 use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -541,7 +544,26 @@ class SchemaToolTest extends OrmTestCase
 
         $table = $schema->getTable('quoted-table');
 
-        self::assertTrue($table->hasIndex('IDX_AA2790FB50D14D90'));
+        $foundIndex = false;
+        if (class_exists(TableEditor::class)) {
+            foreach ($table->getIndexes() as $index) {
+                foreach ($index->getIndexedColumns() as $column) {
+                    if (
+                        $column->getColumnName()->getIdentifier()->equals(
+                            Identifier::quoted('quoted-name'),
+                            UnquotedIdentifierFolding::NONE,
+                        )
+                    ) {
+                        $foundIndex = true;
+                        break 2;
+                    }
+                }
+            }
+        } elseif ($table->hasIndex('IDX_AA2790FB50D14D90')) {
+            $foundIndex = true;
+        }
+
+        self::assertTrue($foundIndex, 'Index on quoted-name should exist.');
 
         // DBAL < 4.3
         if (! class_exists(PrimaryKeyConstraint::class)) {


### PR DESCRIPTION
I had to relax a test that checked for the name of an index, which we do
not really care about. What we really care about is that there is an
index on the column named `quoted-name`.

The name changes because the quoting changed as follows:

```diff
-`quoted-name`
+"quoted-name"
```