### PR TITLE
Add @no-named-arguments to QueryBuilder condition helpers

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1041,6 +1041,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function where(mixed ...$predicates): static
     {
@@ -1068,6 +1070,8 @@ class QueryBuilder implements Stringable
      * @see where()
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function andWhere(mixed ...$where): static
     {
@@ -1100,6 +1104,8 @@ class QueryBuilder implements Stringable
      * @see where()
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function orWhere(mixed ...$where): static
     {
@@ -1162,6 +1168,8 @@ class QueryBuilder implements Stringable
      * Replaces any previous having restrictions, if any.
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function having(mixed ...$having): static
     {
@@ -1179,6 +1187,8 @@ class QueryBuilder implements Stringable
      * conjunction with any existing having restrictions.
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function andHaving(mixed ...$having): static
     {
@@ -1201,6 +1211,8 @@ class QueryBuilder implements Stringable
      * disjunction with any existing having restrictions.
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function orHaving(mixed ...$having): static
     {


### PR DESCRIPTION
## Summary

Add `@no-named-arguments` to the variadic `QueryBuilder` helpers that build `WHERE` and `HAVING` conditions:

- `where()`
- `andWhere()`
- `orWhere()`
- `having()`
- `andHaving()`
- `orHaving()`

## Why

These helpers use a variadic predicate-style API where parameter names are not meant to be part of a stable public contract.

There is already a related issue showing that named-argument usage is problematic for `where()`:

- Closes #12511
- Related: #11253

Adding the annotation makes that intent explicit and helps tooling avoid introducing named arguments for these methods.

## Validation

- `vendor/bin/phpunit tests/Tests/ORM/QueryBuilderTest.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/QueryBuilder.php`
