### PR TITLE
Add @no-named-arguments to QueryBuilder select and group helpers

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -697,6 +697,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function select(mixed ...$select): static
     {
@@ -745,6 +747,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function addSelect(mixed ...$select): static
     {
@@ -1129,6 +1133,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function groupBy(string ...$groupBy): static
     {
@@ -1149,6 +1155,8 @@ class QueryBuilder implements Stringable
      * </code>
      *
      * @return $this
+     *
+     * @no-named-arguments
      */
     public function addGroupBy(string ...$groupBy): static
     {


### PR DESCRIPTION
## Summary

Add `@no-named-arguments` to the variadic `QueryBuilder` helpers used for projections and grouping:

- `select()`
- `addSelect()`
- `groupBy()`
- `addGroupBy()`

## Why this is separate from #12512

I split this out from the `where()` / `having()` condition helpers on purpose.

The first PR focused on the most obvious condition-building methods, where named arguments are especially misleading for the variadic predicate-style API and where there is already a related bug signal in #11253.

This PR covers a second group of variadic helpers where the main concern is API contract clarity and tooling guidance: the parameter names are still implementation details rather than something that should be treated as a stable named-argument contract.

## Related

- Follow-up to #12512
- Related issue: #12511

## Validation

- `vendor/bin/phpunit tests/Tests/ORM/QueryBuilderTest.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist src/QueryBuilder.php`
