### PR TITLE
Make Paginator use simpler queries when the paginated query allows it.

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -1482,6 +1482,15 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     }
 
     /**
+     * Whether the entity uses a single-field identifier, and it's set.
+     */
+    public function hasSingleIdentifier(): bool
+    {
+        return ! $this->isIdentifierComposite
+            && isset($this->identifier[0]);
+    }
+
+    /**
      * Gets the name of the single id field. Note that this only works on
      * entity classes that have a single-field pk.
      *

--- a/src/Tools/Pagination/CountWalker.php
+++ b/src/Tools/Pagination/CountWalker.php
@@ -24,6 +24,9 @@ class CountWalker extends TreeWalkerAdapter
      */
     public const HINT_DISTINCT = 'doctrine_paginator.distinct';
 
+    /** @internal */
+    public const HINT_DROP_GROUP_BY_CLAUSE = 'doctrine_paginator.drop_group_by_clause';
+
     public function walkSelectStatement(SelectStatement $selectStatement): void
     {
         if ($selectStatement->havingClause) {
@@ -37,13 +40,17 @@ class CountWalker extends TreeWalkerAdapter
             throw new RuntimeException('Cannot count query which selects two FROM components, cannot make distinction');
         }
 
-        $distinct = $this->_getQuery()->getHint(self::HINT_DISTINCT);
+        $dropGroupByClause = $this->_getQuery()->getHint(self::HINT_DROP_GROUP_BY_CLAUSE);
+        $distinct          = $this->_getQuery()->getHint(self::HINT_DISTINCT);
 
         $countPathExpressionOrLiteral = '*';
         if ($distinct) {
-            $fromRoot            = reset($from);
-            $rootAlias           = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
-            $rootClass           = $this->getMetadataForDqlAlias($rootAlias);
+            $fromRoot  = reset($from);
+            $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+            $rootClass = $this->getMetadataForDqlAlias($rootAlias);
+            // For broader compatibility, only a single id column is supported for the SELECT COUNT(DISTINCT id) query,
+            // despite the fact that multiple popular databases do support running such queries with multiple id columns
+            // (though with a varying syntax).
             $identifierFieldName = $rootClass->getSingleIdentifierFieldName();
 
             $pathType = PathExpression::TYPE_STATE_FIELD;
@@ -65,6 +72,13 @@ class CountWalker extends TreeWalkerAdapter
                 null,
             ),
         ];
+
+        // The GROUP BY clause has a mixed support. There are however cases when the clause produces records count
+        // that is exactly equal to running SELECT COUNT(*) / SELECT COUNT(DISTINCT id), provided that the clause
+        // is removed from the query.
+        if ($dropGroupByClause) {
+            $selectStatement->groupByClause = null;
+        }
 
         // ORDER BY is not needed, only increases query execution through unnecessary sorting.
         $selectStatement->orderByClause = null;

--- a/src/Tools/Pagination/CursorPaginator.php
+++ b/src/Tools/Pagination/CursorPaginator.php
@@ -34,6 +34,7 @@ use function is_string;
 final class CursorPaginator implements IteratorAggregate
 {
     use SQLResultCasing;
+    /** @use PaginatorQuery<T> */
     use PaginatorQuery;
 
     private readonly Query $query;
@@ -56,6 +57,12 @@ final class CursorPaginator implements IteratorAggregate
         }
 
         $this->query = $query;
+    }
+
+    /** @return self<T> */
+    protected static function doCreateNewWithAutoDetection(Query $query, bool $queryProducesDuplicates): self
+    {
+        return new self($query, $queryProducesDuplicates);
     }
 
     /**

--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -25,22 +25,32 @@ use function array_sum;
 class Paginator implements Countable, IteratorAggregate
 {
     use SQLResultCasing;
+    /** @use PaginatorQuery<T> */
     use PaginatorQuery;
 
     public const HINT_ENABLE_DISTINCT = 'paginator.distinct.enable';
 
     private readonly Query $query;
 
-    /** @param bool $fetchJoinCollection Whether the query joins a collection (true by default). */
+    /**
+     * @param bool $queryProducesDuplicates Whether the query could produce partially duplicated records. One case
+     *  when it does is when it joins a collection.
+     */
     public function __construct(
         Query|QueryBuilder $query,
-        private readonly bool $fetchJoinCollection = true,
+        private readonly bool $queryProducesDuplicates = true,
     ) {
         if ($query instanceof QueryBuilder) {
             $query = $query->getQuery();
         }
 
         $this->query = $query;
+    }
+
+    /** @return self<T> */
+    protected static function doCreateNewWithAutoDetection(Query $query, bool $queryProducesDuplicates): self
+    {
+        return new self($query, $queryProducesDuplicates);
     }
 
     /**
@@ -52,13 +62,21 @@ class Paginator implements Countable, IteratorAggregate
     }
 
     /**
-     * Returns whether the query joins a collection.
+     * @deprecated Use ::getQueryProducesDuplicates() instead.
      *
-     * @return bool Whether the query joins a collection.
+     * Returns whether the query joins a collection.
      */
     public function getFetchJoinCollection(): bool
     {
-        return $this->fetchJoinCollection;
+        return $this->queryProducesDuplicates;
+    }
+
+    /**
+     * Returns whether the query could produce partially duplicated records.
+     */
+    public function getQueryProducesDuplicates(): bool
+    {
+        return $this->queryProducesDuplicates;
     }
 
     public function count(): int
@@ -84,7 +102,7 @@ class Paginator implements Countable, IteratorAggregate
         $offset = $this->query->getFirstResult();
         $length = $this->query->getMaxResults();
 
-        if ($this->fetchJoinCollection && $length !== null) {
+        if ($this->queryProducesDuplicates && $length !== null) {
             $subQuery = $this->cloneQuery($this->query);
 
             if ($this->useOutputWalker($subQuery)) {

--- a/src/Tools/Pagination/PaginatorQuery.php
+++ b/src/Tools/Pagination/PaginatorQuery.php
@@ -5,57 +5,780 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\AST\Join;
+use Doctrine\ORM\Query\AST\JoinAssociationDeclaration;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\TreeWalker;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\ValueObject\LazyEntityAliasesToClassMetadataMap;
+use Doctrine\ORM\Tools\Pagination\ValueObject\SelectFieldIdentificationVariablesToSelectExpressionsMap;
+use ReflectionClass;
+use ReflectionProperty;
+use RuntimeException;
 
+use function array_intersect;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
+use function array_unique;
 use function assert;
+use function count;
+use function in_array;
+use function is_array;
 use function is_string;
+use function reset;
 
 /**
  * Provides the implementation shared by {@see Paginator} and {@see CursorPaginator}.
  *
  * @internal
+ *
+ * @template-covariant TEntityClass
  */
 trait PaginatorQuery
 {
-    private int|null $count             = null;
-    private bool|null $useOutputWalkers = null;
+    private int|null $count = null;
+    // Whether to use LimitSubqueryWalker or LimitSubqueryOutputWalker. Null means "auto-decide".
+    private bool|null $useResultQueryOutputWalker = null;
+    // Whether to use CountWalker or CountOutputWalker. Null means "auto-decide".
+    private bool|null $useCountQueryOutputWalker = null;
+
+    private bool $defaultCountWalkerNeedsToUseCountDistinct = true;
+    private bool $countWalkerShouldDropGroupByClause        = false;
 
     /**
+     * Create an instance of Paginator with auto-detection of whether the provided
+     * query is suitable for simple (and fast) pagination queries, or whether a complex
+     * set of pagination queries has to be used.
+     *
+     * @return static<TEntityClass>
+     */
+    public static function newWithAutoDetection(Query|QueryBuilder $query): static
+    {
+        if ($query instanceof QueryBuilder) {
+            $query = $query->getQuery();
+        }
+
+        $queryAST = $query->getAST();
+        assert($queryAST instanceof Query\AST\SelectStatement);
+
+        [
+            'queryIsPlainSelectScalars' => $queryIsPlainSelectScalars,
+            'queryUsesGrouping' => $queryUsesGrouping,
+            'queryGroupingCouldUseColumnsFromToManyJoins' => $queryGroupingCouldUseColumnsFromToManyJoins,
+            'queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount' => $queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount,
+            'hasHavingClause' => $queryHasHavingClause,
+            'rootEntityHasSingleIdentifierFieldName' => $rootEntityHasSingleIdentifierFieldName,
+            'couldProduceDuplicates' => $queryCouldProduceDuplicates,
+            'couldHaveToManyJoins' => $queryCouldHaveToManyJoins,
+            'resultQueryCanUseLimitSubqueryWalker' => $resultQueryCanUseLimitSubqueryWalker,
+        ] = self::autoDetectQueryFeatures($query->getEntityManager(), $queryAST);
+
+        /** @var static<TEntityClass> $paginator */
+        $paginator = static::doCreateNewWithAutoDetection(
+            $query,
+            // A "plain select scalars" query never runs into the duplication problems that the Paginator tries to handle.
+            // In that case, the result from the Paginator should be exactly what the query Selects, even if it does
+            // end up in duplicated scalars (in which case, the user should use SELECT DISTINCT on their own).
+            $queryIsPlainSelectScalars ? false : $queryCouldProduceDuplicates,
+        );
+
+        // Case when the query already has a custom output walker: do not use any of the further "auto detected" result.
+        // Note that this will force the paginator to use the equivalent non-output tree walkers which are more than
+        // likely to not produce correct results (or they could even not run at all), so custom output walkers are not
+        // exactly a very supported use case in the Paginator.
+        if ($query->getHint(Query::HINT_CUSTOM_OUTPUT_WALKER) !== false) {
+            return $paginator;
+        }
+
+        // Conditions for when the CountWalker doesn't need to use COUNT(DISTINCT), assuming CountWalker ends up
+        // being used (to be decided by ::useCountQueryOutputWalker).
+        if ($queryIsPlainSelectScalars || ! $queryCouldHaveToManyJoins) {
+            $paginator->defaultCountWalkerNeedsToUseCountDistinct = false;
+        }
+
+        if ($resultQueryCanUseLimitSubqueryWalker) {
+            $paginator->useResultQueryOutputWalker = false;
+        }
+
+        // The following is ensuring the conditions for when the CountWalker cannot be used (i.e. when the
+        // CountOutputWalker has to be used). Note how CountWalker _is_ compatible with _some_ queries with ToMany joins,
+        // as long as COUNT(DISTINCT) is also used (which is what ::getCountQuery() ensures).
+        //
+        // HAVING exists -> cannot use CountWalker (it throws an exception)
+        $paginator->useCountQueryOutputWalker = $queryHasHavingClause !== false
+            // The root entity does not have a single identifier and CountWalker has to use SELECT COUNT(DISTINCT id)
+            // -> cannot use CountWalker because it does not support root entities with composite primary key for that
+            // kind of query
+            || (
+                $rootEntityHasSingleIdentifierFieldName !== true
+                && ($query->hasHint(CountWalker::HINT_DISTINCT) || $paginator->defaultCountWalkerNeedsToUseCountDistinct)
+            )
+            // It wasn't determined whether the query uses grouping -> cannot use CountWalker
+            || $queryUsesGrouping === null
+            // The query uses grouping with columns from the ToMany joins -> cannot use CountWalker, because the query
+            // produces "duplicate rows" that cannot be "deduplicated" with COUNT(DISTINCT). Note that it does mean
+            // that queries with ToMany joins and without grouping can unconditionally use the CountWalker (but with
+            // COUNT(DISTINCT)).
+            || ($queryUsesGrouping === true && $queryGroupingCouldUseColumnsFromToManyJoins)
+            // The query uses grouping that does not produce the same number of groups as the count of all root entity records
+            // -> cannot use CountWalker, because it would produce an incorrect result. Think what happens when grouping
+            // on a non-unique, nullable column.
+            || ($queryUsesGrouping === true && ! $queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount);
+
+        // If CountWalker can be used, then tell it whether it should drop the GroupBy clause because the count of
+        // the GroupBy result is the same as the count of all root entity records.
+        if (! $paginator->useCountQueryOutputWalker && $queryAST->groupByClause !== null) {
+            $paginator->countWalkerShouldDropGroupByClause = $queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount;
+        }
+
+        return $paginator;
+    }
+
+    abstract protected static function doCreateNewWithAutoDetection(Query $query, bool $queryProducesDuplicates): self;
+
+    /**
+     * @return array{
+     *  queryIsPlainSelectScalars: bool|null,
+     *  hasMultipleFrom: bool|null,
+     *  queryUsesGrouping: bool|null,
+     *  queryGroupingCouldUseColumnsFromToManyJoins: bool,
+     *  queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount: bool,
+     *  hasHavingClause: bool|null,
+     *  rootEntityHasSingleIdentifierFieldName: bool|null,
+     *  couldProduceDuplicates: bool,
+     *  couldHaveToManyJoins: bool,
+     *  resultQueryCanUseLimitSubqueryWalker: bool|null,
+     * }
+     */
+    private static function autoDetectQueryFeatures(EntityManagerInterface $entityManager, Query\AST\SelectStatement $queryAST): array
+    {
+        $queryFeatures = [
+            // Null means undetermined
+            'queryIsPlainSelectScalars' => null,
+            'hasMultipleFrom' => null,
+            'queryUsesGrouping' => null,
+            // Note: the "queryGrouping*" values are only valid if "queryUsesGrouping" is not null
+            'queryGroupingCouldUseColumnsFromToManyJoins' => false,
+            'queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount' => false,
+            'hasHavingClause' => null,
+            'rootEntityHasSingleIdentifierFieldName' => null,
+            'couldProduceDuplicates' => true,
+            'couldHaveToManyJoins' => true,
+            'resultQueryCanUseLimitSubqueryWalker' => null,
+        ];
+
+        // First, exclude the special case when the query could be selecting only aggregate functions (i.e. always
+        // producing 1 row). This exclusion cannot actually be done "safely" (because aggregate functions could be buried
+        // within other functions to an arbitrary level), therefore instead of trying to detect this case with 100%
+        // certainty, only see whether it could potentially occur. I.e. if none of the Select expressions are a plain
+        // string or a plain PathExpression, then it could potentially be this "aggregate functions only" case. Do not
+        // support queries of this kind (even if they end up being falsly detected to be of this kind).
+        $entityAliasOrPathExpressionPresentInSelectClause = false;
+        $anyEntityAliasPresentInSelectClause              = false;
+
+        foreach ($queryAST->selectClause->selectExpressions as $selectExpression) {
+            if (! $selectExpression instanceof SelectExpression) {
+                return $queryFeatures;
+            }
+
+            if (is_string($selectExpression->expression)) {
+                $anyEntityAliasPresentInSelectClause              = true;
+                $entityAliasOrPathExpressionPresentInSelectClause = true;
+
+                break;
+            }
+
+            if ($selectExpression->expression instanceof Query\AST\PathExpression) {
+                $entityAliasOrPathExpressionPresentInSelectClause = true;
+
+                continue;
+            }
+        }
+
+        if (! $entityAliasOrPathExpressionPresentInSelectClause) {
+            return $queryFeatures;
+        }
+
+        $queryFeatures['queryUsesGrouping'] = $queryAST->selectClause->isDistinct || $queryAST->groupByClause !== null;
+        $queryFeatures['hasHavingClause']   = $queryAST->havingClause !== null;
+
+        // When the query uses multiple entities in the FROM clause (also known as CROSS JOIN), then this
+        // query's result cannot in fact be counted by the Paginator. Don't attempt to auto-detect anything here and
+        // let the further Paginator code throw exceptions in case the user tries to count the result.
+        $from                             = $queryAST->fromClause->identificationVariableDeclarations;
+        $queryFeatures['hasMultipleFrom'] = count($from) > 1;
+        if ($queryFeatures['hasMultipleFrom']) {
+            return $queryFeatures;
+        }
+
+        $fromRoot = reset($from);
+        if (! $fromRoot instanceof Query\AST\IdentificationVariableDeclaration) {
+            return $queryFeatures;
+        }
+
+        if (! $fromRoot->rangeVariableDeclaration) {
+            return $queryFeatures;
+        }
+
+        $rootAlias                                               = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
+        $rootClassMetadata                                       = $entityManager->getClassMetadata($fromRoot->rangeVariableDeclaration->abstractSchemaName);
+        $queryFeatures['rootEntityHasSingleIdentifierFieldName'] = $rootClassMetadata->hasSingleIdentifier();
+
+        $lazyEntityAliasesToClassMetadataMap = new LazyEntityAliasesToClassMetadataMap($entityManager);
+        $lazyEntityAliasesToClassMetadataMap->addEntityAlias($rootAlias, $rootClassMetadata);
+        /** @var string[] $toManyJoinsAliases */
+        $toManyJoinsAliases = [];
+
+        // Check the Joins list.
+        foreach ($fromRoot->joins as $join) {
+            if (! $join instanceof Join || ! $join->joinAssociationDeclaration instanceof JoinAssociationDeclaration) {
+                return $queryFeatures;
+            }
+
+            $joinParentAlias     = $join->joinAssociationDeclaration->joinAssociationPathExpression->identificationVariable;
+            $joinParentFieldName = $join->joinAssociationDeclaration->joinAssociationPathExpression->associationField;
+            $joinAlias           = $join->joinAssociationDeclaration->aliasIdentificationVariable;
+
+            // Every Join descending from a ToMany Join is "in principle" also a ToMany Join
+            if (in_array($joinParentAlias, $toManyJoinsAliases, true)) {
+                $toManyJoinsAliases[] = $joinAlias;
+
+                continue;
+            }
+
+            $parentClassMetadata = $lazyEntityAliasesToClassMetadataMap->getClassMetadata($joinParentAlias);
+
+            $parentJoinAssociationMapping = $parentClassMetadata->associationMappings[$joinParentFieldName] ?? null;
+            if (! $parentJoinAssociationMapping) {
+                return $queryFeatures;
+            }
+
+            $lazyEntityAliasesToClassMetadataMap->addEntityAlias($joinAlias, $parentJoinAssociationMapping['targetEntity']);
+
+            if (! ($parentJoinAssociationMapping['type'] & ClassMetadata::TO_MANY)) {
+                continue;
+            }
+
+            // The Join is a ToMany Join.
+            $toManyJoinsAliases[] = $joinAlias;
+        }
+
+        $queryFeatures['couldHaveToManyJoins'] = count($toManyJoinsAliases) > 0;
+
+        // Check if the query could end up producing "duplicate rows".
+
+        // Check the grouping in the query. Note: "grouping" means that the query either has a GroupBy clause or
+        // that it uses "SELECT DISTINCT". Both cases require the same level of "inspection".
+        if ($queryFeatures['queryUsesGrouping']) {
+            $queryFeatures['queryGroupingCouldUseColumnsFromToManyJoins'] = $queryFeatures['couldHaveToManyJoins'];
+
+            /** @var array<int, string|Query\AST\PathExpression|Node> $groupingNodes */
+            $groupingNodes = [];
+
+            // "Collapse" the "SELECT DISTINCT" case into a "GROUP BY [all selected columns]" case. Note: when both
+            // "SELECT DISTINCT" and "GROUP BY" are present, then either the "GROUP BY" effectively takes precedence
+            // or the entire query is incorrect and will not run. For that reason, when "both are present", "GROUP BY"
+            // wins.
+            $groupingUsesSelectDistinct = false;
+            if ($queryAST->groupByClause !== null) {
+                // Note: in the case of GroupBy, the grouping nodes can only be string or Query\AST\PathExpression.
+                // I.e. they will never be Node instances (i.e. "expressions").
+                $groupingNodes = $queryAST->groupByClause->groupByItems;
+            } else {
+                $groupingUsesSelectDistinct = true;
+                $groupingNodes              = array_map(
+                    static fn (SelectExpression $selectExpression): mixed => $selectExpression->expression,
+                    $queryAST->selectClause->selectExpressions,
+                );
+            }
+
+            // Collect information about what is being grouped by.
+
+            /**
+             * @var array<string, Query\AST\PathExpression[]> $groupingEntityAliasesToPathExpressions Empty array as value
+             * means: GroupBy the entire entity.
+             */
+            $groupingEntityAliasesToPathExpressions                   = [];
+            $selectFieldIdentificationVariablesToSelectExpressionsMap = null;
+
+            foreach ($groupingNodes as $groupingNode) {
+                if (is_string($groupingNode)) {
+                    // Case when this is an entity alias: store and continue.
+                    if ($lazyEntityAliasesToClassMetadataMap->hasEntityAlias($groupingNode)) {
+                        $groupingEntityAliasesToPathExpressions[$groupingNode] = [];
+
+                        continue;
+                    }
+
+                    // Case when this is a "SELECT DISTINCT", the string value is unrecognised. This should never
+                    // happen at this point because the query would have failed AST parsing a lot earlier.
+                    if ($groupingUsesSelectDistinct) {
+                        throw new RuntimeException('SELECT clause uses an unrecognized alias: ' . $groupingNode);
+                    }
+
+                    // Populate a helper map
+                    if (! $selectFieldIdentificationVariablesToSelectExpressionsMap) {
+                        $selectFieldIdentificationVariablesToSelectExpressionsMap = new SelectFieldIdentificationVariablesToSelectExpressionsMap($queryAST);
+                    }
+
+                    // Case when this is an alias from the Select list: see what the Select item is.
+                    /** @var Query\AST\PathExpression|mixed|null $usedSelectExpressionExpression */
+                    $usedSelectExpressionExpression = $selectFieldIdentificationVariablesToSelectExpressionsMap->getSelectExpression($groupingNode)->expression ?? null;
+                    if (! $usedSelectExpressionExpression) {
+                        // The GroupBy uses an alias that is unrecognized. This should never happen (because it would be
+                        // a SQL/DQL syntax error).
+                        throw new RuntimeException('GroupBy clause uses an unrecognized alias: ' . $groupingNode);
+                    }
+
+                    // Treat the "extracted" Select expression as the groupingNode and let the rest of the foreach code
+                    // handle it.
+                    $groupingNode = $usedSelectExpressionExpression;
+                }
+
+                if ($groupingNode instanceof Query\AST\PathExpression) {
+                    $groupingEntityAliasesToPathExpressions[$groupingNode->identificationVariable][]
+                        = $groupingNode;
+
+                    continue;
+                }
+
+                // At this point, the grouping node could either be an expression or a literal (both of which: instances
+                // of an AST Node). Literals don't change anything, so they are ignored. The expressions however are
+                // the tricky part. There's no point trying to inspect the expression totally because it would be a fool's
+                // errand (think about complex expressions within expressions). Instead, the following is done: if the
+                // expression uses at least 1 column from a ToMany Join, then it _could_ result in duplicate rows, and
+                // therefore there is nothing more to inspect. If that's not the case, then the "auto detection" will
+                // continue, but it will treat the expression as a "black/Pandora box". In that case, the expression
+                // could be complex or could be trivial, but the "auto detection" will not even attempt "to find out".
+                //
+                // An example of a ToMany usage that does NOT result in duplicate rows, but the "auto detection" will not
+                // ask further questions and "assume the worst": "CASE WHEN TRUE THEN 'lorem ipsum' ELSE to_many.id END".
+
+                // Look for ToMany usages only when there actually are ToMany Joins.
+                if (! $queryFeatures['couldHaveToManyJoins']) {
+                    continue;
+                }
+
+                $searchResult = self::searchEntityAliasesUsageInASTNode($toManyJoinsAliases, $groupingNode);
+
+                // Case when the expression is too complex: It's not safe to make any assumptions about what is being
+                // grouped on. Return immediately.
+                if ($searchResult === null) {
+                    return $queryFeatures;
+                }
+
+                // Case when there is at least one ToMany column usage: return immediately.
+                if ($searchResult === true) {
+                    $queryFeatures['resultQueryCanUseLimitSubqueryWalker'] = self::autoDetectCanUseLimitSubqueryWalker(
+                        $queryAST,
+                        $rootAlias,
+                        $lazyEntityAliasesToClassMetadataMap,
+                        $toManyJoinsAliases,
+                        $selectFieldIdentificationVariablesToSelectExpressionsMap,
+                    );
+
+                    return $queryFeatures;
+                }
+
+                // There aren't any ToMany columns usages, so the iteration continues. The grouping node is not
+                // however tracked in $groupingEntityAliasesToPathExpressions because at this point it's treated
+                // as an "unknown/risky".
+            }
+
+            // Case when the grouping uses any columns from any of the ToMany joins: nothing more to do here.
+            if (
+                $queryFeatures['queryGroupingCouldUseColumnsFromToManyJoins']
+                && array_intersect($toManyJoinsAliases, array_keys($groupingEntityAliasesToPathExpressions))
+            ) {
+                $queryFeatures['resultQueryCanUseLimitSubqueryWalker'] = self::autoDetectCanUseLimitSubqueryWalker(
+                    $queryAST,
+                    $rootAlias,
+                    $lazyEntityAliasesToClassMetadataMap,
+                    $toManyJoinsAliases,
+                    $selectFieldIdentificationVariablesToSelectExpressionsMap,
+                );
+
+                return $queryFeatures;
+            }
+
+            $queryFeatures['queryGroupingCouldUseColumnsFromToManyJoins'] = false;
+            $queryFeatures['couldProduceDuplicates']                      = false;
+
+            // Case when no tracked path expressions: return immediately. This could happen only if the grouping
+            // uses an expression, which isn't safe to work with any further (unfortunately).
+            if (! $groupingEntityAliasesToPathExpressions) {
+                return $queryFeatures;
+            }
+
+            // Check whether the grouping will produce the same number of groups as the count of all root entity records.
+            // This can happen only if at least one of the grouping items is a unique and not-nullable column. This
+            // includes (complete) primary keys. Note: the order of columns in the grouping (e.g. the GroupBy clause)
+            // is not relevant. This allows to short-circuit this lookup on the first condition that satisfies the
+            // search.
+            /** @var array<string, string[]> $groupingIdentifierFieldNamesByEntityAliasToRecheck */
+            $groupingIdentifierFieldNamesByEntityAliasToRecheck = [];
+            foreach ($groupingEntityAliasesToPathExpressions as $groupingEntityAlias => $groupingPathExpressions) {
+                // Case when no PathExpression: grouping uses an entire entity, including its primary key.
+                if (! $groupingPathExpressions) {
+                    $groupingIdentifierFieldNamesByEntityAliasToRecheck = [];
+
+                    break;
+                }
+
+                foreach ($groupingPathExpressions as $groupingPathExpression) {
+                    // Case when no field on the PathExpression: grouping uses an entire entity, including its primary key.
+                    if ($groupingPathExpression->field === null) {
+                        $groupingIdentifierFieldNamesByEntityAliasToRecheck = [];
+
+                        break 2;
+                    }
+
+                    $entityClassMetadata = $lazyEntityAliasesToClassMetadataMap->getClassMetadata($groupingEntityAlias);
+
+                    // Case when the field is unique and not nullable: the counts will be equal.
+                    if (
+                        $entityClassMetadata->isUniqueField($groupingPathExpression->field)
+                        && ! $entityClassMetadata->isNullable($groupingPathExpression->field)
+                    ) {
+                        $groupingIdentifierFieldNamesByEntityAliasToRecheck = [];
+
+                        break 2;
+                    }
+
+                    // Case when the field is a primary key: collect it to recheck it later in case it's a composite primary
+                    // key.
+                    if ($entityClassMetadata->isIdentifier($groupingPathExpression->field)) {
+                        $groupingIdentifierFieldNamesByEntityAliasToRecheck[$groupingEntityAlias][] = $groupingPathExpression->field;
+
+                        continue;
+                    }
+
+                    // Any other case: the counts will not be equal.
+                    return $queryFeatures;
+                }
+            }
+
+            // Recheck the primary key fields presence.
+            foreach ($groupingIdentifierFieldNamesByEntityAliasToRecheck as $entityAlias => $presentIdentifierFieldNames) {
+                $presentIdentifierFieldNames = array_unique($presentIdentifierFieldNames);
+
+                $entityClassMetadata = $lazyEntityAliasesToClassMetadataMap->getClassMetadata($entityAlias);
+
+                /// Case when the grouping uses primary keys from an entity, but not all of them: return.
+                if (
+                    count(array_intersect($presentIdentifierFieldNames, $entityClassMetadata->getIdentifierFieldNames()))
+                    !== count($entityClassMetadata->getIdentifierFieldNames())
+                ) {
+                    return $queryFeatures;
+                }
+            }
+
+            $queryFeatures['queryGroupingProducesGroupsCountEqualToRootEntityRecordsCount'] = true;
+
+            // The usage of grouping conclusively determines whether there "could be duplicates" (or the
+            // query itself is invalid because it selects columns that are not in the GroupBy and are not in an aggregate
+            // function).
+            return $queryFeatures;
+        }
+
+        // Case when the query doesn't SELECT DISTINCT and doesn't use GROUP BY, and when it SELECTs only scalar values
+        // (including expressions), then it's considered a "plain select scalars" query.
+        if (! $anyEntityAliasPresentInSelectClause) {
+            $queryFeatures['queryIsPlainSelectScalars'] = true;
+
+            return $queryFeatures;
+        }
+
+        // When no ToMany joins (and no multiple FROMs), then a DQL query cannot produce duplicates. In particular:
+        // DQL queries disallow the usage of "rows generating" functions (that can appear in the Select list or
+        // through joins).
+        if (! $queryFeatures['couldHaveToManyJoins']) {
+            $queryFeatures['couldProduceDuplicates'] = false;
+
+            return $queryFeatures;
+        }
+
+        // When there are ToMany joins, and no GroupBy clause, then the Select list HAS TO NOT use any of the columns
+        // from the ToMany relations, and it HAS TO use "SELECT DISTINCT"
+
+        if (! $queryAST->selectClause->isDistinct) {
+            $queryFeatures['resultQueryCanUseLimitSubqueryWalker'] = self::autoDetectCanUseLimitSubqueryWalker(
+                $queryAST,
+                $rootAlias,
+                $lazyEntityAliasesToClassMetadataMap,
+                $toManyJoinsAliases,
+            );
+
+            return $queryFeatures;
+        }
+
+        // Check the Select list.
+        foreach ($queryAST->selectClause->selectExpressions as $selectExpression) {
+            if (! $selectExpression instanceof SelectExpression) {
+                return $queryFeatures;
+            }
+
+            // Case when the expression is a bare entity alias, it must not be an alias from a ToMany relation
+            if (is_string($selectExpression->expression)) {
+                if (in_array($selectExpression->expression, $toManyJoinsAliases, true)) {
+                    return $queryFeatures;
+                }
+
+                continue;
+            }
+
+            // Search for usage of any of the ToMany columns.
+            $searchResult = self::searchEntityAliasesUsageInASTNode($toManyJoinsAliases, $selectExpression->expression);
+
+            // Case when the expression is too complex: It's not safe to make any assumptions about what is being
+            // Selected. Return immediately.
+            if ($searchResult === null) {
+                return $queryFeatures;
+            }
+
+            // Case when there is at least one ToMany column usage: return immediately.
+            if ($searchResult === true) {
+                $queryFeatures['resultQueryCanUseLimitSubqueryWalker'] = self::autoDetectCanUseLimitSubqueryWalker(
+                    $queryAST,
+                    $rootAlias,
+                    $lazyEntityAliasesToClassMetadataMap,
+                    $toManyJoinsAliases,
+                );
+
+                return $queryFeatures;
+            }
+        }
+
+        $queryFeatures['couldProduceDuplicates'] = false;
+
+        return $queryFeatures;
+    }
+
+    /**
+     * @param string[] $searchedEntityAliases The entity aliases to find anywhere in the Node
+     * @param mixed    $node                  Mostly instances of Doctrine\ORM\Query\AST\Node but could be anything
+     * @param int      $remainingDepth        When reaches 0, the recursion is shorted for safety with no conclusion.
+     *
+     * @return bool|null When bool: whether at least one usage found. When null: the function was shorted for safety
+     *                   and its result should not be relied upon.
+     */
+    private static function searchEntityAliasesUsageInASTNode(
+        array $searchedEntityAliases,
+        mixed $node,
+        int $remainingDepth = 20,
+    ): bool|null {
+        if ($node instanceof Query\AST\PathExpression) {
+            return in_array($node->identificationVariable, $searchedEntityAliases, true);
+        }
+
+        if ($remainingDepth === 0) {
+            // Too deep: exit the recursion for safety.
+            return null;
+        }
+
+        if ($node instanceof Node) {
+            foreach ((new ReflectionClass($node))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+                $result = self::searchEntityAliasesUsageInASTNode($searchedEntityAliases, $property->getValue($node), $remainingDepth - 1);
+
+                if ($result === null || $result === true) {
+                    return $result;
+                }
+            }
+        } elseif (is_array($node)) {
+            foreach ($node as $item) {
+                // $remainingDepth not decremented here because arrays of Nodes aren't worthwhile "counting"
+                $result = self::searchEntityAliasesUsageInASTNode($searchedEntityAliases, $item, $remainingDepth);
+
+                if ($result === null || $result === true) {
+                    return $result;
+                }
+            }
+        }
+
+        // For all other "Node cases", there necessarily must not be any mentions of entity aliases.
+        return false;
+    }
+
+    /**
+     * Check whether the query can use the {@see LimitSubqueryWalker}.
+     *
+     * Roughly follows what LimitSubqueryWalker::validate() does, plus some of the "exception cases".
+     *
+     * @param string[] $toManyJoinsAliases
+     *
+     * @return bool|null Null means "undetermined"
+     */
+    private static function autoDetectCanUseLimitSubqueryWalker(
+        Query\AST\SelectStatement $queryAST,
+        string $rootAlias,
+        LazyEntityAliasesToClassMetadataMap $lazyEntityAliasesToClassMetadataMap,
+        array $toManyJoinsAliases,
+        SelectFieldIdentificationVariablesToSelectExpressionsMap|null $selectExpressionsByFieldIdentificationVariable = null,
+    ): bool|null {
+        $rootClassMetadata = $lazyEntityAliasesToClassMetadataMap->getClassMetadata($rootAlias);
+
+        // The primary key of the root entity must be single-column and must not be a foreign key (aka. "an association").
+        if (
+            $rootClassMetadata->isIdentifierComposite
+            || $rootClassMetadata->hasAssociation($rootClassMetadata->getSingleIdentifierFieldName())
+        ) {
+            return false;
+        }
+
+        // None of the OrderBy items must be using a ToMany column
+
+        // Case when no OrderBy clause or no ToMany joins: can use the LimitSubqueryWalker.
+        if ($queryAST->orderByClause === null || count($toManyJoinsAliases) === 0) {
+            return true;
+        }
+
+        // The processing of an OrderyBy clause is similar to that of GroupBy.
+        foreach ($queryAST->orderByClause->orderByItems as $orderByItem) {
+            $orderByItemExpression = $orderByItem->expression;
+
+            if (is_string($orderByItemExpression)) {
+                // Case when this is an entity alias
+                if ($lazyEntityAliasesToClassMetadataMap->hasEntityAlias($orderByItemExpression)) {
+                    if (in_array($orderByItemExpression, $toManyJoinsAliases, true)) {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                // Populate a helper map
+                if (! $selectExpressionsByFieldIdentificationVariable) {
+                    $selectExpressionsByFieldIdentificationVariable = new SelectFieldIdentificationVariablesToSelectExpressionsMap($queryAST);
+                }
+
+                // Case when this is an alias from the Select list: see what the Select item is.
+                /** @var Query\AST\PathExpression|mixed|null $usedSelectExpressionExpression */
+                $usedSelectExpressionExpression = $selectExpressionsByFieldIdentificationVariable->getSelectExpression($orderByItemExpression)->expression ?? null;
+                if (! $usedSelectExpressionExpression) {
+                    // The OrderBy uses an alias that is unrecognized. This should never happen (because it would be
+                    // a SQL/DQL syntax error).
+                    throw new RuntimeException('OrderBy clause uses an unrecognized alias: ' . $orderByItemExpression);
+                }
+
+                // Treat the "extracted" Select expression as the orderByItemExpression and let the rest of the foreach code
+                // handle it.
+                $orderByItemExpression = $usedSelectExpressionExpression;
+            }
+
+            if ($orderByItemExpression instanceof Query\AST\PathExpression) {
+                if (in_array($orderByItemExpression->identificationVariable, $toManyJoinsAliases, true)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            // At this point, the orderByItemExpression is an expression. The same caveats and decisions are made here as for
+            // the same situation in the GroupBy case.
+
+            $searchResult = self::searchEntityAliasesUsageInASTNode($toManyJoinsAliases, $orderByItemExpression);
+
+            // Case when the expression is too complex: It's not safe to make any assumptions about what is being
+            // ordered by on.
+            if ($searchResult === null) {
+                return null;
+            }
+
+            // Case when there is at least one ToMany column usage: cannot use the LimitSubqueryWalker.
+            if ($searchResult === true) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @deprecated Use the individual ::get*OutputWalker()
+     *
      * Returns whether the paginator will use an output walker.
      */
     public function getUseOutputWalkers(): bool|null
     {
-        return $this->useOutputWalkers;
+        return $this->getUseResultQueryOutputWalker() === null && $this->getUseCountQueryOutputWalker() === null
+            ? null
+            : $this->getUseResultQueryOutputWalker() && $this->getUseCountQueryOutputWalker();
     }
 
     /**
+     * @deprecated Use the individual ::set*OutputWalker()
+     *
      * Sets whether the paginator will use an output walker.
      *
      * @return $this
      */
     public function setUseOutputWalkers(bool|null $useOutputWalkers): static
     {
-        $this->useOutputWalkers = $useOutputWalkers;
+        $this->setUseResultQueryOutputWalker($useOutputWalkers);
+        $this->setUseCountQueryOutputWalker($useOutputWalkers);
 
         return $this;
     }
 
-    /**
-     * Determines whether to use an output walker for the query.
-     */
-    private function useOutputWalker(Query $query): bool
+    public function getUseResultQueryOutputWalker(): bool|null
     {
-        if ($this->useOutputWalkers === null) {
-            return (bool) $query->getHint(Query::HINT_CUSTOM_OUTPUT_WALKER) === false;
+        return $this->useResultQueryOutputWalker;
+    }
+
+    public function setUseResultQueryOutputWalker(bool|null $useResultQueryOutputWalker): static
+    {
+        $this->useResultQueryOutputWalker = $useResultQueryOutputWalker;
+
+        return $this;
+    }
+
+    public function getUseCountQueryOutputWalker(): bool|null
+    {
+        return $this->useCountQueryOutputWalker;
+    }
+
+    public function setUseCountQueryOutputWalker(bool|null $useCountQueryOutputWalker): static
+    {
+        $this->useCountQueryOutputWalker = $useCountQueryOutputWalker;
+
+        return $this;
+    }
+
+    /** @internal */
+    public function getDefaultCountWalkerNeedsToUseCountDistinct(): bool
+    {
+        return $this->defaultCountWalkerNeedsToUseCountDistinct;
+    }
+
+    /** @internal */
+    public function getCountWalkerShouldDropGroupByClause(): bool
+    {
+        return $this->countWalkerShouldDropGroupByClause;
+    }
+
+    /**
+     * Determines whether to use an output-equivalent query walker for the pagination result query or the count query.
+     */
+    private function useOutputWalker(Query $query, bool $forCountQuery = false): bool
+    {
+        if (! $forCountQuery && $this->useResultQueryOutputWalker !== null) {
+            return $this->useResultQueryOutputWalker;
         }
 
-        return $this->useOutputWalkers;
+        if ($forCountQuery && $this->useCountQueryOutputWalker !== null) {
+            return $this->useCountQueryOutputWalker;
+        }
+
+        // Auto-decide: when a custom output walker already present, then do not use the Paginator's.
+        return $query->getHint(Query::HINT_CUSTOM_OUTPUT_WALKER) === false;
     }
 
     private function cloneQuery(Query $query): Query
@@ -108,11 +831,7 @@ trait PaginatorQuery
             $countQuery->setHint($name, $value);
         }
 
-        if (! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
-            $countQuery->setHint(CountWalker::HINT_DISTINCT, true);
-        }
-
-        if ($this->useOutputWalker($countQuery)) {
+        if ($this->useOutputWalker($countQuery, forCountQuery: true)) {
             $platform = $countQuery->getEntityManager()->getConnection()->getDatabasePlatform(); // law of demeter win
 
             $rsm = new ResultSetMapping();
@@ -123,6 +842,12 @@ trait PaginatorQuery
         } else {
             $this->appendTreeWalker($countQuery, CountWalker::class);
             $this->unbindUnusedQueryParams($countQuery);
+
+            if (! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
+                $countQuery->setHint(CountWalker::HINT_DISTINCT, $this->defaultCountWalkerNeedsToUseCountDistinct);
+            }
+
+            $countQuery->setHint(CountWalker::HINT_DROP_GROUP_BY_CLAUSE, $this->countWalkerShouldDropGroupByClause);
         }
 
         $countQuery->setFirstResult(0)->setMaxResults(null);

--- a/src/Tools/Pagination/ValueObject/LazyEntityAliasesToClassMetadataMap.php
+++ b/src/Tools/Pagination/ValueObject/LazyEntityAliasesToClassMetadataMap.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination\ValueObject;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use RuntimeException;
+
+use function is_string;
+use function sprintf;
+
+/** @internal */
+final class LazyEntityAliasesToClassMetadataMap
+{
+    /** @var array<string, string|ClassMetadata<object>> */
+    private array $map = [];
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function hasEntityAlias(string $entityAlias): bool
+    {
+        return isset($this->map[$entityAlias]);
+    }
+
+    /** @param string|ClassMetadata<object> $classNameOrClassMetadata */
+    public function addEntityAlias(string $entityAlias, string|ClassMetadata $classNameOrClassMetadata): void
+    {
+        $this->map[$entityAlias] = $classNameOrClassMetadata;
+    }
+
+    /** @return ClassMetadata<object> */
+    public function getClassMetadata(string $entityAlias): ClassMetadata
+    {
+        $classNameOrClassMetadata = $this->map[$entityAlias] ?? null;
+
+        if ($classNameOrClassMetadata === null) {
+            throw new RuntimeException(sprintf('Unknown entity alias: "%s".', $entityAlias));
+        }
+
+        // Load entity class metadata.
+        if (is_string($classNameOrClassMetadata)) {
+            $classMetadata = $this->entityManager->getClassMetadata($classNameOrClassMetadata);
+            $this->addEntityAlias($entityAlias, $classMetadata);
+
+            return $classMetadata;
+        }
+
+        return $classNameOrClassMetadata;
+    }
+}

--- a/src/Tools/Pagination/ValueObject/SelectFieldIdentificationVariablesToSelectExpressionsMap.php
+++ b/src/Tools/Pagination/ValueObject/SelectFieldIdentificationVariablesToSelectExpressionsMap.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination\ValueObject;
+
+use Doctrine\ORM\Query\AST\SelectExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+
+use function is_string;
+
+/** @internal */
+final class SelectFieldIdentificationVariablesToSelectExpressionsMap
+{
+    /** @var array<string, SelectExpression> */
+    private array $map;
+
+    public function __construct(SelectStatement $selectStatement)
+    {
+        foreach ($selectStatement->selectClause->selectExpressions as $selectExpression) {
+            if (
+                ! $selectExpression instanceof SelectExpression
+                || ! is_string($selectExpression->fieldIdentificationVariable)
+            ) {
+                continue;
+            }
+
+            $this->map[$selectExpression->fieldIdentificationVariable] = $selectExpression;
+        }
+    }
+
+    public function getSelectExpression(string $fieldIdentificationVariable): SelectExpression|null
+    {
+        return $this->map[$fieldIdentificationVariable] ?? null;
+    }
+}

--- a/tests/Tests/Models/CMS/CmsArticleAssociatedDetail.php
+++ b/tests/Tests/Models/CMS/CmsArticleAssociatedDetail.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'cms_article_associated_details')]
+#[Entity]
+class CmsArticleAssociatedDetail
+{
+    #[Id]
+    #[OneToOne(targetEntity: 'CmsArticle')]
+    #[JoinColumn(name: 'article_id', referencedColumnName: 'id')]
+    public CmsArticle $article;
+
+    /** @var string */
+    #[Column(type: 'text')]
+    public $detail;
+}

--- a/tests/Tests/Models/CMS/CmsComment.php
+++ b/tests/Tests/Models/CMS/CmsComment.php
@@ -31,10 +31,20 @@ class CmsComment implements Stringable
     #[Column(type: 'string', length: 255)]
     public $text;
 
+    /** @var CmsUser|null */
+    #[ManyToOne(targetEntity: 'CmsUser')]
+    #[JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true)]
+    public $user;
+
     /** @var CmsArticle */
     #[ManyToOne(targetEntity: 'CmsArticle', inversedBy: 'comments')]
     #[JoinColumn(name: 'article_id', referencedColumnName: 'id')]
     public $article;
+
+    public function setAuthor(CmsUser|null $author): void
+    {
+        $this->user = $author;
+    }
 
     public function setArticle(CmsArticle $article): void
     {

--- a/tests/Tests/Models/CompositeKeyRelations/CustomerClass.php
+++ b/tests/Tests/Models/CompositeKeyRelations/CustomerClass.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\CompositeKeyRelations;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
 
 #[Entity]
 class CustomerClass
@@ -18,6 +20,10 @@ class CustomerClass
     #[Id]
     #[Column(type: 'string')]
     public string $code;
+
+    /** @var Collection<int, InvoiceClass> */
+    #[OneToMany(targetEntity: InvoiceClass::class, mappedBy: 'customer')]
+    public Collection $invoices;
 
     #[Column(type: 'string')]
     public string $name;

--- a/tests/Tests/Models/CompositeKeyRelations/InvoiceClass.php
+++ b/tests/Tests/Models/CompositeKeyRelations/InvoiceClass.php
@@ -21,7 +21,7 @@ class InvoiceClass
     #[Column(type: 'string')]
     public string $invoiceNumber;
 
-    #[ManyToOne(targetEntity: CustomerClass::class)]
+    #[ManyToOne(targetEntity: CustomerClass::class, inversedBy: 'invoices')]
     #[JoinColumn(name: 'companyCode', referencedColumnName: 'companyCode')]
     #[JoinColumn(name: 'customerCode', referencedColumnName: 'code')]
     public CustomerClass|null $customer;

--- a/tests/Tests/ORM/Functional/PaginatorAutoDetectionTest.php
+++ b/tests/Tests/ORM/Functional/PaginatorAutoDetectionTest.php
@@ -1,0 +1,912 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Closure;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsArticleAssociatedDetail;
+use Doctrine\Tests\Models\CMS\CmsComment;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass;
+use Doctrine\Tests\Models\CompositeKeyRelations\InvoiceClass;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function iterator_to_array;
+use function min;
+
+class PaginatorAutoDetectionTest extends OrmFunctionalTestCase
+{
+    private const RESULT_QUERY_FAST                           = 'result-query-fast';
+    private const RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER      = 'result-query-with-subquery-tree-walker';
+    private const RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER    = 'result-query-with-subquery-output-walker';
+    private const COUNT_QUERY_FAST                            = 'count-query-fast';
+    private const COUNT_QUERY_FAST_WITH_DISTINCT              = 'count-query-fast-with-distinct';
+    private const COUNT_QUERY_FAST_NO_DISTINCT                = 'count-query-fast-no-distinct';
+    private const COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE  = 'count-query-fast-should-drop-group-by-true';
+    private const COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE = 'count-query-fast-should-drop-group-by-false';
+    private const COUNT_QUERY_WITH_OUTPUT_WALKER              = 'count-query-with-output-walker';
+
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+        $this->useModelSet('compositekeyrelations');
+
+        parent::setUp();
+
+        $this->populate();
+    }
+
+    /** @param Closure(self, EntityManagerInterface): (Query|QueryBuilder) $testSetUpAndQueryFactory */
+    #[DataProvider('provideQueriesForNewWithAutoDetection')]
+    public function testNewWithAutoDetection(
+        Closure $testSetUpAndQueryFactory,
+        string $expectedResultQueryKind,
+        string $expectedCountQueryKind,
+        string $expectedFastCountQueryDistinctUsage,
+        string $expectedFastCountQueryShouldDropGroupBy,
+        int $expectedCount,
+    ): void {
+        $paginator = Paginator::newWithAutoDetection($testSetUpAndQueryFactory($this, $this->_em));
+
+        // Walker-selection assertions
+        self::assertSame(
+            $expectedResultQueryKind,
+            match (true) {
+                ! $paginator->getQueryProducesDuplicates() => self::RESULT_QUERY_FAST,
+                $paginator->getUseResultQueryOutputWalker() === false => self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+                default => self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            },
+        );
+        self::assertSame(
+            $expectedCountQueryKind,
+            match ($paginator->getUseCountQueryOutputWalker()) {
+                true => self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+                false => self::COUNT_QUERY_FAST,
+                null => null,
+            },
+        );
+        self::assertSame(
+            $expectedFastCountQueryDistinctUsage,
+            $paginator->getDefaultCountWalkerNeedsToUseCountDistinct()
+                ? self::COUNT_QUERY_FAST_WITH_DISTINCT
+                : self::COUNT_QUERY_FAST_NO_DISTINCT,
+        );
+        self::assertSame(
+            $expectedFastCountQueryShouldDropGroupBy,
+            $paginator->getCountWalkerShouldDropGroupByClause()
+                ? self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE
+                : self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+        );
+
+        // Sanity-check the pagination results
+        self::assertSame($expectedCount, $paginator->count());
+        self::assertCount(min($expectedCount, 10), iterator_to_array($paginator->getIterator()));
+    }
+
+    /** @return iterable<string, array{Closure, string, string, string, string, int}> */
+    public static function provideQueriesForNewWithAutoDetection(): iterable
+    {
+        yield 'QueryBuilder is supported' => [
+            static function (self $testCase, EntityManagerInterface $em): QueryBuilder {
+                $queryBuilder = $em->createQueryBuilder()
+                    ->select('u')
+                    ->from(CmsUser::class, 'u')
+                    ->orderBy('u.id');
+                $queryBuilder->setMaxResults(10);
+
+                return $queryBuilder;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with no joins' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u FROM ' . CmsUser::class . ' u ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with no joins, composite primary key' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT c FROM ' . CustomerClass::class . ' c ORDER BY c.companyCode');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            5,
+        ];
+
+        yield 'query with OneToOne join' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.address a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, select scalars only' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id, a.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            45,
+        ];
+
+        yield 'query with OneToMany join, select scalars only, select only ToOne' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            // It returns this many records because the query does not do SELECT DISTINCT on its own.
+            45,
+        ];
+
+        yield 'query with OneToMany join, select scalar DISTINCT' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u.id, a.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                // This case isn't in fact supported even by the "compatible" queries. At least assert that the test
+                // fails for a consistent reason.
+                $testCase->expectExceptionMessageMatches('/^Not all identifier properties can be found in the ResultSetMapping:/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            45,
+        ];
+
+        // A ToOne relation that is a descendant of a ToMany relation, is effectively a ToMany relation.
+        yield 'query with OneToMany join, fetch-join a deep ToMany-dependant ToOne relation' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, comment_author.id FROM ' . CmsUser::class . ' u JOIN u.articles a JOIN a.comments c JOIN c.user comment_author ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            5,
+        ];
+
+        yield 'query with OneToMany join, not fetch-joined' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, not fetch-joined, with DISTINCT' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, not fetch-joined, with DISTINCT, composite primary key' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT c FROM ' . CustomerClass::class . ' c JOIN c.invoices i ORDER BY c.companyCode');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            5,
+        ];
+
+        yield 'query with OneToMany join, not fetch-joined, with DISTINCT, with path expression' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with complex select expression, no ToMany joins' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, (CASE WHEN u.id < 5 THEN 1 ELSE 0 END) AS complexExpression FROM ' . CmsUser::class . ' u ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with complex select expression, no columns from the ToMany join' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, (CASE WHEN u.id < 5 THEN 1 ELSE 0 END) AS complexExpression FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with complex select expression, no columns from the ToMany join, with DISTINCT' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u, (CASE WHEN u.id < 5 THEN 1 ELSE 0 END) AS complexExpression FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with complex select expression, with columns from the ToMany join' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, (CASE WHEN a.id < 5 THEN 1 ELSE 0 END) AS complexExpression FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            // This should really return either 45 or 10 rows. The scalar result is 45 rows. User with id 3 has 2 distinct
+            // rows: one with complexExpression=1 and one with complexExpression=0, so it could have been expected to either
+            // get 10 result rows here, or 9 rows with the row for User3 with complexExpression column being an array of
+            // 2 values. But what happens is that Paginator drops one of the User3 result rows.
+            //
+            // It's not clear what the actual expectation and support is for queries that select an entity and a scalar
+            // from a ToMany relation.
+            //
+            // The same "dilemma" happens in similar subsequent test cases.
+            9,
+        ];
+
+        yield 'query with complex select expression, with columns from the ToMany join, with DISTINCT' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u, (CASE WHEN SUBSTRING(a.text, LENGTH(a.text), 1) = \'2\' THEN 1 ELSE 0 END) AS complexExpression FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            // Note: this query produces 16 result rows but for some reason both the "with subquery" result queries and
+            // the "with output walker" count query produce 9, which is not expected. If this ever gets "fixed", then
+            // the following test assertion could be restored.
+            // 16,
+            9,
+        ];
+
+        // Note: sub-selects in the select expression will never result in "duplicate rows". The DISTINCT is needed
+        // only because the main query still joins on a ToMany relation.
+        yield 'query with sub-select select expression, no columns from the ToMany join, with DISTINCT' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT DISTINCT u, (SELECT MAX(a_inner.version) FROM ' . CmsArticle::class . ' a_inner WHERE a_inner.user = u) AS complexExpression FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        // The auto-detection should not process select expressions that are too complex. Instead, it should assume
+        // the worst case scenario and use the "slower but more compatible" result query.
+        yield 'query with too complex select expression' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery(<<<'DQL'
+                    SELECT
+                        u,
+                        (
+                            CASE WHEN u.id > 0 THEN
+                                CASE WHEN u.id > 1 THEN
+                                    CASE WHEN u.id > 2 THEN
+                                        CASE WHEN u.id > 3 THEN
+                                            CASE WHEN u.id > 4 THEN
+                                                CASE WHEN u.id > 5 THEN
+                                                    CASE WHEN u.id > 6 THEN
+                                                        CASE WHEN u.id > 7 THEN
+                                                            'deep'
+                                                        ELSE 'x7' END
+                                                    ELSE 'x6' END
+                                                ELSE 'x5' END
+                                            ELSE 'x4' END
+                                        ELSE 'x3' END
+                                    ELSE 'x2' END
+                                ELSE 'x1' END
+                            ELSE 'x0' END
+                        ) AS ridiculousValue
+                    FROM Doctrine\Tests\Models\CMS\CmsUser u
+                    JOIN u.articles a
+                    ORDER BY u.id
+                DQL);
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        // Queries that only select aggregate functions are pointless to paginate (because they return only 1 row)
+        // but they are still valid cases. They should always be run using the "slow but compatible" pagination queries.
+        yield 'query selects only aggregate functions' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT MAX(u.id) FROM ' . CmsUser::class . ' u');
+                $query->setMaxResults(10);
+
+                // This case isn't in fact supported even by the "compatible" queries. At least assert that the test
+                // fails for a consistent reason.
+                $testCase->expectExceptionMessageMatches('/^Not all identifier properties can be found in the ResultSetMapping:/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            1,
+        ];
+
+        // This case is the "false positive" detection of the "only aggregate functions" detection.
+        yield 'query selects only function-like expressions' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT CONCAT(\'Test: \', u.id) FROM ' . CmsUser::class . ' u');
+                $query->setMaxResults(10);
+
+                // This case isn't in fact supported even by the "compatible" queries. At least assert that the test
+                // fails for a consistent reason.
+                $testCase->expectExceptionMessageMatches('/^Not all identifier properties can be found in the ResultSetMapping:/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        // A "no ToMany" GroupBy case is a bit pointless but it's still a use case.
+        yield 'query with GroupBy, no ToMany joins, group by entity alias' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u FROM ' . CmsUser::class . ' u GROUP BY u ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by Select alias on an id column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id AS my_result FROM ' . CmsUser::class . ' u GROUP BY my_result ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by Select alias on a unique, not nullable column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.username AS my_result FROM ' . CmsUser::class . ' u GROUP BY my_result ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by Select alias on any other column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.status AS my_result, COUNT(u) FROM ' . CmsUser::class . ' u GROUP BY my_result ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            2,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by an id column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id FROM ' . CmsUser::class . ' u GROUP BY u.id ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by a unique, not nullable column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.username FROM ' . CmsUser::class . ' u GROUP BY u.username ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by any other column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.status, COUNT(u) FROM ' . CmsUser::class . ' u GROUP BY u.status ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            2,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by an id column, composite primary key, partial key grouped' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT c.companyCode, COUNT(c) FROM ' . CustomerClass::class . ' c GROUP BY c.companyCode ORDER BY c.companyCode');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            2,
+        ];
+
+        yield 'query with GroupBy, no ToMany joins, group by an id column, composite primary key, full key grouped' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT c.name FROM ' . CustomerClass::class . ' c GROUP BY c.companyCode, c.code ORDER BY c.companyCode');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            5,
+        ];
+
+        yield 'query with GroupBy, with ToMany joins, group by root id column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY u.id ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        yield 'query with GroupBy, with ToMany joins, select COUNT(ToMany), group by root id column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u.id, COUNT(a) FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY u.id ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_TRUE,
+            9,
+        ];
+
+        // Note how this cannot use the "fast" count query, because the entity has a composite primary key, for
+        // which a fast count query would need to run COUNT(DISTINCT id) (instead of COUNT(*)), which it cannot do.
+        yield 'query with GroupBy, with ToMany joins, group by root id column, composite primary key, full key grouped' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT c FROM ' . CustomerClass::class . ' c JOIN c.invoices i GROUP BY c.companyCode, c.code ORDER BY c.companyCode');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            5,
+        ];
+
+        yield 'query with GroupBy, with ToMany joins, group by ToMany column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT a.id, COUNT(u.id) FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY a.id ORDER BY a.id');
+                $query->setMaxResults(10);
+
+                // The "default" LimitSubqueryOutputWalker result subquery doesn't in fact support running this query.
+                $testCase->expectExceptionMessageMatches('/^The Paginator does not support Queries which only yield ScalarResults/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            45,
+        ];
+
+        // Note: this use case doesn't use the fast count query because it groups by an expression, and the auto-detection
+        // feature does not even attempt to find out "what the expressions do".
+        yield 'query with GroupBy, with ToMany joins, select COUNT(ToMany), group by Select expression not using ToMany columns' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT CONCAT(\'lorem ipsum: \', u.id) AS my_result, u.username, COUNT(a) FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY my_result ORDER BY my_result');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with GroupBy, with ToMany joins, group by Select expression using ToMany columns' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT CONCAT(\'lorem ipsum: \', a.id) AS my_result, COUNT(u) FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY my_result ORDER BY my_result');
+                $query->setMaxResults(10);
+
+                // The "default" LimitSubqueryOutputWalker result subquery doesn't in fact support running this query.
+                $testCase->expectExceptionMessageMatches('/^The Paginator does not support Queries which only yield ScalarResults/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            45,
+        ];
+
+        yield 'query with Having' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, COUNT(a) articles_count FROM ' . CmsUser::class . ' u JOIN u.articles a GROUP BY u.id HAVING articles_count > 2 ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            7,
+        ];
+
+        yield 'query with multiple Froms' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, a FROM ' . CmsUser::class . ' u, ' . CmsArticle::class . ' a ORDER BY u.id');
+                $query->setMaxResults(10);
+
+                // Neither CountWalker nor CountOutputWalker supports this query.
+                $testCase->expectExceptionMessageMatches('/^Cannot count query which selects two FROM components/');
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_WITH_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, no OrderBy' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.articles a');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, root entity uses a primary key that is a foreign key' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT ad, a, c FROM ' . CmsArticleAssociatedDetail::class . ' ad JOIN ad.article a JOIN a.comments c');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            5,
+        ];
+
+        yield 'query with OneToMany join, order by ToMany column' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY a.id');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, order by ToOne Select alias (expression), Select scalars only' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT CONCAT(\'Test: \', u.id) AS my_result, a.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY my_result');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_FAST,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_NO_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            45,
+        ];
+
+        yield 'query with OneToMany join, order by ToOne Select alias (expression)' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, CONCAT(\'Test: \', u.id) AS my_result, a.id FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY my_result');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, order by ToMany Select alias (expression)' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u, CONCAT(\'Test: \', a.id) AS my_result FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY my_result');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, order by ToOne expression' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY CONCAT(\'Test: \', u.id)');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_TREE_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+
+        yield 'query with OneToMany join, order by ToMany expression' => [
+            static function (self $testCase, EntityManagerInterface $em): Query {
+                $query = $em->createQuery('SELECT u FROM ' . CmsUser::class . ' u JOIN u.articles a ORDER BY CONCAT(\'Test: \', a.id)');
+                $query->setMaxResults(10);
+
+                return $query;
+            },
+            self::RESULT_QUERY_WITH_SUBQUERY_OUTPUT_WALKER,
+            self::COUNT_QUERY_FAST,
+            self::COUNT_QUERY_FAST_WITH_DISTINCT,
+            self::COUNT_QUERY_FAST_SHOULD_DROP_GROUP_BY_FALSE,
+            9,
+        ];
+    }
+
+    private function populate(): void
+    {
+        /** @var CmsUser[] $users */
+        $users = [];
+        for ($i = 0; $i < 9; $i++) {
+            $user           = new CmsUser();
+            $user->name     = 'User' . $i;
+            $user->username = 'user' . $i;
+            $user->status   = $i % 2 ? 'active' : 'inactive';
+            $this->_em->persist($user);
+
+            // Create "$i + 1" articles for each user.
+            for ($j = 0; $j < $i + 1; $j++) {
+                $article        = new CmsArticle();
+                $article->topic = 'topic' . $i . $j;
+                $article->text  = 'text' . $i . $j;
+                $article->setAuthor($user);
+                $article->version = 0;
+
+                // Add an associated detail.
+                if ($j === 0) {
+                    $articleAssociatedDetail          = new CmsArticleAssociatedDetail();
+                    $articleAssociatedDetail->article = $article;
+                    $articleAssociatedDetail->detail  = 'big detail ' . $i . ',' . $j;
+                    $this->_em->persist($articleAssociatedDetail);
+                }
+
+                // Add some comments to the first article of each user beyond user #3.
+                if ($j === 0 && $i > 3) {
+                    $comment        = new CmsComment();
+                    $comment->topic = 'topic' . $i . $j;
+                    $comment->text  = 'text' . $i . $j;
+                    $comment->setAuthor($users[$i % 3]);
+                    $comment->setArticle($article);
+                    $this->_em->persist($comment);
+
+                    $comment        = new CmsComment();
+                    $comment->topic = 'topic' . $i . $j;
+                    $comment->text  = 'text, reply' . $i . $j;
+                    $comment->setAuthor($users[($i + 1) % 3]);
+                    $comment->setArticle($article);
+                    $this->_em->persist($comment);
+                }
+
+                $this->_em->persist($article);
+            }
+
+            $address          = new CmsAddress();
+            $address->country = 'Country';
+            $address->zip     = 'CNTR';
+            $address->city    = 'City' . $i;
+            $address->setUser($user);
+            $this->_em->persist($address);
+
+            $users[] = $user;
+        }
+
+        // Composite identifier test records
+        for ($i = 0; $i < 5; $i++) {
+            $customer              = new CustomerClass();
+            $customer->companyCode = $i % 2 ? 'ACME USA' : 'ACME LATAM';
+            $customer->code        = 'user' . $i;
+            $customer->name        = 'User ' . $i;
+            $this->_em->persist($customer);
+
+            // Create "$i + 1" invoices for each customer.
+            for ($j = 0; $j < $i + 1; $j++) {
+                $invoice                = new InvoiceClass();
+                $invoice->companyCode   = $customer->companyCode;
+                $invoice->customerCode  = $customer->code;
+                $invoice->invoiceNumber = 'invoice' . $i . '|' . $j;
+                $invoice->customer      = $customer;
+
+                $this->_em->persist($invoice);
+            }
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}

--- a/tests/Tests/OrmFunctionalTestCase.php
+++ b/tests/Tests/OrmFunctionalTestCase.php
@@ -55,6 +55,7 @@ use Doctrine\Tests\Models\Cache\TravelerProfile;
 use Doctrine\Tests\Models\Cache\TravelerProfileInfo;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsArticleAssociatedDetail;
 use Doctrine\Tests\Models\CMS\CmsComment;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsGroup;
@@ -269,6 +270,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             CmsGroup::class,
             CmsTag::class,
             CmsArticle::class,
+            CmsArticleAssociatedDetail::class,
             CmsComment::class,
         ],
         'company' => [
@@ -557,6 +559,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM cms_addresses');
             $conn->executeStatement('DELETE FROM cms_phonenumbers');
             $conn->executeStatement('DELETE FROM cms_comments');
+            $conn->executeStatement('DELETE FROM cms_article_associated_details');
             $conn->executeStatement('DELETE FROM cms_articles');
             $conn->executeStatement('DELETE FROM cms_users');
             $conn->executeStatement('DELETE FROM cms_emails');
@@ -658,6 +661,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeStatement('DELETE FROM JoinedChildClass');
             $conn->executeStatement('DELETE FROM JoinedRootClass');
             $conn->executeStatement('DELETE FROM SingleRootClass');
+        }
+
+        if (isset($this->_usedModelSets['compositekeyrelations'])) {
+            $conn->executeStatement('DELETE FROM InvoiceClass');
+            $conn->executeStatement('DELETE FROM CustomerClass');
         }
 
         if (isset($this->_usedModelSets['taxi'])) {


### PR DESCRIPTION
This PR is a follow-up from the following closed/abandoned PR: https://github.com/doctrine/orm/pull/11595. It now targets the `3.7.x` git branch, and addresses all the comments from that past PR (apart from "please update the docs", which is explained further below).

To recap: this PR attempts to "action" the following ticket: https://github.com/doctrine/orm/issues/8278.

In particular: it implements all the use cases that stof mentioned.

I would like to get a "code sign-off" before I go and update the docs about the Paginator. In particular, I would like to get a "looks good" from stof, and greg0ire (or any other ORM maintainer).

Things that might need further discussion:

1. The "auto-detection" code spans 3 static functions in the `PaginatorQuery` trait, and takes over 600 lines. It's about 70% of the `PaginatorQuery` source file. If preferred, I can extract that code to another class.

2. In `PaginatorQuery::searchEntityAliasesUsageInASTNode()`, php reflection is used to "walk" AST expressions, in search for specific "entity aliases usage" (namely: whether ToMany JOIN aliases are used anywhere within those expressions). The function recursively lists all public properties of `AST\Node` classes, and seeks for instances of `Query\AST\PathExpression`. I believe that the only "contestable" fact here is that php reflection is used. I would however say that the code makes 0 assumptions about the reflected classes, making it quite "safe" to run in this context.

3. I'd like to note that the "auto-detection" treats the result/count "output walkers" (i.e. the current default "code execution path") as the "fallback" if anything during the auto-detection procedure "looks strange". In particular, the auto-detection does NOT attempt to ascertain whether the output walkers can be run. I personally consider this alright.

4. Stof, what follows from the point above, is that the code does NOT check whether the `LimitSubqueryOutputWalker.php` can be run (despite your listing (in one of your past comments) the conditions under which that output walker cannot be run). Again: I consider this acceptable but let me know if you have any further comments here.

5. A new query hint was added: `CountWalker::HINT_DROP_GROUP_BY_CLAUSE`. It's needed to handle a few "GROUP BY" cases in the CountWalker. I "docblock'd" that hint as `@internal` because I believe that there are already too many query hints in the Paginator. But if it should be "opened to the public", then this can be discussed further.

6. The auto-detection does not allow to run queries with `GROUP BY` by the CountWalker (beside a few exceptions).

7. Less obvious fact: the `CountWalker.php` supports root entities with composite primary keys, but only if the `COUNT(*)` branch in its code is executed (as opposed to the `COUNT(DISTINCT id)` code branch).

8. Less obvious fact: Paginator currently supports root entities with composite primary keys, only if the "fast result query" is run.

9. I created the following directory: `src/Tools/Pagination/ValueObject`. Note that there already exists the following dir: `tests/Tests/Models/ValueObjects` (i.e. in plural). I generally don't use plurals in namespaces (or class names). If however naming consistency is desired, I can rename that directory to: `src/Tools/Pagination/ValueObjects`. 

10. Stof, just a quick note that I ensured that all the cases that you listed in the following past comment, are implemented / checked for:
> Counting queries
> 
>- all counting queries are incompatible with queries selecting multiple entities in the FROM (so the Paginator is actually incompatible with them).
>- the fast counting query (tree-walker one) is incompatible with entities using a composite primary key
>- the fast counting query is incompatible with queries using a HAVING clause
>- the fast counting query is compatible with toMany joins when using CountWalker::HINT_DISTINCT as it will count distinct values (compatibility with GROUP BY clause is probably partial in the case of toMany join as I think it breaks if one entity can end up in multiple groups due to including a field of the toMany relation in the grouping). This is the reason why the Paginator sets this hint by default.
>- the fast counting query is not compatible with toMany joins without CountWalker::HINT_DISTINCT (but this can go even faster for compatible queries)
>
>Result fetching
>- the fast result fetching query (using a limit on the original query without changing it) is:
>    - compatible with queries not using toMany joins
>    - compatible with queries using toMany joins and GROUP BY when no fields from the grouping condition is dependant on the ToMany join (i.e. is part of the joined entity or of other entities joined again from that one)
>    - incompatible with queries selecting data from toMany joins
>    - compatible with queries doing toMany joins without selecting data from it (i.e. using it only for filtering in the WHERE clause or for aggregate functions) if the query does a SELECT DISTINCT
>- the tree-walker fetching query does not support entities using a relation as primary key
>- the tree walker fetching query does not support queries using a field from a toMany relation in its ORDER BY clause when using a limit (queries without a limit always use the fast result fetching query anyway)
>
>NOTE: I DID NOT IMPLEMENT THE FOLLOWING, as mentioned in point 4.
>
>- walker-based fetching queries do not support entities using a composite primary key
>- walker-based fetching queries do not support queries selecting multiple entities in the FROM

12. The code is heavily inline-docblocked. This is how I usually write code but I recognise that there are "other schools of thought" in this matter. I'm fine to drop some of the comments if needed, but please tell me which.

13. In `PaginatorAutoDetectionTest.php`, there are test cases that assert an exception being thrown. There are also a few cases which produce a result that I personally did not expect (but those results are what the already released code already does). Please take note of those uses cases and let me know if they are "not acceptable".

Thank you.

cc @stof 

---

Please note that phpstan is failing (at least on my local machine) for reasons that are not related to the code in this PR.