### PR TITLE
Change return type of getReflectionClass to ReflectionClass

### DIFF
--- a/src/Mapping/GetReflectionClassImplementation.php
+++ b/src/Mapping/GetReflectionClassImplementation.php
@@ -25,7 +25,7 @@ if (! class_exists(StaticReflectionService::class)) {
          *
          * Can return null when using static reflection, in violation of the LSP
          */
-        public function getReflectionClass(): ReflectionClass|null
+        public function getReflectionClass(): ReflectionClass
         {
             return $this->reflClass;
         }


### PR DESCRIPTION
Updated the return type of getReflectionClass method to ensure it always returns a ReflectionClass instance. should fix: PHP Fatal error:  Declaration of Doctrine\ORM\Mapping\ClassMetadata::getReflectionClass(): ?ReflectionClass must be compatible with Doctrine\Persistence\Mapping\ClassMetadata::getReflectionClass(): ReflectionClass in /Application/vendor/doctrine/orm/src/Mapping/GetReflectionClassImplementation.php on line 28

(both traits should have the same signature of a required ReflectionClass according to the latest version 4.2)
