### PR TITLE
Add support for selectable columns

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -256,6 +256,7 @@
     <xs:attribute name="index" type="xs:boolean" default="false" />
     <xs:attribute name="insertable" type="xs:boolean" default="true" />
     <xs:attribute name="updatable" type="xs:boolean" default="true" />
+    <xs:attribute name="selectable" type="xs:boolean" default="true" />
     <xs:attribute name="generated" type="orm:generated-type" default="NEVER" />
     <xs:attribute name="enum-type" type="xs:string" />
     <xs:attribute name="version" type="xs:boolean" />
@@ -590,6 +591,7 @@
     <xs:attribute name="nullable" type="xs:boolean" default="false" />
     <xs:attribute name="insertable" type="xs:boolean" default="true" />
     <xs:attribute name="updateable" type="xs:boolean" default="true" />
+    <xs:attribute name="selectable" type="xs:boolean" default="true" />
     <xs:attribute name="version" type="xs:boolean" />
     <xs:attribute name="column-definition" type="xs:string" />
     <xs:attribute name="precision" type="xs:integer" use="optional" />

--- a/src/Mapping/Column.php
+++ b/src/Mapping/Column.php
@@ -32,6 +32,7 @@ final class Column implements MappingAttribute
         public readonly string|null $columnDefinition = null,
         public readonly string|null $generated = null,
         public readonly bool $index = false,
+        public readonly bool $selectable = true,
     ) {
     }
 }

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -765,6 +765,10 @@ class AttributeDriver implements MappingDriver
             $mapping['enumType'] = $column->enumType;
         }
 
+        if ($column->selectable === false) {
+            $mapping['selectable'] = false;
+        }
+
         return $mapping;
     }
 }

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -858,6 +858,10 @@ class XmlDriver extends FileDriver
             $mapping['enumType'] = (string) $fieldMapping['enum-type'];
         }
 
+        if (isset($fieldMapping['selectable']) && ! $this->evaluateBoolean($fieldMapping['selectable'])) {
+            $mapping['selectable'] = false;
+        }
+
         if (isset($fieldMapping->options)) {
             $mapping['options'] = $this->parseOptions($fieldMapping->options->children());
         }

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -25,6 +25,7 @@ final class FieldMapping implements ArrayAccess
     public bool|null $nullable           = null;
     public bool|null $notInsertable      = null;
     public bool|null $notUpdatable       = null;
+    public bool|null $selectable         = null;
     public string|null $columnDefinition = null;
     /** @phpstan-var ClassMetadata::GENERATED_*|null */
     public int|null $generated = null;
@@ -100,6 +101,7 @@ final class FieldMapping implements ArrayAccess
      *     index?: bool|null,
      *     notInsertable?: bool|null,
      *     notUpdatable?: bool|null,
+     *     selectable?: bool|null,
      *     columnDefinition?: string|null,
      *     generated?: ClassMetadata::GENERATED_*|null,
      *     enumType?: string|null,
@@ -163,6 +165,7 @@ final class FieldMapping implements ArrayAccess
                 'declaredField',
                 'options',
                 'default',
+                'selectable',
             ] as $key
         ) {
             if ($this->$key !== null) {

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -1265,6 +1265,10 @@ class BasicEntityPersister implements EntityPersister
 
         // Add regular columns to select list
         foreach ($this->class->fieldNames as $field) {
+            $fieldMapping = $this->class->fieldMappings[$field];
+            if ($fieldMapping->selectable === false) {
+                continue;
+            }
             $columnList[] = $this->getSelectColumnSQL($field, $this->class);
         }
 

--- a/src/Persisters/Entity/JoinedSubclassPersister.php
+++ b/src/Persisters/Entity/JoinedSubclassPersister.php
@@ -382,6 +382,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // Add regular columns
         foreach ($this->class->fieldMappings as $fieldName => $mapping) {
+            if ($mapping->selectable === false) {
+                continue;
+            }
             $class = isset($mapping->inherited)
                 ? $this->em->getClassMetadata($mapping->inherited)
                 : $this->class;
@@ -426,6 +429,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             // Add subclass columns
             foreach ($subClass->fieldMappings as $fieldName => $mapping) {
                 if (isset($mapping->inherited)) {
+                    continue;
+                }
+
+                if ($mapping->selectable === false) {
                     continue;
                 }
 
@@ -532,6 +539,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     ? $this->em->getClassMetadata($column->inherited)
                     : $this->class;
             } else {
+                continue;
+            }
+
+            if ($column->selectable === false) {
                 continue;
             }
 

--- a/src/Persisters/Entity/SingleTablePersister.php
+++ b/src/Persisters/Entity/SingleTablePersister.php
@@ -66,6 +66,10 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
                     continue;
                 }
 
+                if ($mapping->selectable === false) {
+                    continue;
+                }
+
                 $columnList[] = $this->getSelectColumnSQL($fieldName, $subClass);
             }
 

--- a/tests/Tests/Models/Upsertable/Selectable.php
+++ b/tests/Tests/Models/Upsertable/Selectable.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Upsertable;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'selectable_column')]
+class Selectable
+{
+    /** @var int */
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public $id;
+
+    /** @var string */
+    #[Column(name: 'non_selectable_content', type: 'string', length: 255, selectable: false)]
+    public $nonSelectableContent;
+
+    /** @var string */
+    #[Column(type: 'string', length: 255, selectable: true)]
+    public $selectableContent;
+
+    public static function loadMetadata(ClassMetadata $metadata): ClassMetadata
+    {
+        $metadata->setPrimaryTable(
+            ['name' => 'selectable_column'],
+        );
+
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+            ],
+        );
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+        $metadata->mapField(
+            [
+                'fieldName' => 'nonSelectableContent',
+                'selectable' => false,
+            ],
+        );
+        $metadata->mapField(
+            ['fieldName' => 'selectableContent'],
+        );
+
+        return $metadata;
+    }
+}

--- a/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
+++ b/tests/Tests/ORM/Mapping/MappingDriverTestCase.php
@@ -62,6 +62,7 @@ use Doctrine\Tests\Models\TypedProperties\UserTyped;
 use Doctrine\Tests\Models\TypedProperties\UserTypedWithCustomTypedField;
 use Doctrine\Tests\Models\Upsertable\Insertable;
 use Doctrine\Tests\Models\Upsertable\Updatable;
+use Doctrine\Tests\Models\Upsertable\Selectable;
 use Doctrine\Tests\ORM\Mapping\NamingStrategy\CustomPascalNamingStrategy;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\Depends;
@@ -941,6 +942,16 @@ abstract class MappingDriverTestCase extends OrmTestCase
 
         self::assertSame(ClassMetadata::GENERATED_ALWAYS, $mapping->generated);
         self::assertNull($metadata->getFieldMapping('updatableContent')->notUpdatable);
+    }
+
+    public function testSelectableColumn(): void
+    {
+        $metadata = $this->createClassMetadata(Selectable::class);
+
+        $mapping = $metadata->getFieldMapping('nonSelectableContent');
+
+        self::assertFalse($mapping->selectable);
+        self::assertNull($metadata->getFieldMapping('selectableContent')->selectable);
     }
 
     public function testEnumType(): void

--- a/tests/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Selectable.php
+++ b/tests/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Upsertable.Selectable.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+$metadata->setPrimaryTable(
+    ['name' => 'selectable_column'],
+);
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+    ],
+);
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+
+$metadata->mapField(
+    [
+        'fieldName' => 'nonSelectableContent',
+        'selectable' => false,
+    ],
+);
+$metadata->mapField(
+    ['fieldName' => 'selectableContent'],
+);

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Upsertable.Selectable.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Upsertable.Selectable.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Upsertable\Selectable" table="selectable_column">
+        <id name="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="nonSelectableContent" column="non_selectable_content" selectable="false" type="string" />
+        <field name="selectableContent" selectable="true" type="string" />
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
https://github.com/doctrine/orm/issues/6669

Like `insertable` and `updatable` add support for `selectable` column.

---

My use case: zero-downtime deployment

To ensure a zero-downtime deployment when removing a column, we need to ensure that the previous version of the code stops reading that column.
- Phase 1: Set selectable, insertable, and updatable to false, then deploy the code.
- Phase 2: Remove the property from the entity mapping and drop the column from the database (using Doctrine migrations, for example).