### PR TITLE
Fixes #7039 paginator count with instance of return 0

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -410,12 +410,16 @@ class Query extends AbstractQuery
         $originalValue = $parameter->getValue();
         $value         = $originalValue;
         $rsm           = $this->getResultSetMapping();
+        $parsedRsm     = $this->parserResult->getResultSetMapping();
 
         if ($value instanceof ClassMetadata && isset($rsm->metadataParameterMapping[$key])) {
             $value = $value->getMetadataValue($rsm->metadataParameterMapping[$key]);
         }
 
-        if ($value instanceof ClassMetadata && isset($rsm->discriminatorParameters[$key])) {
+        if (
+            $value instanceof ClassMetadata
+            && (isset($parsedRsm->discriminatorParameters[$key]) || isset($rsm->discriminatorParameters[$key]))
+        ) {
             $value = array_keys(HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($value, $this->em));
         }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH7039Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH7039Test.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTime;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\Models\Company\CompanyManager;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function iterator_to_array;
+
+final class GH7039Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('company');
+
+        parent::setUp();
+
+        $employee = new CompanyEmployee();
+        $employee->setName('emp');
+        $employee->setSalary(1000);
+        $employee->setDepartment('IT');
+        $employee->setStartDate(new DateTime());
+
+        $manager = new CompanyManager();
+        $manager->setName('mgr');
+        $manager->setSalary(2000);
+        $manager->setDepartment('IT');
+        $manager->setStartDate(new DateTime());
+        $manager->setTitle('boss');
+
+        $this->_em->persist($employee);
+        $this->_em->persist($manager);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testCountWithInstanceOfParameterDefaultWalkers(): void
+    {
+        $query = $this->_em->createQuery(
+            'SELECT p FROM Doctrine\Tests\Models\Company\CompanyEmployee p WHERE p INSTANCE OF :type',
+        );
+        $query->setParameter('type', $this->_em->getClassMetadata(CompanyManager::class));
+        $query->setMaxResults(10);
+
+        $paginator = new Paginator($query, true);
+
+        $items = iterator_to_array($paginator->getIterator());
+        self::assertCount(1, $items, 'iteration should find the manager');
+
+        self::assertSame(1, $paginator->count(), 'count() should also find the manager');
+    }
+
+    public function testCountWithInstanceOfParameterTreeWalkers(): void
+    {
+        $query = $this->_em->createQuery(
+            'SELECT p FROM Doctrine\Tests\Models\Company\CompanyEmployee p WHERE p INSTANCE OF :type',
+        );
+        $query->setParameter('type', $this->_em->getClassMetadata(CompanyManager::class));
+        $query->setMaxResults(10);
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+
+        self::assertSame(1, $paginator->count(), 'count() with tree walkers');
+    }
+}


### PR DESCRIPTION
### Fix Paginator count with INSTANCE OF parameter return 0
[Fixes #7039](https://github.com/doctrine/orm/issues/7039)
When a custom ResultSetMapping is set on a query, as the Paginator does for its count query, discriminator parameters recorded by the SqlWalker in the parsed RSM were ignored
A ClassMetadata bound to an INSTANCE OF expression was bound as its FQCN instead of the discriminator values, so the count was always 0.
This PR resolve discriminator parameters against the parser result's RSM, which is always populated once the query has been parsed.

I added ` $parsedRsm     = $this->parserResult->getResultSetMapping();` in Query:resolveParameterValue()  and updated the conditions on discriminatorParameters to use parsedRsm by default.
I added a test 7039 as asked by contribution guidline