### PR TITLE
[Encryption] Add transparent field encryption, with queryable capability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "suggest": {
         "ext-deepclone": "Improves performance when not using native lazy objects (Symfony 8.1+)",
         "ext-dom": "Provides support for XSD validation for XML mapping files",
+        "ext-openssl": "Allow to use the built-in OpenSSLCipher for encryption",
         "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2035,8 +2035,26 @@ parameters:
 			path: src/Persisters/Entity/BasicEntityPersister.php
 
 		-
+			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandCriteriaParameters\(\) should return array\{list\<mixed\>, list\<Doctrine\\DBAL\\ArrayParameterType\:\:ASCII\|Doctrine\\DBAL\\ArrayParameterType\:\:BINARY\|Doctrine\\DBAL\\ArrayParameterType\:\:INTEGER\|Doctrine\\DBAL\\ArrayParameterType\:\:STRING\|Doctrine\\DBAL\\ParameterType\:\:ASCII\|Doctrine\\DBAL\\ParameterType\:\:BINARY\|Doctrine\\DBAL\\ParameterType\:\:BOOLEAN\|Doctrine\\DBAL\\ParameterType\:\:INTEGER\|Doctrine\\DBAL\\ParameterType\:\:LARGE_OBJECT\|Doctrine\\DBAL\\ParameterType\:\:NULL\|Doctrine\\DBAL\\ParameterType\:\:STRING\|string\>\} but returns array\{array\<mixed\>, array\<mixed\>\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Persisters/Entity/BasicEntityPersister.php
+
+		-
+			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandParameters\(\) should return array\{list\<mixed\>, list\<Doctrine\\DBAL\\ArrayParameterType\:\:ASCII\|Doctrine\\DBAL\\ArrayParameterType\:\:BINARY\|Doctrine\\DBAL\\ArrayParameterType\:\:INTEGER\|Doctrine\\DBAL\\ArrayParameterType\:\:STRING\|Doctrine\\DBAL\\ParameterType\:\:ASCII\|Doctrine\\DBAL\\ParameterType\:\:BINARY\|Doctrine\\DBAL\\ParameterType\:\:BOOLEAN\|Doctrine\\DBAL\\ParameterType\:\:INTEGER\|Doctrine\\DBAL\\ParameterType\:\:LARGE_OBJECT\|Doctrine\\DBAL\\ParameterType\:\:NULL\|Doctrine\\DBAL\\ParameterType\:\:STRING\|string\>\} but returns array\{array\<mixed\>, array\<mixed\>\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Persisters/Entity/BasicEntityPersister.php
+
+		-
 			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandToManyParameters\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
+			count: 1
+			path: src/Persisters/Entity/BasicEntityPersister.php
+
+		-
+			message: '#^Method Doctrine\\ORM\\Persisters\\Entity\\BasicEntityPersister\:\:expandToManyParameters\(\) should return array\{array, list\<Doctrine\\DBAL\\ArrayParameterType\:\:ASCII\|Doctrine\\DBAL\\ArrayParameterType\:\:BINARY\|Doctrine\\DBAL\\ArrayParameterType\:\:INTEGER\|Doctrine\\DBAL\\ArrayParameterType\:\:STRING\|Doctrine\\DBAL\\ParameterType\:\:ASCII\|Doctrine\\DBAL\\ParameterType\:\:BINARY\|Doctrine\\DBAL\\ParameterType\:\:BOOLEAN\|Doctrine\\DBAL\\ParameterType\:\:INTEGER\|Doctrine\\DBAL\\ParameterType\:\:LARGE_OBJECT\|Doctrine\\DBAL\\ParameterType\:\:NULL\|Doctrine\\DBAL\\ParameterType\:\:STRING\|string\>\} but returns array\{array\<mixed\>, array\<mixed\>\}\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Persisters/Entity/BasicEntityPersister.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -925,7 +925,7 @@ parameters:
 			path: src/Mapping/Builder/ClassMetadataBuilder.php
 
 		-
-			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string\}, array\<mixed\> given\.$#'
+			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string, encrypt\?\: array\<string, mixed\>\|null\}, array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/Builder/EmbeddedBuilder.php
@@ -985,7 +985,7 @@ parameters:
 			path: src/Mapping/ClassMetadata.php
 
 		-
-			message: '#^Parameter \#1 \$mappingArray of static method Doctrine\\ORM\\Mapping\\EmbeddedClassMapping\:\:fromMappingArray\(\) expects array\{class\: class\-string, columnPrefix\?\: string\|false\|null, declaredField\?\: string\|null, originalField\?\: string\|null, inherited\?\: class\-string\|null, declared\?\: class\-string\|null\}, array\{class\: string, columnPrefix\: string\|false\|null, declaredField\: string\|null, originalField\: string\|null\} given\.$#'
+			message: '#^Parameter \#1 \$mappingArray of static method Doctrine\\ORM\\Mapping\\EmbeddedClassMapping\:\:fromMappingArray\(\) expects array\{class\: class\-string, columnPrefix\?\: string\|false\|null, declaredField\?\: string\|null, originalField\?\: string\|null, inherited\?\: class\-string\|null, declared\?\: class\-string\|null, encrypt\?\: array\<string, mixed\>\|null\}, array\{class\: string, columnPrefix\: string\|false\|null, declaredField\: string\|null, originalField\: string\|null, encrypt\: array\<string, mixed\>\|null\} given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/ClassMetadata.php
@@ -1309,7 +1309,7 @@ parameters:
 			path: src/Mapping/Driver/AttributeDriver.php
 
 		-
-			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string\}, array\{fieldName\: string, cache\?\: array\{usage\: int, region\: string\|null\}, class\: string\|null, columnPrefix\: bool\|string\|null\} given\.$#'
+			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string, encrypt\?\: array\<string, mixed\>\|null\}, array\{fieldName\: string, cache\?\: array\{usage\: int, region\: string\|null\}, class\: string\|null, columnPrefix\: bool\|string\|null, encrypt\?\: array\{cipher\: string\|null, keyProvider\: string\|null, queryType\: Doctrine\\ORM\\Encrypt\\EncryptQuery\|null\}\} given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/Driver/AttributeDriver.php
@@ -1447,7 +1447,7 @@ parameters:
 			path: src/Mapping/Driver/XmlDriver.php
 
 		-
-			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string\}, array\{fieldName\: string, class\: string\|null, columnPrefix\: string\|false\|null\} given\.$#'
+			message: '#^Parameter \#1 \$mapping of method Doctrine\\ORM\\Mapping\\ClassMetadata\<T of object\>\:\:mapEmbedded\(\) expects array\{fieldName\: string, class\?\: class\-string, declaredField\?\: string, columnPrefix\?\: string\|false\|null, originalField\?\: string, encrypt\?\: array\<string, mixed\>\|null\}, array\{fieldName\: string, class\: string\|null, columnPrefix\: string\|false\|null\} given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/Driver/XmlDriver.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2395,12 +2395,6 @@ parameters:
 			path: src/Query.php
 
 		-
-			message: '#^Parameter \#2 \$sqlParams of method Doctrine\\ORM\\Query\:\:evictResultSetCache\(\) expects array\<string, mixed\>, list\<mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Query.php
-
-		-
 			message: '#^Property Doctrine\\ORM\\Query\\AST\\Functions\\BitAndFunction\:\:\$firstArithmetic \(Doctrine\\ORM\\Query\\AST\\Node\) does not accept Doctrine\\ORM\\Query\\AST\\Node\|string\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -7,6 +7,8 @@ namespace Doctrine\ORM;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\CacheConfiguration;
+use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
+use Doctrine\ORM\Encrypt\KMS\KeyProviderRegistry;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -722,5 +724,37 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function getEagerFetchBatchSize(): int
     {
         return $this->attributes['fetchModeSubselectBatchSize'] ?? 100;
+    }
+
+    /**
+     * Sets the CipherRegistry used to resolve ciphers for encryption.
+     */
+    public function setCipherRegistry(CipherRegistry|null $cipherRegistry): void
+    {
+        $this->attributes['cipherRegistry'] = $cipherRegistry;
+    }
+
+    /**
+     * Gets the CipherRegistry used to resolve ciphers for encryption.
+     */
+    public function getCipherRegistry(): CipherRegistry|null
+    {
+        return $this->attributes['cipherRegistry'] ?? null;
+    }
+
+    /**
+     * Sets the KeyProviderRegistry used to resolve key providers for #[Encrypt] mappings.
+     */
+    public function setKeyProviderRegistry(KeyProviderRegistry|null $keyProviderRegistry): void
+    {
+        $this->attributes['keyProviderRegistry'] = $keyProviderRegistry;
+    }
+
+    /**
+     * Gets the KeyProviderRegistry used to resolve key providers for #[Encrypt] mappings.
+     */
+    public function getKeyProviderRegistry(): KeyProviderRegistry|null
+    {
+        return $this->attributes['keyProviderRegistry'] ?? null;
     }
 }

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
@@ -150,6 +151,11 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     public function getProxyFactory(): ProxyFactory
     {
         return $this->wrapped->getProxyFactory();
+    }
+
+    public function getEncryptHelper(): EncryptHelper
+    {
+        return $this->wrapped->getEncryptHelper();
     }
 
     public function getFilters(): FilterCollection

--- a/src/Encrypt/Cipher/AbstractCipherRegistry.php
+++ b/src/Encrypt/Cipher/AbstractCipherRegistry.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\UnknownCipher;
+
+use function array_keys;
+
+abstract class AbstractCipherRegistry implements CipherRegistry
+{
+    /** @param array<string, string> $cipherServices cipher name => service id */
+    public function __construct(
+        private readonly array $cipherServices,
+        private readonly string $defaultCipherName,
+    ) {
+        if (! isset($this->cipherServices[$this->defaultCipherName])) {
+            throw UnknownCipher::create($this->defaultCipherName, $this->getCipherNames());
+        }
+    }
+
+    /**
+     * Fetches/creates the given Cipher service.
+     *
+     * @param string $name The name of the service.
+     */
+    abstract protected function getService(string $name): Cipher;
+
+    public function getDefaultCipherName(): string
+    {
+        return $this->defaultCipherName;
+    }
+
+    final public function getCipher(string|null $name = null): Cipher
+    {
+        $name ??= $this->defaultCipherName;
+
+        if (! isset($this->cipherServices[$name])) {
+            throw UnknownCipher::create($name, $this->getCipherNames());
+        }
+
+        return $this->getService($this->cipherServices[$name]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCiphers(): array
+    {
+        $ciphers = [];
+
+        foreach (array_keys($this->cipherServices) as $name) {
+            $ciphers[$name] = $this->getCipher($name);
+        }
+
+        return $ciphers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCipherNames(): array
+    {
+        return array_keys($this->cipherServices);
+    }
+}

--- a/src/Encrypt/Cipher/BatchableCipher.php
+++ b/src/Encrypt/Cipher/BatchableCipher.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\DecryptionFailed;
+use Doctrine\ORM\Encrypt\Cipher\Exception\EncryptionFailed;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use SensitiveParameter;
+
+/**
+ * Cipher can implement this interface to handle batch encrypt/decrypt.
+ * The ORM will use it preferably, if your Cipher implement it.
+ * Useful when using remote Cipher service.
+ */
+interface BatchableCipher extends Cipher
+{
+    /**
+     * Encrypts many values in one call. The returned array MUST preserve the input keys.
+     * Every value MUST be a non-null string.
+     *
+     * @param array<array-key, string> $plaintexts
+     *
+     * @return array<array-key, string>
+     *
+     * @throws EncryptionFailed
+     */
+    public function encryptMany(
+        #[SensitiveParameter]
+        array $plaintexts,
+        KeyProvider $keyProvider,
+    ): array;
+
+    /**
+     * Decrypts many values in one call. The returned array MUST preserve the input keys.
+     *
+     * @param array<array-key, string> $ciphertexts
+     *
+     * @return array<array-key, string>
+     *
+     * @throws DecryptionFailed
+     */
+    public function decryptMany(
+        #[SensitiveParameter]
+        array $ciphertexts,
+        KeyProvider $keyProvider,
+    ): array;
+}

--- a/src/Encrypt/Cipher/Cipher.php
+++ b/src/Encrypt/Cipher/Cipher.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\DecryptionFailed;
+use Doctrine\ORM\Encrypt\Cipher\Exception\EncryptionFailed;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use SensitiveParameter;
+
+/**
+ * Implement this interface to create a service that handle encrypt/decrypt of a value.
+ * IMPORTANT: ciphertext (envelope) MUST embed key's id.
+ */
+interface Cipher
+{
+    /**
+     * Encrypts a plaintext string into a self-describing ciphertext (envelope): MUST embed key's id.
+     *
+     * @throws EncryptionFailed
+     */
+    public function encrypt(
+        #[SensitiveParameter]
+        string $plaintext,
+        KeyProvider $keyProvider,
+    ): string;
+
+    /**
+     * Decrypts an envelope produced by encrypt(), return plaintext.
+     *
+     * @throws DecryptionFailed on wrong key / tampered data / malformed input.
+     */
+    public function decrypt(
+        #[SensitiveParameter]
+        string $envelope,
+        KeyProvider $keyProvider,
+    ): string;
+
+    /**
+     * Extracts the key id embedded in an envelope produced by encrypt(), without decrypting it.
+     *
+     * @throws DecryptionFailed on malformed input.
+     */
+    public function extractKeyId(
+        #[SensitiveParameter]
+        string $envelope,
+    ): int|string;
+
+    /**
+     * TRUE when the same (plaintext, key) pair always yields the identical ciphertext.
+     */
+    public function isDeterministic(): bool;
+
+    /**
+     * TRUE when encrypt() returns raw binary bytes (suitable for a blob column).
+     * FALSE when it returns printable text (safe for a text column).
+     */
+    public function isBinary(): bool;
+}

--- a/src/Encrypt/Cipher/CipherRegistry.php
+++ b/src/Encrypt/Cipher/CipherRegistry.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\UnknownCipher;
+
+interface CipherRegistry
+{
+    public function getDefaultCipherName(): string;
+
+    /**
+     * @param string|null $name null resolves to the default cipher
+     *
+     * @throws UnknownCipher when $name is not registered.
+     */
+    public function getCipher(string|null $name = null): Cipher;
+
+    /**
+     * Get all Ciphers in this registry.
+     *
+     * @return array<string, Cipher> indexed by cipher name
+     */
+    public function getCiphers(): array;
+
+    /** @return list<string> */
+    public function getCipherNames(): array;
+}

--- a/src/Encrypt/Cipher/Exception/DecryptionFailed.php
+++ b/src/Encrypt/Cipher/Exception/DecryptionFailed.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use RuntimeException;
+
+use function sprintf;
+
+final class DecryptionFailed extends RuntimeException implements ORMException
+{
+    public static function create(string $message): self
+    {
+        return new self(sprintf('Decryption failed: %s', $message));
+    }
+
+    public static function envelopTooShort(): self
+    {
+        return new self('Invalid ciphertext envelope: value is shorter than the minimum envelope size.');
+    }
+}

--- a/src/Encrypt/Cipher/Exception/EncryptionFailed.php
+++ b/src/Encrypt/Cipher/Exception/EncryptionFailed.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use RuntimeException;
+
+use function sprintf;
+
+final class EncryptionFailed extends RuntimeException implements ORMException
+{
+    public static function create(string $message): self
+    {
+        return new self(sprintf('Encryption failed: %s', $message));
+    }
+}

--- a/src/Encrypt/Cipher/Exception/UnknownCipher.php
+++ b/src/Encrypt/Cipher/Exception/UnknownCipher.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use InvalidArgumentException;
+
+use function implode;
+use function sprintf;
+
+final class UnknownCipher extends InvalidArgumentException implements ORMException
+{
+    /** @param list<string> $knownNames */
+    public static function create(string $name, array $knownNames): self
+    {
+        return new self(sprintf(
+            'Unknown cipher "%s". Known ciphers: "%s".',
+            $name,
+            implode('", "', $knownNames),
+        ));
+    }
+}

--- a/src/Encrypt/Cipher/OpenSSLCipher.php
+++ b/src/Encrypt/Cipher/OpenSSLCipher.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\DecryptionFailed;
+use Doctrine\ORM\Encrypt\Cipher\Exception\EncryptionFailed;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use LogicException;
+use SensitiveParameter;
+
+use function array_keys;
+use function chr;
+use function hash_hmac;
+use function implode;
+use function openssl_cipher_iv_length;
+use function openssl_decrypt;
+use function openssl_encrypt;
+use function openssl_error_string;
+use function ord;
+use function random_bytes;
+use function sprintf;
+use function strlen;
+use function substr;
+
+use const OPENSSL_RAW_DATA;
+
+/**
+ * AES-GCM cipher (algorithm configurable among the AES-*-GCM family), with a self-describing
+ * envelope so decrypt() can locate the KMS key used for a given ciphertext (key rotation).
+ *
+ * Random mode (default) uses a random IV per encryption. Deterministic mode derives a
+ * synthetic IV from an HMAC-SHA256 of the plaintext keyed with the raw KMS key, so the
+ * same (plaintext, key) pair always produces the same envelope — required for
+ * equality-queryable fields.
+ */
+final class OpenSSLCipher implements Cipher
+{
+    public const AES_128_GCM = 'aes-128-gcm';
+    public const AES_192_GCM = 'aes-192-gcm';
+    public const AES_256_GCM = 'aes-256-gcm';
+
+    private const TAG_LENGTH = 16;
+
+    private const SUPPORTED_ALGORITHMS = [
+        self::AES_128_GCM => 16,
+        self::AES_192_GCM => 24,
+        self::AES_256_GCM => 32,
+    ];
+
+    private readonly int $keyLength;
+
+    /** @var positive-int */
+    private readonly int $ivLength;
+
+    public function __construct(
+        private readonly string $algorithm = 'aes-256-gcm',
+        private readonly bool $deterministic = false,
+    ) {
+        if (! isset(self::SUPPORTED_ALGORITHMS[$this->algorithm])) {
+            throw new LogicException(sprintf(
+                'Unsupported algorithm "%s". Supported algorithms: "%s".',
+                $this->algorithm,
+                implode('", "', array_keys(self::SUPPORTED_ALGORITHMS)),
+            ));
+        }
+
+        $ivLength = openssl_cipher_iv_length($this->algorithm);
+        if ($ivLength === false || $ivLength < 1) {
+            throw new LogicException(sprintf(
+                'Unsupported algorithm "%s". Supported algorithms: "%s".',
+                $this->algorithm,
+                implode('", "', array_keys(self::SUPPORTED_ALGORITHMS)),
+            ));
+        }
+
+        $this->keyLength = self::SUPPORTED_ALGORITHMS[$this->algorithm];
+        $this->ivLength  = $ivLength;
+    }
+
+    public function encrypt(
+        #[SensitiveParameter]
+        string $plaintext,
+        KeyProvider $keyProvider,
+    ): string {
+        $key         = $keyProvider->getEncryptionKey();
+        $keyIdBytes  = (string) $key->id;
+        $keyIdLength = strlen($keyIdBytes);
+
+        if ($keyIdLength === 0 || $keyIdLength > 255) {
+            throw EncryptionFailed::create(sprintf(
+                'Key id must be a non-empty string of at most 255 UTF-8 bytes, got %d bytes.',
+                $keyIdLength,
+            ));
+        }
+
+        $rawKey = $key->key;
+
+        if (strlen($rawKey) !== $this->keyLength) {
+            throw EncryptionFailed::create(sprintf(
+                'Expected a %d-byte key, got %d bytes.',
+                $this->keyLength,
+                strlen($rawKey),
+            ));
+        }
+
+        $header = chr($keyIdLength) . $keyIdBytes;
+        $iv     = $this->deterministic
+            ? substr(hash_hmac('sha256', $plaintext, $rawKey, true), 0, $this->ivLength)
+            : random_bytes($this->ivLength);
+
+        $tag        = '';
+        $ciphertext = openssl_encrypt($plaintext, $this->algorithm, $rawKey, OPENSSL_RAW_DATA, $iv, $tag, $header, self::TAG_LENGTH);
+
+        if ($ciphertext === false) {
+            throw EncryptionFailed::create(openssl_error_string() ?: 'unknown error');
+        }
+
+        return $header . $iv . $tag . $ciphertext;
+    }
+
+    public function decrypt(
+        #[SensitiveParameter]
+        string $envelope,
+        KeyProvider $keyProvider,
+    ): string {
+        $keyId          = $this->extractKeyId($envelope);
+        $headerLength   = 1 + strlen($keyId);
+        $envelopeLength = $headerLength + $this->ivLength + self::TAG_LENGTH;
+
+        if (strlen($envelope) < $envelopeLength) {
+            throw DecryptionFailed::envelopTooShort();
+        }
+
+        $header        = substr($envelope, 0, $headerLength);
+        $iv            = substr($envelope, $headerLength, $this->ivLength);
+        $tag           = substr($envelope, $headerLength + $this->ivLength, self::TAG_LENGTH);
+        $rawCiphertext = substr($envelope, $envelopeLength);
+
+        $key    = $keyProvider->getDecryptionKey($keyId);
+        $rawKey = $key->key;
+
+        if (strlen($rawKey) !== $this->keyLength) {
+            throw DecryptionFailed::create(sprintf(
+                'Expected a %d-byte key, got %d bytes.',
+                $this->keyLength,
+                strlen($rawKey),
+            ));
+        }
+
+        $plaintext = openssl_decrypt($rawCiphertext, $this->algorithm, $rawKey, OPENSSL_RAW_DATA, $iv, $tag, $header);
+
+        if ($plaintext === false) {
+            throw DecryptionFailed::create(openssl_error_string() ?: 'unknown error');
+        }
+
+        return $plaintext;
+    }
+
+    public function extractKeyId(
+        #[SensitiveParameter]
+        string $envelope,
+    ): string {
+        if (strlen($envelope) < 1) {
+            throw DecryptionFailed::envelopTooShort();
+        }
+
+        $keyIdLength = ord($envelope[0]);
+
+        if ($keyIdLength === 0 || strlen($envelope) < 1 + $keyIdLength) {
+            throw DecryptionFailed::envelopTooShort();
+        }
+
+        return substr($envelope, 1, $keyIdLength);
+    }
+
+    public function isDeterministic(): bool
+    {
+        return $this->deterministic;
+    }
+
+    public function isBinary(): bool
+    {
+        return true;
+    }
+}

--- a/src/Encrypt/EncryptHelper.php
+++ b/src/Encrypt/EncryptHelper.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Encrypt;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Encrypt\Cipher\BatchableCipher;
 use Doctrine\ORM\Encrypt\Cipher\Cipher;
 use Doctrine\ORM\Encrypt\Exception\EncryptConfigurationMissing;
 use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
@@ -17,6 +18,7 @@ use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Query\EncryptedQuerySetMapping;
 use Doctrine\ORM\Query\ResultSetMapping;
 
+use function array_filter;
 use function array_flip;
 use function array_intersect_key;
 use function array_map;
@@ -208,6 +210,10 @@ final class EncryptHelper
             $plainDbValues[$index] = $this->convertToPlainDbValue($param, $types[$index], $platform);
         }
 
+        if ($cipher instanceof BatchableCipher) {
+            return $this->batchEncrypt($cipher, $keyProvider, $plainDbValues);
+        }
+
         $encrypt = static fn (string|null $plainDbValue): string|null => $plainDbValue === null
             ? null
             : $cipher->encrypt($plainDbValue, $keyProvider);
@@ -218,6 +224,52 @@ final class EncryptHelper
                 : $encrypt($plainDbValue),
             $plainDbValues,
         );
+    }
+
+    /**
+     * @param array<array-key, string|array<array-key, string|null>|null> $plainDbValues
+     *
+     * @return array<array-key, string|array<array-key, string|null>|null>
+     */
+    private function batchEncrypt(BatchableCipher $cipher, KeyProvider $keyProvider, array $plainDbValues): array
+    {
+        $flatPlaintexts = [];
+
+        foreach ($plainDbValues as $index => $plainDbValue) {
+            if (is_array($plainDbValue)) {
+                foreach ($plainDbValue as $subIndex => $subValue) {
+                    if ($subValue !== null) {
+                        $flatPlaintexts[$index . ':' . $subIndex] = $subValue;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($plainDbValue !== null) {
+                $flatPlaintexts[$index] = $plainDbValue;
+            }
+        }
+
+        $flatCiphertexts = $flatPlaintexts === [] ? [] : $cipher->encryptMany($flatPlaintexts, $keyProvider);
+
+        $ciphertexts = [];
+
+        foreach ($plainDbValues as $index => $plainDbValue) {
+            if (is_array($plainDbValue)) {
+                $ciphertexts[$index] = [];
+
+                foreach ($plainDbValue as $subIndex => $subValue) {
+                    $ciphertexts[$index][$subIndex] = $subValue === null ? null : $flatCiphertexts[$index . ':' . $subIndex];
+                }
+
+                continue;
+            }
+
+            $ciphertexts[$index] = $plainDbValue === null ? null : $flatCiphertexts[$index];
+        }
+
+        return $ciphertexts;
     }
 
     /**
@@ -250,12 +302,36 @@ final class EncryptHelper
             $encryptedValues[$column] = $encryptedValue;
         }
 
+        if ($cipher instanceof BatchableCipher) {
+            return $this->batchDecrypt($cipher, $keyProvider, $encryptedValues);
+        }
+
         return array_map(
             static fn (string|null $encryptedValue): string|null => $encryptedValue === null
                 ? null
                 : $cipher->decrypt($encryptedValue, $keyProvider),
             $encryptedValues,
         );
+    }
+
+    /**
+     * @param array<string, string|null> $encryptedValues
+     *
+     * @return array<string, string|null>
+     */
+    private function batchDecrypt(BatchableCipher $cipher, KeyProvider $keyProvider, array $encryptedValues): array
+    {
+        $flatCiphertexts = array_filter($encryptedValues, static fn (string|null $value): bool => $value !== null);
+
+        $flatPlaintexts = $flatCiphertexts === [] ? [] : $cipher->decryptMany($flatCiphertexts, $keyProvider);
+
+        $plaintexts = [];
+
+        foreach ($encryptedValues as $column => $encryptedValue) {
+            $plaintexts[$column] = $encryptedValue === null ? null : $flatPlaintexts[$column];
+        }
+
+        return $plaintexts;
     }
 
     private function convertToPlainDbValue(mixed $value, string $typeName, AbstractPlatform $platform): string|null

--- a/src/Encrypt/EncryptHelper.php
+++ b/src/Encrypt/EncryptHelper.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+use Doctrine\ORM\Encrypt\Exception\EncryptConfigurationMissing;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\EncryptMapping;
+use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Query\EncryptedQuerySetMapping;
+use Doctrine\ORM\Query\ResultSetMapping;
+
+use function array_flip;
+use function array_intersect_key;
+use function array_map;
+use function array_replace;
+use function array_unique;
+use function assert;
+use function is_array;
+use function is_resource;
+use function stream_get_contents;
+
+/** @internal */
+final class EncryptHelper
+{
+    /** @var array<string, true> */
+    private array $queryableFieldCache = [];
+
+    /** @var array<class-string, bool> */
+    private array $containEncryptClasses = [];
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /** @param class-string $class */
+    public function doesClassContainEncrypt(string $class): bool
+    {
+        if (isset($this->containEncryptClasses[$class])) {
+            return $this->containEncryptClasses[$class];
+        }
+
+        $classMetadata = $this->em->getClassMetadata($class);
+
+        if ($classMetadata->encrypt !== null) {
+            return $this->containEncryptClasses[$class] = true;
+        }
+
+        foreach ($classMetadata->fieldMappings as $fieldMapping) {
+            if ($fieldMapping->encrypt !== null) {
+                return $this->containEncryptClasses[$class] = true;
+            }
+        }
+
+        return $this->containEncryptClasses[$class] = false;
+    }
+
+    public function doesRsmContainEncrypt(ResultSetMapping $rsm): bool
+    {
+        foreach (array_unique($rsm->declaringClasses) as $class) {
+            if ($this->doesClassContainEncrypt($class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param class-string $className */
+    public function assertQueryable(string $className, FieldMapping $fieldMapping): void
+    {
+        $cacheKey = $className . '::' . $fieldMapping->fieldName;
+
+        if (isset($this->queryableFieldCache[$cacheKey])) {
+            return;
+        }
+
+        assert($fieldMapping->encrypt !== null);
+
+        if ($fieldMapping->encrypt->queryType === null) {
+            throw UnsupportedEncryptedFieldUsage::missingQueryType($className, $fieldMapping->fieldName);
+        }
+
+        if (! $this->resolveCipher($fieldMapping->encrypt->cipher)->isDeterministic()) {
+            throw UnsupportedEncryptedFieldUsage::notDeterministic($className, $fieldMapping->fieldName);
+        }
+
+        $this->queryableFieldCache[$cacheKey] = true;
+    }
+
+    /** DBAL type name used for binding and DDL: 'text' (String) or 'blob' (Binary). */
+    public function getStorageTypeName(EncryptMapping $encrypt): string
+    {
+        return $this->resolveCipher($encrypt->cipher)->isBinary() ? 'blob' : 'text';
+    }
+
+    /**
+     * Encrypts the parameters registered in the given EncryptedQuerySetMapping in place,
+     * rewriting their binding types to the cipher's storage type.
+     *
+     * @param array<array-key, mixed> $params
+     * @param array<array-key, mixed> $types
+     */
+    public function encryptParameters(EncryptedQuerySetMapping $mapping, array &$params, array &$types): void
+    {
+        $batchable        = [];
+        $plainTypes       = [];
+        $expansionIndexes = [];
+
+        foreach ($mapping->encryptedParameters as $index => [$class, $field]) {
+            $fieldMapping   = $this->em->getClassMetadata($class)->fieldMappings[$field];
+            $encryptMapping = $fieldMapping->encrypt;
+            assert($encryptMapping !== null);
+
+            $keyProvider = $encryptMapping->keyProvider ?? '';
+            $cipher      = $encryptMapping->cipher ?? '';
+
+            $batchable[$keyProvider][$cipher][] = $index;
+
+            $storageTypeName = $this->getStorageTypeName($encryptMapping);
+
+            if ($types[$index] instanceof ArrayParameterType) {
+                $expansionIndexes[$index] = true;
+                $types[$index]            = $storageTypeName === 'blob' ? ArrayParameterType::BINARY : ArrayParameterType::STRING;
+            } else {
+                $types[$index] = $storageTypeName;
+            }
+
+            $plainTypes[$index] = $fieldMapping->type;
+        }
+
+        foreach ($batchable as $keyProvider => $cipherIndexes) {
+            foreach ($cipherIndexes as $cipher => $indexes) {
+                $keys           = array_flip($indexes);
+                $filteredParams = array_intersect_key($params, $keys);
+                $filteredTypes  = array_intersect_key($plainTypes, $keys);
+
+                $params = array_replace(
+                    $params,
+                    $this->encryptMany($cipher, $keyProvider, $filteredParams, $filteredTypes, $expansionIndexes),
+                );
+            }
+        }
+    }
+
+    /**
+     * Decrypts the given row's encrypted columns in place.
+     *
+     * @param array<string, EncryptMapping> $encryptedFieldMappings encrypted columns, mapped to their EncryptMapping
+     * @param array<string, mixed>          $row
+     */
+    public function decryptRow(array $encryptedFieldMappings, array &$row): void
+    {
+        $batchable = [];
+
+        foreach ($encryptedFieldMappings as $column => $encryptMapping) {
+            $keyProvider = $encryptMapping->keyProvider ?? '';
+            $cipher      = $encryptMapping->cipher ?? '';
+
+            $batchable[$keyProvider][$cipher][$column] = $this->getStorageTypeName($encryptMapping);
+        }
+
+        foreach ($batchable as $keyProvider => $cipherColumns) {
+            foreach ($cipherColumns as $cipher => $columnAndStorageTypes) {
+                $filteredRow = array_intersect_key($row, $columnAndStorageTypes);
+
+                $row = array_replace(
+                    $row,
+                    $this->decryptMany($cipher, $keyProvider, $filteredRow, $columnAndStorageTypes),
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed>  $params
+     * @param array<array-key, string> $types
+     * @param array<array-key, true>   $expansionIndexes indexes holding array-expansion parameters
+     *
+     * @return array<array-key, string|array<array-key, string|null>|null>
+     */
+    private function encryptMany(string $cipherName, string $keyProviderName, array $params, array $types, array $expansionIndexes): array
+    {
+        $cipher      = $this->resolveCipher($cipherName === '' ? null : $cipherName);
+        $keyProvider = $this->resolveKeyProvider($keyProviderName === '' ? null : $keyProviderName);
+
+        $platform      = $this->em->getConnection()->getDatabasePlatform();
+        $plainDbValues = [];
+
+        foreach ($params as $index => $param) {
+            if (isset($expansionIndexes[$index]) && is_array($param)) {
+                $plainDbValues[$index] = array_map(
+                    fn (mixed $value): string|null => $this->convertToPlainDbValue($value, $types[$index], $platform),
+                    $param,
+                );
+
+                continue;
+            }
+
+            $plainDbValues[$index] = $this->convertToPlainDbValue($param, $types[$index], $platform);
+        }
+
+        $encrypt = static fn (string|null $plainDbValue): string|null => $plainDbValue === null
+            ? null
+            : $cipher->encrypt($plainDbValue, $keyProvider);
+
+        return array_map(
+            static fn (array|string|null $plainDbValue): array|string|null => is_array($plainDbValue)
+                ? array_map($encrypt, $plainDbValue)
+                : $encrypt($plainDbValue),
+            $plainDbValues,
+        );
+    }
+
+    /**
+     * @param array<string, mixed>  $row
+     * @param array<string, string> $types
+     *
+     * @return array<string, string|null>
+     */
+    private function decryptMany(string $cipherName, string $keyProviderName, array $row, array $types): array
+    {
+        $cipher      = $this->resolveCipher($cipherName === '' ? null : $cipherName);
+        $keyProvider = $this->resolveKeyProvider($keyProviderName === '' ? null : $keyProviderName);
+
+        $platform        = $this->em->getConnection()->getDatabasePlatform();
+        $encryptedValues = [];
+
+        foreach ($row as $column => $encryptedDbValue) {
+            if ($encryptedDbValue === null) {
+                $encryptedValues[$column] = null;
+
+                continue;
+            }
+
+            $encryptedValue = Type::getType($types[$column])->convertToPHPValue($encryptedDbValue, $platform);
+
+            if (is_resource($encryptedValue)) {
+                $encryptedValue = stream_get_contents($encryptedValue);
+            }
+
+            $encryptedValues[$column] = $encryptedValue;
+        }
+
+        return array_map(
+            static fn (string|null $encryptedValue): string|null => $encryptedValue === null
+                ? null
+                : $cipher->decrypt($encryptedValue, $keyProvider),
+            $encryptedValues,
+        );
+    }
+
+    private function convertToPlainDbValue(mixed $value, string $typeName, AbstractPlatform $platform): string|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $plainDbValue = Type::getType($typeName)->convertToDatabaseValue($value, $platform);
+
+        if (is_resource($plainDbValue)) {
+            $plainDbValue = stream_get_contents($plainDbValue);
+        }
+
+        return $plainDbValue === null ? null : (string) $plainDbValue;
+    }
+
+    /** @throws EncryptConfigurationMissing */
+    private function resolveCipher(string|null $name): Cipher
+    {
+        $registry = $this->em->getConfiguration()->getCipherRegistry();
+
+        if ($registry === null) {
+            throw EncryptConfigurationMissing::forCipherRegistry();
+        }
+
+        return $registry->getCipher($name);
+    }
+
+    /** @throws EncryptConfigurationMissing */
+    private function resolveKeyProvider(string|null $name): KeyProvider
+    {
+        $registry = $this->em->getConfiguration()->getKeyProviderRegistry();
+
+        if ($registry === null) {
+            throw EncryptConfigurationMissing::forKeyProviderRegistry();
+        }
+
+        return $registry->getKeyProvider($name);
+    }
+}

--- a/src/Encrypt/EncryptQuery.php
+++ b/src/Encrypt/EncryptQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt;
+
+/**
+ * List all filtering supported for Encrypt.
+ * Possible to compare using query on an encrypted field of an entity.
+ */
+enum EncryptQuery: string
+{
+    /**
+     * Support Equality compare on a deterministic encrypted field.
+     *
+     * e.g. SELECT * FROM user WHERE encrypted_email = :email
+     */
+    case Equality = 'equality';
+}

--- a/src/Encrypt/Exception/EncryptConfigurationMissing.php
+++ b/src/Encrypt/Exception/EncryptConfigurationMissing.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use LogicException;
+
+final class EncryptConfigurationMissing extends LogicException implements ORMException
+{
+    public static function forCipherRegistry(): self
+    {
+        return new self(
+            'Cipher registry is not configured. Call Configuration::setCipherRegistry() to set it.',
+        );
+    }
+
+    public static function forKeyProviderRegistry(): self
+    {
+        return new self(
+            'Key provider registry is not configured. Call Configuration::setKeyProviderRegistry() to set it.',
+        );
+    }
+}

--- a/src/Encrypt/Exception/UnsupportedEncryptedFieldUsage.php
+++ b/src/Encrypt/Exception/UnsupportedEncryptedFieldUsage.php
@@ -11,6 +11,16 @@ use function sprintf;
 
 final class UnsupportedEncryptedFieldUsage extends LogicException implements ORMException
 {
+    public static function unsupportedOperator(string $className, string $fieldName, string $operator): self
+    {
+        return new self(sprintf(
+            '%s::$%s is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got "%s".',
+            $className,
+            $fieldName,
+            $operator,
+        ));
+    }
+
     public static function missingQueryType(string $className, string $fieldName): self
     {
         return new self(sprintf(

--- a/src/Encrypt/Exception/UnsupportedEncryptedFieldUsage.php
+++ b/src/Encrypt/Exception/UnsupportedEncryptedFieldUsage.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use LogicException;
+
+use function sprintf;
+
+final class UnsupportedEncryptedFieldUsage extends LogicException implements ORMException
+{
+    public static function missingQueryType(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            '%s::$%s is encrypted; filtering by an encrypted field without queryType set is not supported.',
+            $className,
+            $fieldName,
+        ));
+    }
+
+    public static function notDeterministic(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            '%s::$%s is encrypted; filtering by an encrypted field using non deterministic cipher is not supported.',
+            $className,
+            $fieldName,
+        ));
+    }
+
+    public static function literal(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            '%s::$%s is encrypted; comparing or assigning a DQL literal is not supported, bind a parameter instead.',
+            $className,
+            $fieldName,
+        ));
+    }
+
+    public static function orderBy(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            '%s::$%s is encrypted; ordering by an encrypted field is not supported.',
+            $className,
+            $fieldName,
+        ));
+    }
+}

--- a/src/Encrypt/KMS/AbstractKeyProviderRegistry.php
+++ b/src/Encrypt/KMS/AbstractKeyProviderRegistry.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKeyProvider;
+
+use function array_keys;
+
+abstract class AbstractKeyProviderRegistry implements KeyProviderRegistry
+{
+    /** @param array<string, string> $keyProviders */
+    public function __construct(
+        private readonly array $keyProviders,
+        private readonly string $defaultKeyProviderName,
+    ) {
+        if (! isset($this->keyProviders[$this->defaultKeyProviderName])) {
+            throw UnknownKeyProvider::create($this->defaultKeyProviderName, $this->getKeyProviderNames());
+        }
+    }
+
+    /**
+     * Fetches/creates the given services.
+     *
+     * @param string $name The name of the service.
+     */
+    abstract protected function getService(string $name): KeyProvider;
+
+    public function getDefaultKeyProviderName(): string
+    {
+        return $this->defaultKeyProviderName;
+    }
+
+    public function getKeyProvider(string|null $name = null): KeyProvider
+    {
+        $name ??= $this->defaultKeyProviderName;
+
+        if (! isset($this->keyProviders[$name])) {
+            throw UnknownKeyProvider::create($name, $this->getKeyProviderNames());
+        }
+
+        return $this->getService($this->keyProviders[$name]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getKeyProviders(): array
+    {
+        $keyProviders = [];
+
+        foreach (array_keys($this->keyProviders) as $name) {
+            $keyProviders[$name] = $this->getKeyProvider($name);
+        }
+
+        return $keyProviders;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getKeyProviderNames(): array
+    {
+        return array_keys($this->keyProviders);
+    }
+}

--- a/src/Encrypt/KMS/ArrayKeyProviderRegistry.php
+++ b/src/Encrypt/KMS/ArrayKeyProviderRegistry.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use function array_combine;
+use function array_key_first;
+use function array_keys;
+
+final class ArrayKeyProviderRegistry extends AbstractKeyProviderRegistry
+{
+    /**
+     * @param non-empty-array<string, KeyProvider> $keyProviders
+     * @param string|null                          $defaultName  defaults to the first key
+     */
+    public function __construct(
+        private readonly array $keyProviders,
+        string|null $defaultName = null,
+    ) {
+        parent::__construct(
+            array_combine($keys = array_keys($keyProviders), $keys),
+            $defaultName ?? array_key_first($keyProviders),
+        );
+    }
+
+    protected function getService(string $name): KeyProvider
+    {
+        return $this->keyProviders[$name];
+    }
+}

--- a/src/Encrypt/KMS/ArraySymmetricKeyProvider.php
+++ b/src/Encrypt/KMS/ArraySymmetricKeyProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKey;
+
+use function array_key_last;
+use function base64_decode;
+use function count;
+
+final class ArraySymmetricKeyProvider implements KeyProvider
+{
+    /** @param array<int|string, Key> $keys Indexed by key id. */
+    public function __construct(
+        private readonly array $keys,
+    ) {
+        if (count($this->keys) === 0) {
+            throw UnknownKey::cannotBeEmpty();
+        }
+    }
+
+    /** @param array<int|string, string> $keys Base64-encoded key material, indexed by key id. */
+    public static function fromScalars(array $keys): self
+    {
+        $decoded = [];
+        foreach ($keys as $id => $base64) {
+            $raw = base64_decode($base64, true);
+            if ($raw === false || $raw === '') {
+                throw UnknownKey::createInvalidBase64($id);
+            }
+
+            $decoded[$id] = new Key($id, $raw);
+        }
+
+        return new self($decoded);
+    }
+
+    public function getEncryptionKey(): Key
+    {
+        return $this->keys[array_key_last($this->keys)];
+    }
+
+    public function getDecryptionKey(int|string $id): Key
+    {
+        return $this->keys[$id] ?? throw UnknownKey::createNotResolveId($id);
+    }
+}

--- a/src/Encrypt/KMS/Exception/UnknownKey.php
+++ b/src/Encrypt/KMS/Exception/UnknownKey.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class UnknownKey extends InvalidArgumentException implements ORMException
+{
+    public static function createNotResolveId(int|string $id): self
+    {
+        return new self(sprintf('Could not resolve a key for id "%s".', $id));
+    }
+
+    public static function createInvalidBase64(int|string $id): self
+    {
+        return new self(sprintf('Could not init key for id "%s", invalid base64 string.', $id));
+    }
+
+    public static function cannotBeEmpty(): self
+    {
+        return new self('Keys cannot be empty.');
+    }
+}

--- a/src/Encrypt/KMS/Exception/UnknownKeyProvider.php
+++ b/src/Encrypt/KMS/Exception/UnknownKeyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS\Exception;
+
+use Doctrine\ORM\Exception\ORMException;
+use InvalidArgumentException;
+
+use function implode;
+use function sprintf;
+
+final class UnknownKeyProvider extends InvalidArgumentException implements ORMException
+{
+    /** @param list<string> $knownNames */
+    public static function create(string $name, array $knownNames): self
+    {
+        return new self(sprintf(
+            'Unknown key provider "%s". Known key providers: "%s".',
+            $name,
+            implode('", "', $knownNames),
+        ));
+    }
+}

--- a/src/Encrypt/KMS/Key.php
+++ b/src/Encrypt/KMS/Key.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use SensitiveParameter;
+
+/**
+ * Value-object to store a key and its id.
+ */
+final class Key
+{
+    public function __construct(
+        public readonly int|string $id,
+        #[SensitiveParameter]
+        public readonly string $key,
+    ) {
+    }
+}

--- a/src/Encrypt/KMS/KeyProvider.php
+++ b/src/Encrypt/KMS/KeyProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKey;
+
+interface KeyProvider
+{
+    /**
+     * The key all NEW ciphertexts must be produced with.
+     */
+    public function getEncryptionKey(): Key;
+
+    /**
+     * Get a decryption key from its id.
+     * Implementations must be able to serve every key id that still exists in the database.
+     *
+     * @throws UnknownKey
+     */
+    public function getDecryptionKey(int|string $id): Key;
+}

--- a/src/Encrypt/KMS/KeyProviderRegistry.php
+++ b/src/Encrypt/KMS/KeyProviderRegistry.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKeyProvider;
+
+interface KeyProviderRegistry
+{
+    public function getDefaultKeyProviderName(): string;
+
+    /**
+     * @param string|null $name null resolves to the default key provider
+     *
+     * @throws UnknownKeyProvider when $name is not registered.
+     */
+    public function getKeyProvider(string|null $name = null): KeyProvider;
+
+    /** @return array<string, KeyProvider> indexed by key provider name */
+    public function getKeyProviders(): array;
+
+    /** @return list<string> All registered KeyProvider provider name. */
+    public function getKeyProviderNames(): array;
+}

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -10,6 +10,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;
@@ -104,6 +105,11 @@ class EntityManager implements EntityManagerInterface
      * The second level cache regions API.
      */
     private Cache|null $cache = null;
+
+    /**
+     * The helper coordinating field-level encryption/decryption.
+     */
+    private EncryptHelper|null $encryptHelper = null;
 
     /**
      * Creates a new EntityManager that operates on the given database connection
@@ -583,6 +589,11 @@ class EntityManager implements EntityManagerInterface
     public function isFiltersStateClean(): bool
     {
         return $this->filterCollection === null || $this->filterCollection->isClean();
+    }
+
+    public function getEncryptHelper(): EncryptHelper
+    {
+        return $this->encryptHelper ??= new EncryptHelper($this);
     }
 
     public function hasFilters(): bool

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -213,6 +214,11 @@ interface EntityManagerInterface extends ObjectManager
      * Gets the proxy factory used by the EntityManager to create entity proxies.
      */
     public function getProxyFactory(): ProxyFactory;
+
+    /**
+     * Gets the helper coordinating field-level encryption/decryption for this EntityManager.
+     */
+    public function getEncryptHelper(): EncryptHelper;
 
     /**
      * Gets the enabled filters.

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -8,9 +8,11 @@ use BackedEnum;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\EncryptMapping;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
 use Doctrine\ORM\UnitOfWork;
@@ -54,6 +56,16 @@ abstract class AbstractHydrator
      */
     protected UnitOfWork $uow;
 
+    protected EncryptHelper $encryptHelper;
+
+    /**
+     * Encrypted result columns, mapped to their EncryptMapping.
+     * Built lazily on the first row of a result set, reset in {@see cleanup()}.
+     *
+     * @var array<string, EncryptMapping>|null
+     */
+    private array|null $encryptedFieldMappings = null;
+
     /**
      * Local ClassMetadata cache to avoid going to the EntityManager all the time.
      *
@@ -85,8 +97,9 @@ abstract class AbstractHydrator
      */
     public function __construct(protected EntityManagerInterface $em)
     {
-        $this->platform = $em->getConnection()->getDatabasePlatform();
-        $this->uow      = $em->getUnitOfWork();
+        $this->platform      = $em->getConnection()->getDatabasePlatform();
+        $this->uow           = $em->getUnitOfWork();
+        $this->encryptHelper = $em->getEncryptHelper();
     }
 
     /**
@@ -120,7 +133,7 @@ abstract class AbstractHydrator
 
                 $result = [];
 
-                $this->hydrateRowData($row, $result);
+                $this->hydrateRowData($this->decryptRowData($row), $result);
 
                 $this->cleanupAfterRowIteration();
                 if (count($result) === 1) {
@@ -205,10 +218,11 @@ abstract class AbstractHydrator
     {
         $this->statement()->free();
 
-        $this->stmt          = null;
-        $this->rsm           = null;
-        $this->cache         = [];
-        $this->metadataCache = [];
+        $this->stmt                   = null;
+        $this->rsm                    = null;
+        $this->cache                  = [];
+        $this->metadataCache          = [];
+        $this->encryptedFieldMappings = null;
 
         $this
             ->em
@@ -611,5 +625,50 @@ abstract class AbstractHydrator
         $value = $isIntBacked ? (int) $value : $value;
 
         return $enumType::from($value);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    final protected function decryptRowData(array $row): array
+    {
+        $mappings = $this->encryptedFieldMappings ??= $this->createEncryptedFieldMappings();
+
+        if ($mappings !== []) {
+            $this->encryptHelper->decryptRow($mappings, $row);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Builds the encrypted-column map once per result set: the encrypted columns only depend on the ResultSetMapping.
+     *
+     * @return array<string, EncryptMapping>
+     */
+    private function createEncryptedFieldMappings(): array
+    {
+        if ($this->rsm->isDecryptDisabled() || ! $this->encryptHelper->doesRsmContainEncrypt($this->rsm)) {
+            return [];
+        }
+
+        $mappings = [];
+
+        foreach ($this->rsm->fieldMappings as $column => $fieldName) {
+            if (! isset($this->rsm->declaringClasses[$column])) {
+                continue;
+            }
+
+            $encrypt = $this->em->getClassMetadata($this->rsm->declaringClasses[$column])
+                ->fieldMappings[$fieldName]->encrypt ?? null;
+
+            if ($encrypt !== null) {
+                $mappings[$column] = $encrypt;
+            }
+        }
+
+        return $mappings;
     }
 }

--- a/src/Internal/Hydration/ArrayHydrator.php
+++ b/src/Internal/Hydration/ArrayHydrator.php
@@ -51,7 +51,7 @@ class ArrayHydrator extends AbstractHydrator
         $result = [];
 
         while ($data = $this->statement()->fetchAssociative()) {
-            $this->hydrateRowData($data, $result);
+            $this->hydrateRowData($this->decryptRowData($data), $result);
         }
 
         return $result;

--- a/src/Internal/Hydration/ObjectHydrator.php
+++ b/src/Internal/Hydration/ObjectHydrator.php
@@ -144,7 +144,7 @@ class ObjectHydrator extends AbstractHydrator
         $result = [];
 
         while ($row = $this->statement()->fetchAssociative()) {
-            $this->hydrateRowData($row, $result);
+            $this->hydrateRowData($this->decryptRowData($row), $result);
         }
 
         // Take snapshots from all newly initialized collections

--- a/src/Internal/Hydration/ScalarHydrator.php
+++ b/src/Internal/Hydration/ScalarHydrator.php
@@ -19,7 +19,7 @@ class ScalarHydrator extends AbstractHydrator
         $result = [];
 
         while ($data = $this->statement()->fetchAssociative()) {
-            $this->hydrateRowData($data, $result);
+            $this->hydrateRowData($this->decryptRowData($data), $result);
         }
 
         return $result;

--- a/src/Internal/Hydration/SimpleObjectHydrator.php
+++ b/src/Internal/Hydration/SimpleObjectHydrator.php
@@ -57,7 +57,7 @@ class SimpleObjectHydrator extends AbstractHydrator
         $result = [];
 
         while ($row = $this->statement()->fetchAssociative()) {
-            $this->hydrateRowData($row, $result);
+            $this->hydrateRowData($this->decryptRowData($row), $result);
         }
 
         $this->em->getUnitOfWork()->triggerEagerLoads();

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -530,6 +530,12 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public array|null $cache = null;
 
     /**
+     * READ-ONLY: Class-level encrypt mapping, applied to every eligible scalar field that does not carry its own
+     * field-level encrypt mapping.
+     */
+    public EncryptMapping|null $encrypt = null;
+
+    /**
      * The ReflectionClass instance of the mapped class.
      *
      * @var ReflectionClass<T>|null
@@ -815,6 +821,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         if ($this->cache) {
             $serialized[] = 'cache';
+        }
+
+        if ($this->encrypt !== null) {
+            $serialized[] = 'encrypt';
         }
 
         if ($this->requiresFetchAfterChange) {
@@ -1205,6 +1215,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     id?: bool,
      *     generated?: self::GENERATED_*,
      *     enumType?: class-string,
+     *     encrypt?: array<string, mixed>|null,
      * } $mapping The field mapping to validate & complete.
      *
      * @return FieldMapping The updated mapping.
@@ -1292,7 +1303,41 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
         }
 
+        if ($mapping->encrypt !== null) {
+            $violation = $this->getFieldEncryptionViolation($mapping);
+            if ($violation !== null) {
+                throw $violation;
+            }
+        } elseif ($this->encrypt !== null && $this->getFieldEncryptionViolation($mapping) === null) {
+            $mapping->encrypt = clone $this->encrypt;
+        }
+
         return $mapping;
+    }
+
+    private function getFieldEncryptionViolation(FieldMapping $mapping): MappingException|null
+    {
+        if ($mapping->id === true) {
+            return MappingException::encryptOnIdentifierNotAllowed($this->name, $mapping->fieldName);
+        }
+
+        if ($mapping->generated !== null) {
+            return MappingException::encryptOnGeneratedNotAllowed($this->name, $mapping->fieldName);
+        }
+
+        if ($mapping->version === true || $this->versionField === $mapping->fieldName) {
+            return MappingException::encryptOnVersionFieldNotAllowed($this->name, $mapping->fieldName);
+        }
+
+        if ($mapping->notInsertable === true || $mapping->notUpdatable === true) {
+            return MappingException::encryptOnImmutableFieldNotSupported($this->name, $mapping->fieldName);
+        }
+
+        if ($this->cache !== null) {
+            return MappingException::encryptFieldWithSecondLevelCacheNotSupported($this->name, $mapping->fieldName);
+        }
+
+        return null;
     }
 
     /**
@@ -2651,7 +2696,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      *     class?: class-string,
      *     declaredField?: string,
      *     columnPrefix?: string|false|null,
-     *     originalField?: string
+     *     originalField?: string,
+     *     encrypt?: array<string, mixed>|null,
      * } $mapping
      *
      * @throws MappingException
@@ -2676,6 +2722,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             'columnPrefix' => $mapping['columnPrefix'] ?? null,
             'declaredField' => $mapping['declaredField'] ?? null,
             'originalField' => $mapping['originalField'] ?? null,
+            'encrypt' => $mapping['encrypt'] ?? null,
         ]);
     }
 
@@ -2692,6 +2739,11 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 : $property;
             $fieldMapping['originalField'] ??= $fieldMapping['fieldName'];
             $fieldMapping['fieldName']       = $property . '.' . $fieldMapping['fieldName'];
+
+            $encrypt = $originalFieldMapping->encrypt ?? $this->embeddedClasses[$property]->encrypt;
+            if ($encrypt !== null) {
+                $fieldMapping['encrypt'] = (array) $encrypt;
+            }
 
             if (! empty($this->embeddedClasses[$property]->columnPrefix)) {
                 $fieldMapping['columnName'] = $this->embeddedClasses[$property]->columnPrefix . $fieldMapping['columnName'];

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -277,6 +277,15 @@ class AttributeDriver implements MappingDriver
             $metadata->setChangeTrackingPolicy(constant('Doctrine\ORM\Mapping\ClassMetadata::CHANGETRACKING_' . $changeTrackingAttribute->value));
         }
 
+        // Evaluate Encrypt attribute (class-level default for eligible scalar fields)
+        if (isset($classAttributes[Mapping\Encrypt::class])) {
+            if ($metadata->cache !== null) {
+                throw MappingException::encryptClassWithSecondLevelCacheNotSupported($metadata->name);
+            }
+
+            $metadata->encrypt = Mapping\EncryptMapping::fromAttribute($classAttributes[Mapping\Encrypt::class]);
+        }
+
         foreach ($reflectionClass->getProperties() as $property) {
             if ($this->isRepeatedPropertyDeclaration($property, $metadata)) {
                 continue;
@@ -296,6 +305,9 @@ class AttributeDriver implements MappingDriver
                     ],
                 );
             }
+
+            // Evaluate Encrypt attribute
+            $encryptAttribute = $this->reader->getPropertyAttribute($property, Mapping\Encrypt::class);
 
             // Check for JoinColumn/JoinColumns attributes
             $joinColumns = [];
@@ -334,6 +346,10 @@ class AttributeDriver implements MappingDriver
                     $metadata->setVersionMapping($mapping);
                 }
 
+                if ($encryptAttribute !== null) {
+                    $mapping['encrypt'] = (array) $encryptAttribute;
+                }
+
                 $metadata->mapField($mapping);
 
                 // Check for SequenceGenerator/TableGenerator definition
@@ -360,6 +376,10 @@ class AttributeDriver implements MappingDriver
                     throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\OneToOne::class);
                 }
 
+                if ($encryptAttribute !== null) {
+                    throw MappingException::encryptOnAssociationNotAllowed($metadata->name, $property->name);
+                }
+
                 $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
                 if ($idAttribute !== null) {
                     $mapping['id']         = true;
@@ -377,6 +397,10 @@ class AttributeDriver implements MappingDriver
             } elseif ($oneToManyAttribute !== null) {
                 if ($metadata->isEmbeddedClass) {
                     throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\OneToMany::class);
+                }
+
+                if ($encryptAttribute !== null) {
+                    throw MappingException::encryptOnAssociationNotAllowed($metadata->name, $property->name);
                 }
 
                 $mapping['mappedBy']      = $oneToManyAttribute->mappedBy;
@@ -398,6 +422,10 @@ class AttributeDriver implements MappingDriver
                     throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\ManyToOne::class);
                 }
 
+                if ($encryptAttribute !== null) {
+                    throw MappingException::encryptOnAssociationNotAllowed($metadata->name, $property->name);
+                }
+
                 $idAttribute = $this->reader->getPropertyAttribute($property, Mapping\Id::class);
 
                 if ($idAttribute !== null) {
@@ -414,6 +442,10 @@ class AttributeDriver implements MappingDriver
             } elseif ($manyToManyAttribute !== null) {
                 if ($metadata->isEmbeddedClass) {
                     throw MappingException::invalidAttributeOnEmbeddable($metadata->name, Mapping\ManyToMany::class);
+                }
+
+                if ($encryptAttribute !== null) {
+                    throw MappingException::encryptOnAssociationNotAllowed($metadata->name, $property->name);
                 }
 
                 $joinTable          = [];
@@ -465,6 +497,10 @@ class AttributeDriver implements MappingDriver
             } elseif ($embeddedAttribute !== null) {
                 $mapping['class']        = $embeddedAttribute->class;
                 $mapping['columnPrefix'] = $embeddedAttribute->columnPrefix;
+
+                if ($encryptAttribute !== null) {
+                    $mapping['encrypt'] = (array) $encryptAttribute;
+                }
 
                 $metadata->mapEmbedded($mapping);
             }

--- a/src/Mapping/EmbeddedClassMapping.php
+++ b/src/Mapping/EmbeddedClassMapping.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 use ArrayAccess;
 
+use function in_array;
 use function property_exists;
 
 /** @template-implements ArrayAccess<string, mixed> */
@@ -42,6 +43,8 @@ final class EmbeddedClassMapping implements ArrayAccess
      */
     public string|null $declared = null;
 
+    public EncryptMapping|null $encrypt = null;
+
     /** @param class-string $class */
     public function __construct(public string $class)
     {
@@ -55,19 +58,25 @@ final class EmbeddedClassMapping implements ArrayAccess
      *     originalField?: string|null,
      *     inherited?: class-string|null,
      *     declared?: class-string|null,
+     *     encrypt?: array<string, mixed>|null,
      * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): self
     {
         $mapping = new self($mappingArray['class']);
         foreach ($mappingArray as $key => $value) {
-            if ($key === 'class') {
+            if (in_array($key, ['class', 'encrypt'])) {
                 continue;
             }
 
             if (property_exists($mapping, $key)) {
                 $mapping->$key = $value;
             }
+        }
+
+        $encryptMapping = $mappingArray['encrypt'] ?? null;
+        if ($encryptMapping !== null) {
+            $mapping->encrypt = EncryptMapping::fromMappingArray($encryptMapping);
         }
 
         return $mapping;
@@ -82,7 +91,7 @@ final class EmbeddedClassMapping implements ArrayAccess
             $serialized[] = 'columnPrefix';
         }
 
-        foreach (['declaredField', 'originalField', 'inherited', 'declared'] as $property) {
+        foreach (['declaredField', 'originalField', 'inherited', 'declared', 'encrypt'] as $property) {
             if ($this->$property !== null) {
                 $serialized[] = $property;
             }

--- a/src/Mapping/Encrypt.php
+++ b/src/Mapping/Encrypt.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use Attribute;
+use Doctrine\ORM\Encrypt\EncryptQuery;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_PROPERTY)]
+final class Encrypt implements MappingAttribute
+{
+    public function __construct(
+        public readonly string|null $cipher = null,
+        public readonly string|null $keyProvider = null,
+        public readonly EncryptQuery|null $queryType = null,
+    ) {
+    }
+}

--- a/src/Mapping/EncryptMapping.php
+++ b/src/Mapping/EncryptMapping.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping;
+
+use ArrayAccess;
+use Doctrine\ORM\Encrypt\EncryptQuery;
+
+/** @template-implements ArrayAccess<string, mixed> */
+final class EncryptMapping implements ArrayAccess
+{
+    use ArrayAccessImplementation;
+
+    public string|null $cipher          = null;
+    public string|null $keyProvider     = null;
+    public EncryptQuery|null $queryType = null;
+
+    public static function fromAttribute(Encrypt $attribute): self
+    {
+        $mapping = new self();
+
+        $mapping->cipher      = $attribute->cipher;
+        $mapping->keyProvider = $attribute->keyProvider;
+        $mapping->queryType   = $attribute->queryType;
+
+        return $mapping;
+    }
+
+    /**
+     * @param array<string, mixed> $mappingArray
+     * @phpstan-param array{
+     *     cipher?: string|null,
+     *     keyProvider?: string|null,
+     *     queryType?: EncryptQuery|string|null,
+     * } $mappingArray
+     */
+    public static function fromMappingArray(array $mappingArray): self
+    {
+        $encryptMapping = new self();
+
+        $encryptMapping->cipher      = $mappingArray['cipher'] ?? null;
+        $encryptMapping->keyProvider = $mappingArray['keyProvider'] ?? null;
+
+        $queryType = $mappingArray['queryType'] ?? null;
+
+        if ($queryType !== null && ! $queryType instanceof EncryptQuery) {
+            $queryType = EncryptQuery::from($queryType);
+        }
+
+        $encryptMapping->queryType = $queryType;
+
+        return $encryptMapping;
+    }
+
+    /** @return list<string> */
+    public function __sleep(): array
+    {
+        return ['cipher', 'keyProvider', 'queryType'];
+    }
+}

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -76,6 +76,8 @@ final class FieldMapping implements ArrayAccess
     /** @deprecated Use options with 'default' key instead */
     public string|int|null $default = null;
 
+    public EncryptMapping|null $encrypt = null;
+
     /**
      * @param string $type       The type name of the mapped field. Can be one of
      *                           Doctrine's mapping types or a custom mapping type.
@@ -117,6 +119,7 @@ final class FieldMapping implements ArrayAccess
      *     options?: array<string, mixed>|null,
      *     version?: bool|null,
      *     default?: string|int|null,
+     *     encrypt?: array<string, mixed>|null,
      * } $mappingArray
      */
     public static function fromMappingArray(array $mappingArray): self
@@ -127,13 +130,18 @@ final class FieldMapping implements ArrayAccess
             $mappingArray['columnName'],
         );
         foreach ($mappingArray as $key => $value) {
-            if (in_array($key, ['type', 'fieldName', 'columnName'])) {
+            if (in_array($key, ['type', 'fieldName', 'columnName', 'encrypt'])) {
                 continue;
             }
 
             if (property_exists($mapping, $key)) {
                 $mapping->$key = $value;
             }
+        }
+
+        $encryptMapping = $mappingArray['encrypt'] ?? null;
+        if ($encryptMapping !== null) {
+            $mapping->encrypt = EncryptMapping::fromMappingArray($encryptMapping);
         }
 
         return $mapping;
@@ -166,6 +174,7 @@ final class FieldMapping implements ArrayAccess
                 'declaredField',
                 'options',
                 'default',
+                'encrypt',
             ] as $key
         ) {
             if ($this->$key !== null) {

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -730,4 +730,66 @@ EXCEPTION
             $className,
         ));
     }
+
+    public static function encryptOnIdentifierNotAllowed(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Encrypted identifier "%s" on entity "%s" is not allowed.',
+            $fieldName,
+            $className,
+        ));
+    }
+
+    public static function encryptOnGeneratedNotAllowed(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Encrypted generated field "%s" on entity "%s" is not allowed.',
+            $fieldName,
+            $className,
+        ));
+    }
+
+    public static function encryptOnVersionFieldNotAllowed(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Encrypted version field "%s" on entity "%s" is not allowed.',
+            $fieldName,
+            $className,
+        ));
+    }
+
+    public static function encryptOnAssociationNotAllowed(string $className, string $associationName): self
+    {
+        return new self(sprintf(
+            'Encrypted association "%s" on entity "%s" is not allowed.',
+            $associationName,
+            $className,
+        ));
+    }
+
+    public static function encryptOnImmutableFieldNotSupported(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Encrypted immutable field "%s" on entity "%s" is not supported.',
+            $fieldName,
+            $className,
+        ));
+    }
+
+    public static function encryptFieldWithSecondLevelCacheNotSupported(string $className, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Because encrypted field "%s" on entity "%s", second level cache is not supported on entity.',
+            $fieldName,
+            $className,
+        ));
+    }
+
+    public static function encryptClassWithSecondLevelCacheNotSupported(string $className): self
+    {
+        return new self(sprintf(
+            'Because encrypted entity "%s", second level cache is not supported on entity.',
+            $className,
+        ));
+    }
 }

--- a/src/Persisters/Collection/AbstractCollectionPersister.php
+++ b/src/Persisters/Collection/AbstractCollectionPersister.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\UnitOfWork;
@@ -19,6 +20,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
     protected UnitOfWork $uow;
     protected AbstractPlatform $platform;
     protected QuoteStrategy $quoteStrategy;
+    protected EncryptHelper $encryptHelper;
 
     /**
      * Initializes a new instance of a class derived from AbstractCollectionPersister.
@@ -30,6 +32,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
         $this->conn          = $em->getConnection();
         $this->platform      = $this->conn->getDatabasePlatform();
         $this->quoteStrategy = $em->getConfiguration()->getQuoteStrategy();
+        $this->encryptHelper = $em->getEncryptHelper();
     }
 
     /**

--- a/src/Persisters/Collection/ManyToManyPersister.php
+++ b/src/Persisters/Collection/ManyToManyPersister.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache\Persister\CompatOrderings;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\InverseSideMapping;
@@ -17,6 +18,7 @@ use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\EncryptedQuerySetMapping;
 use Doctrine\ORM\Utility\PersisterHelper;
 use SortDirection;
 
@@ -27,6 +29,7 @@ use function assert;
 use function count;
 use function implode;
 use function in_array;
+use function range;
 use function reset;
 use function sprintf;
 
@@ -244,16 +247,32 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $paramTypes[]   = PersisterHelper::getTypeOfColumn($value, $ownerMetadata, $this->em);
         }
 
-        $parameters = $this->expandCriteriaParameters($criteria);
+        $parameters      = $this->expandCriteriaParameters($criteria);
+        $querySetMapping = new EncryptedQuerySetMapping();
 
         foreach ($parameters as $parameter) {
             [$name, $value, $operator] = $parameter;
 
-            $field = $this->quoteStrategy->getColumnName($name, $targetClass, $this->platform);
+            $field        = $this->quoteStrategy->getColumnName($name, $targetClass, $this->platform);
+            $fieldMapping = $targetClass->fieldMappings[$name] ?? null;
+            $encrypt      = $fieldMapping?->encrypt !== null;
+            $countParams  = count($params);
 
             if ($value === null && ($operator === Comparison::EQ || $operator === Comparison::NEQ)) {
                 $whereClauses[] = sprintf('te.%s %s NULL', $field, $operator === Comparison::EQ ? 'IS' : 'IS NOT');
-            } elseif ($operator === Comparison::IN || $operator === Comparison::NIN) {
+
+                continue;
+            }
+
+            if ($encrypt) {
+                if (! in_array($operator, [Comparison::EQ, Comparison::NEQ, Comparison::IN, Comparison::NIN], true)) {
+                    throw UnsupportedEncryptedFieldUsage::unsupportedOperator($targetClass->name, $name, $operator);
+                }
+
+                $this->encryptHelper->assertQueryable($targetClass->name, $fieldMapping);
+            }
+
+            if ($operator === Comparison::IN || $operator === Comparison::NIN) {
                 $whereClauses[] = sprintf('te.%s %s (%s)', $field, $operator === Comparison::IN ? 'IN' : 'NOT IN', implode(', ', array_fill(0, count($value), '?')));
                 foreach ($value as $item) {
                     $params     = array_merge($params, PersisterHelper::convertToParameterValue($item, $this->em));
@@ -264,6 +283,18 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
                 $params     = [...$params, ...PersisterHelper::convertToParameterValue($value, $this->em)];
                 $paramTypes = [...$paramTypes, ...PersisterHelper::inferParameterTypes($name, $value, $targetClass, $this->em)];
+            }
+
+            if ($encrypt) {
+                $nowCountParams = count($params);
+
+                if ($nowCountParams > $countParams) {
+                    $querySetMapping->addEncryptedParameters(
+                        range($countParams, $nowCountParams - 1),
+                        $targetClass->name,
+                        $name,
+                    );
+                }
             }
         }
 
@@ -282,6 +313,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $sql .= $this->getOrderingSql($criteria, $targetClass);
 
         $sql .= $this->getLimitSql($criteria);
+
+        if (! $querySetMapping->isEmpty()) {
+            $this->encryptHelper->encryptParameters($querySetMapping, $params, $paramTypes);
+        }
 
         $stmt = $this->conn->executeQuery($sql, $params, $paramTypes);
 
@@ -750,6 +785,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
         if ($orderings) {
             $orderBy = [];
             foreach ($orderings as $name => $direction) {
+                if ($targetClass->fieldMappings[$name]->encrypt !== null) {
+                    throw UnsupportedEncryptedFieldUsage::orderBy($targetClass->name, $name);
+                }
+
                 $field = $this->quoteStrategy->getColumnName(
                     $name,
                     $targetClass,

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -16,6 +16,8 @@ use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Cache\Persister\CompatOrderings;
+use Doctrine\ORM\Encrypt\EncryptHelper;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -32,6 +34,7 @@ use Doctrine\ORM\Persisters\Exception\UnrecognizedField;
 use Doctrine\ORM\Persisters\SqlExpressionVisitor;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\EncryptedQuerySetMapping;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Repository\Exception\InvalidFindByCall;
 use Doctrine\ORM\UnitOfWork;
@@ -45,14 +48,19 @@ use function array_combine;
 use function array_diff_key;
 use function array_fill;
 use function array_flip;
+use function array_intersect_key;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_unique;
 use function array_values;
+use function array_walk;
 use function assert;
 use function count;
 use function implode;
+use function in_array;
 use function is_array;
+use function range;
 use function reset;
 use function spl_object_id;
 use function sprintf;
@@ -167,6 +175,8 @@ class BasicEntityPersister implements EntityPersister
     private readonly CachedPersisterContext $limitsHandlingContext;
     private readonly CachedPersisterContext $noLimitsContext;
 
+    private EncryptHelper $encryptHelper;
+
     private string|null $filterHash = null;
 
     /**
@@ -193,6 +203,7 @@ class BasicEntityPersister implements EntityPersister
             new Query\ResultSetMapping(),
             true,
         );
+        $this->encryptHelper         = $this->em->getEncryptHelper();
     }
 
     final protected function isFilterHashUpToDate(): bool
@@ -594,9 +605,10 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function prepareUpdateData(object $entity, bool $isInsert = false): array
     {
-        $versionField = null;
-        $result       = [];
-        $uow          = $this->em->getUnitOfWork();
+        $versionField    = null;
+        $result          = [];
+        $uow             = $this->em->getUnitOfWork();
+        $querySetMapping = new EncryptedQuerySetMapping();
 
         $versioned = $this->class->isVersioned;
         if ($versioned !== false) {
@@ -629,6 +641,10 @@ class BasicEntityPersister implements EntityPersister
                 $this->columnTypes[$columnName] = $fieldMapping->type;
 
                 $result[$this->getOwningTable($field)][$columnName] = $newVal;
+
+                if ($fieldMapping->encrypt !== null) {
+                    $querySetMapping->addEncryptedParameter($columnName, $this->class->name, $field);
+                }
 
                 continue;
             }
@@ -693,6 +709,15 @@ class BasicEntityPersister implements EntityPersister
                 $newValue                            = $newValId ? $newValId[$targetClass->getFieldForColumn($targetColumn)] : null;
                 $result[$owningTable][$sourceColumn] = $newValue instanceof BackedEnum ? $newValue->value : $newValue;
             }
+        }
+
+        if (! $querySetMapping->isEmpty()) {
+            $concatResult = array_merge(...array_values($result));
+            $this->encryptHelper->encryptParameters($querySetMapping, $concatResult, $this->columnTypes);
+
+            array_walk($result, static function (array &$values) use ($concatResult): void {
+                $values = array_intersect_key($concatResult, $values);
+            });
         }
 
         return $result;
@@ -904,7 +929,8 @@ class BasicEntityPersister implements EntityPersister
             return [$sqlParams, $sqlTypes];
         }
 
-        $valueVisitor = new SqlValueVisitor();
+        $valueVisitor    = new SqlValueVisitor();
+        $querySetMapping = new EncryptedQuerySetMapping();
 
         $valueVisitor->dispatch($expression);
 
@@ -915,6 +941,18 @@ class BasicEntityPersister implements EntityPersister
 
             if ($value === null && ($operator === Comparison::EQ || $operator === Comparison::NEQ)) {
                 continue;
+            }
+
+            $fieldMapping = $this->class->fieldMappings[$field] ?? null;
+            $encrypt      = $fieldMapping?->encrypt !== null;
+            $countParams  = count($sqlParams);
+
+            if ($encrypt) {
+                if (! in_array($operator, [Comparison::EQ, Comparison::NEQ, Comparison::IN, Comparison::NIN], true)) {
+                    throw UnsupportedEncryptedFieldUsage::unsupportedOperator($this->class->name, $field, $operator);
+                }
+
+                $this->encryptHelper->assertQueryable($this->class->name, $fieldMapping);
             }
 
             if ($operator === Comparison::IN || $operator === Comparison::NIN) {
@@ -937,11 +975,31 @@ class BasicEntityPersister implements EntityPersister
                     $sqlTypes  = [...$sqlTypes, ...PersisterHelper::inferParameterTypes($field, $item, $this->class, $this->em)];
                 }
 
+                if ($encrypt) {
+                    $nowCountParams = count($sqlParams);
+
+                    if ($nowCountParams > $countParams) {
+                        $querySetMapping->addEncryptedParameters(
+                            range($countParams, $nowCountParams - 1),
+                            $this->class->name,
+                            $field,
+                        );
+                    }
+                }
+
                 continue;
             }
 
             $sqlParams = [...$sqlParams, ...PersisterHelper::convertToParameterValue($value, $this->em)];
             $sqlTypes  = [...$sqlTypes, ...PersisterHelper::inferParameterTypes($field, $value, $this->class, $this->em)];
+
+            if ($encrypt) {
+                $querySetMapping->addEncryptedParameter($countParams, $this->class->name, $field);
+            }
+        }
+
+        if (! $querySetMapping->isEmpty()) {
+            $this->encryptHelper->encryptParameters($querySetMapping, $sqlParams, $sqlTypes);
         }
 
         return [$sqlParams, $sqlTypes];
@@ -1213,6 +1271,10 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if (isset($this->class->fieldMappings[$fieldName])) {
+                if ($this->class->fieldMappings[$fieldName]->encrypt !== null) {
+                    throw UnsupportedEncryptedFieldUsage::orderBy($this->class->name, $fieldName);
+                }
+
                 $tableAlias = isset($this->class->fieldMappings[$fieldName]->inherited)
                     ? $this->getSQLTableAlias($this->class->fieldMappings[$fieldName]->inherited)
                     : $baseTableAlias;
@@ -1881,12 +1943,21 @@ class BasicEntityPersister implements EntityPersister
      */
     public function expandParameters(array $criteria): array
     {
-        $params = [];
-        $types  = [];
+        $params          = [];
+        $types           = [];
+        $querySetMapping = new EncryptedQuerySetMapping();
 
         foreach ($criteria as $field => $value) {
             if ($value === null) {
                 continue; // skip null values.
+            }
+
+            $fieldMapping = $this->class->fieldMappings[$field] ?? null;
+            $encrypt      = $fieldMapping?->encrypt !== null;
+            $countParams  = count($params);
+
+            if ($encrypt) {
+                $this->encryptHelper->assertQueryable($this->class->name, $fieldMapping);
             }
 
             if (is_array($value)) {
@@ -1896,11 +1967,31 @@ class BasicEntityPersister implements EntityPersister
                     $params = [...$params, ...PersisterHelper::convertToParameterValue($item, $this->em)];
                 }
 
+                if ($encrypt) {
+                    $nowCountParams = count($params);
+
+                    if ($nowCountParams > $countParams) {
+                        $querySetMapping->addEncryptedParameters(
+                            range($countParams, $nowCountParams - 1),
+                            $this->class->name,
+                            $field,
+                        );
+                    }
+                }
+
                 continue;
             }
 
             $types  = [...$types, ...PersisterHelper::inferParameterTypes($field, $value, $this->class, $this->em)];
             $params = [...$params, ...PersisterHelper::convertToParameterValue($value, $this->em)];
+
+            if ($encrypt) {
+                $querySetMapping->addEncryptedParameter($countParams, $this->class->name, $field);
+            }
+        }
+
+        if (! $querySetMapping->isEmpty()) {
+            $this->encryptHelper->encryptParameters($querySetMapping, $params, $types);
         }
 
         return [$params, $types];
@@ -1920,16 +2011,41 @@ class BasicEntityPersister implements EntityPersister
      */
     private function expandToManyParameters(array $criteria): array
     {
-        $params = [];
-        $types  = [];
+        $params          = [];
+        $types           = [];
+        $querySetMapping = new EncryptedQuerySetMapping();
 
         foreach ($criteria as $criterion) {
             if ($criterion['value'] === null) {
                 continue; // skip null values.
             }
 
+            $fieldMapping = $criterion['class']->fieldMappings[$criterion['field']] ?? null;
+            $encrypt      = $fieldMapping?->encrypt !== null;
+            $countParams  = count($params);
+
+            if ($encrypt) {
+                $this->encryptHelper->assertQueryable($criterion['class']->name, $fieldMapping);
+            }
+
             $types  = [...$types, ...PersisterHelper::inferParameterTypes($criterion['field'], $criterion['value'], $criterion['class'], $this->em)];
             $params = [...$params, ...PersisterHelper::convertToParameterValue($criterion['value'], $this->em)];
+
+            if ($encrypt) {
+                $nowCountParams = count($params);
+
+                if ($nowCountParams > $countParams) {
+                    $querySetMapping->addEncryptedParameters(
+                        range($countParams, $nowCountParams - 1),
+                        $criterion['class']->name,
+                        $criterion['field'],
+                    );
+                }
+            }
+        }
+
+        if (! $querySetMapping->isEmpty()) {
+            $this->encryptHelper->encryptParameters($querySetMapping, $params, $types);
         }
 
         return [$params, $types];

--- a/src/Query.php
+++ b/src/Query.php
@@ -286,6 +286,12 @@ class Query extends AbstractQuery
 
         [$sqlParams, $types] = $this->processParameterMappings($paramMappings);
 
+        $querySetMapping = $this->parserResult->getEncryptedQuerySetMapping();
+
+        if (! $querySetMapping->isEmpty()) {
+            $this->em->getEncryptHelper()->encryptParameters($querySetMapping, $sqlParams, $types);
+        }
+
         $this->evictResultSetCache(
             $executor,
             $sqlParams,

--- a/src/Query/EncryptedQuerySetMapping.php
+++ b/src/Query/EncryptedQuerySetMapping.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query;
+
+/**
+ * An EncryptedQuerySetMapping describes which bind parameters of an SQL query target encrypted
+ * fields and therefore must be encrypted before execution.
+ *
+ * <b>Same as ResultSetMapping, Users should use the public methods.</b>
+ *
+ * @see ResultSetMapping
+ */
+class EncryptedQuerySetMapping
+{
+    /**
+     * Parameter positions (int) or column names (string), mapped to the encrypted field
+     * they are compared to or assigned to, as [declaring class, field name] tuples.
+     *
+     * @ignore
+     * @var array<int|string, array{class-string, string}>
+     */
+    public array $encryptedParameters = [];
+
+    /** @param class-string $class */
+    public function addEncryptedParameter(int|string $position, string $class, string $field): void
+    {
+        $this->encryptedParameters[$position] = [$class, $field];
+    }
+
+    /**
+     * @param list<int|string> $positions
+     * @param class-string     $class
+     */
+    public function addEncryptedParameters(array $positions, string $class, string $field): void
+    {
+        $tuple = [$class, $field];
+
+        foreach ($positions as $position) {
+            $this->encryptedParameters[$position] = $tuple;
+        }
+    }
+
+    /** @return array<int|string, array{class-string, string}> */
+    public function getEncryptedParameters(): array
+    {
+        return $this->encryptedParameters;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->encryptedParameters === [];
+    }
+}

--- a/src/Query/ParserResult.php
+++ b/src/Query/ParserResult.php
@@ -43,12 +43,27 @@ class ParserResult
     private array $parameterMappings = [];
 
     /**
+     * The EncryptedQuerySetMapping that describes which SQL parameters must be encrypted.
+     */
+    private EncryptedQuerySetMapping $encryptedQuerySetMapping;
+
+    /**
      * Initializes a new instance of the <tt>ParserResult</tt> class.
-     * The new instance is initialized with an empty <tt>ResultSetMapping</tt>.
+     * The new instance is initialized with an empty <tt>ResultSetMapping</tt>
+     * and an empty <tt>EncryptedQuerySetMapping</tt>.
      */
     public function __construct()
     {
-        $this->resultSetMapping = new ResultSetMapping();
+        $this->resultSetMapping         = new ResultSetMapping();
+        $this->encryptedQuerySetMapping = new EncryptedQuerySetMapping();
+    }
+
+    /**
+     * Gets the EncryptedQuerySetMapping for the parsed query.
+     */
+    public function getEncryptedQuerySetMapping(): EncryptedQuerySetMapping
+    {
+        return $this->encryptedQuerySetMapping;
     }
 
     /**

--- a/src/Query/ResultSetMapping.php
+++ b/src/Query/ResultSetMapping.php
@@ -194,6 +194,8 @@ class ResultSetMapping
      */
     public array $nestedEntities = [];
 
+    public bool $isDecryptDisabled = false;
+
     /**
      * Adds an entity result to this ResultSetMapping.
      *
@@ -587,6 +589,21 @@ class ResultSetMapping
         if ($type) {
             $this->typeMappings[$columnName] = $type;
         }
+
+        return $this;
+    }
+
+    public function isDecryptDisabled(): bool
+    {
+        return $this->isDecryptDisabled;
+    }
+
+    /**
+     * Use to disable decryption when manually create RSM and you want to get raw encrypted values.
+     */
+    public function disableDecrypt(): static
+    {
+        $this->isDecryptDisabled = true;
 
         return $this;
     }

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -10,8 +10,11 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Deprecations\Deprecation;
+use Doctrine\ORM\Encrypt\EncryptHelper;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
@@ -141,6 +144,8 @@ class SqlWalker
      */
     private readonly QuoteStrategy $quoteStrategy;
 
+    private readonly EncryptHelper $encryptHelper;
+
     /** @phpstan-param array<string, QueryComponent> $queryComponents The query components (symbol table). */
     public function __construct(
         private readonly Query $query,
@@ -152,6 +157,7 @@ class SqlWalker
         $this->conn          = $this->em->getConnection();
         $this->platform      = $this->conn->getDatabasePlatform();
         $this->quoteStrategy = $this->em->getConfiguration()->getQuoteStrategy();
+        $this->encryptHelper = $this->em->getEncryptHelper();
     }
 
     /**
@@ -1774,8 +1780,13 @@ class SqlWalker
         $useTableAliasesBefore    = $this->useSqlTableAliases;
         $this->useSqlTableAliases = false;
 
-        $sql      = $this->walkPathExpression($updateItem->pathExpression) . ' = ';
-        $newValue = $updateItem->newValue;
+        $sql       = $this->walkPathExpression($updateItem->pathExpression) . ' = ';
+        $newValue  = $updateItem->newValue;
+        $encrypted = $this->resolveEncryptedPathOperand($updateItem->pathExpression);
+
+        if ($encrypted !== null && $newValue !== null) {
+            $this->registerEncryptedOperand($newValue, $encrypted);
+        }
 
         $sql .= match (true) {
             $newValue instanceof AST\Node => $newValue->dispatch($this),
@@ -2040,9 +2051,22 @@ class SqlWalker
      */
     public function walkInListExpression(AST\InListExpression $inExpr): string
     {
+        $encrypted       = $this->resolveEncryptedPathOperand($inExpr->expression);
+        $walkInParameter = [$this, 'walkInParameter'];
+
+        if ($encrypted !== null) {
+            $this->encryptHelper->assertQueryable($encrypted[0]->name, $encrypted[1]);
+
+            $walkInParameter = function (mixed $literal) use ($encrypted): string {
+                $this->registerEncryptedOperand($literal, $encrypted);
+
+                return $this->walkInParameter($literal);
+            };
+        }
+
         return $this->walkArithmeticExpression($inExpr->expression)
             . ($inExpr->not ? ' NOT' : '') . ' IN ('
-            . implode(', ', array_map($this->walkInParameter(...), $inExpr->literals))
+            . implode(', ', array_map($walkInParameter(...), $inExpr->literals))
             . ')';
     }
 
@@ -2108,6 +2132,12 @@ class SqlWalker
      */
     public function walkBetweenExpression(AST\BetweenExpression $betweenExpr): string
     {
+        $encrypted = $this->resolveEncryptedPathOperand($betweenExpr->expression);
+
+        if ($encrypted !== null) {
+            throw UnsupportedEncryptedFieldUsage::unsupportedOperator($encrypted[0]->name, $encrypted[1]->fieldName, 'BETWEEN');
+        }
+
         $sql = $this->walkArithmeticExpression($betweenExpr->expression);
 
         if ($betweenExpr->not) {
@@ -2126,6 +2156,15 @@ class SqlWalker
     public function walkLikeExpression(AST\LikeExpression $likeExpr): string
     {
         $stringExpr = $likeExpr->stringExpression;
+
+        if (! is_string($stringExpr)) {
+            $encrypted = $this->resolveEncryptedPathOperand($stringExpr);
+
+            if ($encrypted !== null) {
+                throw UnsupportedEncryptedFieldUsage::unsupportedOperator($encrypted[0]->name, $encrypted[1]->fieldName, 'LIKE');
+            }
+        }
+
         if (is_string($stringExpr)) {
             if (! isset($this->queryComponents[$stringExpr]['resultVariable'])) {
                 throw new LogicException(sprintf('No result variable found for string expression "%s".', $stringExpr));
@@ -2168,6 +2207,8 @@ class SqlWalker
      */
     public function walkComparisonExpression(AST\ComparisonExpression $compExpr): string
     {
+        $this->validateEncryptedComparison($compExpr);
+
         $leftExpr  = $compExpr->leftExpression;
         $rightExpr = $compExpr->rightExpression;
         $sql       = '';
@@ -2183,6 +2224,100 @@ class SqlWalker
             : (is_numeric($rightExpr) ? $rightExpr : $this->conn->quote($rightExpr));
 
         return $sql;
+    }
+
+    /**
+     * Validates a comparison where one side is an encrypted field: only equality operators
+     * (=, <>, !=) are supported, and the other side must be a bound parameter, not a literal.
+     * Registers the parameter for encryption when valid.
+     */
+    private function validateEncryptedComparison(AST\ComparisonExpression $compExpr): void
+    {
+        $encrypted = $this->resolveEncryptedPathOperand($compExpr->leftExpression);
+        $otherSide = $compExpr->rightExpression;
+
+        if ($encrypted === null) {
+            $encrypted = $this->resolveEncryptedPathOperand($compExpr->rightExpression);
+            $otherSide = $compExpr->leftExpression;
+        }
+
+        if ($encrypted === null) {
+            return;
+        }
+
+        [$class, $fieldMapping] = $encrypted;
+
+        if (! in_array($compExpr->operator, ['=', '<>', '!='], true)) {
+            throw UnsupportedEncryptedFieldUsage::unsupportedOperator($class->name, $fieldMapping->fieldName, $compExpr->operator);
+        }
+
+        $this->encryptHelper->assertQueryable($class->name, $fieldMapping);
+
+        $this->registerEncryptedOperand($otherSide, $encrypted);
+    }
+
+    /**
+     * Resolves an operand to its class metadata and field mapping when it is a state field
+     * path to an encrypted field, null otherwise.
+     *
+     * @return array{ClassMetadata<object>, FieldMapping}|null
+     */
+    private function resolveEncryptedPathOperand(AST\Node|string $expr): array|null
+    {
+        $expr = $this->unwrapArithmeticOperand($expr);
+
+        if (
+            ! $expr instanceof AST\PathExpression
+            || $expr->type !== AST\PathExpression::TYPE_STATE_FIELD
+            || $expr->field === null
+        ) {
+            return null;
+        }
+
+        $class        = $this->getMetadataForDqlAlias($expr->identificationVariable);
+        $fieldMapping = $class->fieldMappings[$expr->field] ?? null;
+
+        if ($fieldMapping?->encrypt === null) {
+            return null;
+        }
+
+        return [$class, $fieldMapping];
+    }
+
+    /**
+     * The value side of a comparison/IN/SET involving an encrypted field: a DQL literal cannot
+     * be encrypted (it is inlined into the cached SQL), a bound parameter is registered for
+     * encryption at its current SQL position, anything else (e.g. another path) is left alone.
+     *
+     * @param array{ClassMetadata<object>, FieldMapping} $encrypted
+     */
+    private function registerEncryptedOperand(mixed $operand, array $encrypted): void
+    {
+        if ($operand instanceof AST\Node || is_string($operand)) {
+            $operand = $this->unwrapArithmeticOperand($operand);
+        }
+
+        if ($operand instanceof AST\Literal) {
+            throw UnsupportedEncryptedFieldUsage::literal($encrypted[0]->name, $encrypted[1]->fieldName);
+        }
+
+        if ($operand instanceof AST\InputParameter) {
+            $this->parserResult->getEncryptedQuerySetMapping()->addEncryptedParameter($this->sqlParamIndex, $encrypted[0]->name, $encrypted[1]->fieldName);
+        }
+    }
+
+    /**
+     * Unwraps the ArithmeticExpression wrapper around a comparison/IN/SET operand, exposing
+     * the bare node (PathExpression, InputParameter, Literal, ...) the parser's phase-1 AST
+     * optimization collapsed single-term expressions to.
+     */
+    private function unwrapArithmeticOperand(AST\Node|string $expr): AST\Node|string
+    {
+        return $expr instanceof AST\ArithmeticExpression
+            && $expr->isSimpleArithmeticExpression()
+            && $expr->simpleArithmeticExpression !== null
+            ? $expr->simpleArithmeticExpression
+            : $expr;
     }
 
     /**

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -570,7 +570,9 @@ class SchemaTool
         Table $table,
     ): void {
         $columnName = $this->quoteStrategy->getColumnName($mapping->fieldName, $class, $this->platform);
-        $columnType = $mapping->type;
+        $columnType = $mapping->encrypt !== null
+            ? $this->em->getEncryptHelper()->getStorageTypeName($mapping->encrypt)
+            : $mapping->type;
 
         $options            = [];
         $options['length']  = $mapping->length ?? null;
@@ -606,6 +608,11 @@ class SchemaTool
 
         // the 'default' option can be overwritten here
         $options = $this->gatherColumnOptions($mapping) + $options;
+
+        // An encrypted column store ciphertexts, not the plaintext values. Some options become irrelevant.
+        if ($mapping->encrypt !== null) {
+            unset($options['length'], $options['precision'], $options['scale'], $options['fixed'], $options['default']);
+        }
 
         if (isset($options['default']) && interface_exists(DefaultExpression::class)) {
             if (

--- a/tests/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
@@ -48,6 +49,11 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
     public function getMetadataFactory(): ClassMetadataFactory
     {
         return $this->realEntityManager->getMetadataFactory();
+    }
+
+    public function getEncryptHelper(): EncryptHelper
+    {
+        return $this->realEntityManager->getEncryptHelper();
     }
 
     public function getClassMetadata(string $className): ClassMetadata

--- a/tests/Tests/Mocks/Encrypt/Cipher/CipherMock.php
+++ b/tests/Tests/Mocks/Encrypt/Cipher/CipherMock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+
+final class CipherMock implements Cipher
+{
+    public function encrypt(string $plaintext, KeyProvider $keyProvider): string
+    {
+        return $plaintext;
+    }
+
+    public function decrypt(string $envelope, KeyProvider $keyProvider): string
+    {
+        return $envelope;
+    }
+
+    public function extractKeyId(string $envelope): string
+    {
+        return 'mock-key';
+    }
+
+    public function isDeterministic(): bool
+    {
+        return false;
+    }
+
+    public function isBinary(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Tests/Mocks/Encrypt/Cipher/CipherRegistryMock.php
+++ b/tests/Tests/Mocks/Encrypt/Cipher/CipherRegistryMock.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\AbstractCipherRegistry;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+
+final class CipherRegistryMock extends AbstractCipherRegistry
+{
+    public Cipher $default;
+    public Cipher $a;
+    public Cipher $b;
+
+    public function __construct(string $defaultCipherName = 'alias')
+    {
+        $this->default = new CipherMock();
+        $this->a       = new CipherMock();
+        $this->b       = new CipherMock();
+
+        parent::__construct([
+            'alias' => 'service.default',
+            'alias-a' => 'service.a',
+            'alias-b' => 'service.b',
+        ], $defaultCipherName);
+    }
+
+    protected function getService(string $name): Cipher
+    {
+        return match ($name) {
+            'service.default' => $this->default,
+            'service.a' => $this->a,
+            'service.b' => $this->b,
+        };
+    }
+}

--- a/tests/Tests/Mocks/Encrypt/KMS/KeyProviderMock.php
+++ b/tests/Tests/Mocks/Encrypt/KMS/KeyProviderMock.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\Key;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+
+final class KeyProviderMock implements KeyProvider
+{
+    public function __construct(
+        private readonly string $keyMaterial,
+    ) {
+    }
+
+    public function getEncryptionKey(): Key
+    {
+        return new Key('current', $this->keyMaterial);
+    }
+
+    public function getDecryptionKey(int|string $id): Key
+    {
+        return new Key($id, $this->keyMaterial);
+    }
+}

--- a/tests/Tests/Mocks/Encrypt/KMS/KeyProviderRegistryMock.php
+++ b/tests/Tests/Mocks/Encrypt/KMS/KeyProviderRegistryMock.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mocks\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\AbstractKeyProviderRegistry;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+
+class KeyProviderRegistryMock extends AbstractKeyProviderRegistry
+{
+    public KeyProvider $default;
+    public KeyProvider $a;
+    public KeyProvider $b;
+
+    public function __construct(string $defaultKeyProviderName = 'alias')
+    {
+        $this->default = new KeyProviderMock('secret');
+        $this->a       = new KeyProviderMock('a');
+        $this->b       = new KeyProviderMock('b');
+
+        parent::__construct([
+            'alias' => 'service.default',
+            'alias-a' => 'service.a',
+            'alias-b' => 'service.b',
+        ], $defaultKeyProviderName);
+    }
+
+    protected function getService(string $name): KeyProvider
+    {
+        return match ($name) {
+            'service.default' => $this->default,
+            'service.a' => $this->a,
+            'service.b' => $this->b,
+        };
+    }
+}

--- a/tests/Tests/Models/Encrypt/EncryptCustomer.php
+++ b/tests/Tests/Models/Encrypt/EncryptCustomer.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Encrypt;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Encrypt;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinTable;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'encrypt_customers')]
+#[Entity]
+class EncryptCustomer
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public int|null $id = null;
+
+    #[Column(type: 'string', length: 255)]
+    public string $name;
+
+    #[Column(type: 'string', length: 255)]
+    #[Encrypt(cipher: 'deterministic', queryType: EncryptQuery::Equality)]
+    public string $ssn;
+
+    #[Column(type: 'string', length: 255)]
+    #[Encrypt]
+    public string $note;
+
+    /** @var Collection<int, EncryptGroup> */
+    #[ManyToMany(targetEntity: EncryptGroup::class, fetch: 'EXTRA_LAZY')]
+    #[JoinTable(name: 'encrypt_customers_groups')]
+    public Collection $groups;
+
+    public function __construct()
+    {
+        $this->groups = new ArrayCollection();
+    }
+}

--- a/tests/Tests/Models/Encrypt/EncryptEmployee.php
+++ b/tests/Tests/Models/Encrypt/EncryptEmployee.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Encrypt;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'encrypt_employees')]
+#[Entity]
+class EncryptEmployee extends EncryptPerson
+{
+    #[Column(type: 'string', length: 255)]
+    public string $department;
+}

--- a/tests/Tests/Models/Encrypt/EncryptGroup.php
+++ b/tests/Tests/Models/Encrypt/EncryptGroup.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Encrypt;
+
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Encrypt;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'encrypt_groups')]
+#[Entity]
+class EncryptGroup
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public int|null $id = null;
+
+    #[Column(type: 'string', length: 255)]
+    #[Encrypt(cipher: 'deterministic', queryType: EncryptQuery::Equality)]
+    public string $name;
+
+    #[Column(type: 'string', length: 255, nullable: true)]
+    #[Encrypt]
+    public string|null $motto = null;
+}

--- a/tests/Tests/Models/Encrypt/EncryptPerson.php
+++ b/tests/Tests/Models/Encrypt/EncryptPerson.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Encrypt;
+
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Encrypt;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Table;
+
+#[Table(name: 'encrypt_persons')]
+#[Entity]
+#[InheritanceType('JOINED')]
+#[DiscriminatorColumn(name: 'discr', type: 'string')]
+#[DiscriminatorMap(['person' => EncryptPerson::class, 'employee' => EncryptEmployee::class])]
+class EncryptPerson
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: 'integer')]
+    public int|null $id = null;
+
+    #[Column(type: 'string', length: 255)]
+    #[Encrypt(cipher: 'deterministic', queryType: EncryptQuery::Equality)]
+    public string $secret;
+}

--- a/tests/Tests/Models/Encrypt/EncryptTypesEntity.php
+++ b/tests/Tests/Models/Encrypt/EncryptTypesEntity.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\Encrypt;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Encrypt;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * One nullable encrypted field per DBAL built-in type, for round-trip coverage of the
+ * conversion pipeline (plaintext -> DB value -> encrypt -> decrypt -> PHP value).
+ */
+#[Table(name: 'encrypt_types')]
+#[Entity]
+class EncryptTypesEntity
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column(type: Types::INTEGER)]
+    public int|null $id = null;
+
+    #[Column(type: Types::ASCII_STRING, length: 255, nullable: true)]
+    #[Encrypt]
+    public mixed $asciiStringValue = null;
+
+    #[Column(type: Types::BIGINT, nullable: true)]
+    #[Encrypt]
+    public mixed $bigintValue = null;
+
+    #[Column(type: Types::BINARY, nullable: true)]
+    #[Encrypt]
+    public mixed $binaryValue = null;
+
+    #[Column(type: Types::BLOB, nullable: true)]
+    #[Encrypt]
+    public mixed $blobValue = null;
+
+    #[Column(type: Types::BOOLEAN, nullable: true)]
+    #[Encrypt]
+    public mixed $booleanValue = null;
+
+    #[Column(type: Types::DATE_MUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $dateValue = null;
+
+    #[Column(type: Types::DATE_IMMUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $dateImmutableValue = null;
+
+    #[Column(type: Types::DATEINTERVAL, nullable: true)]
+    #[Encrypt]
+    public mixed $dateintervalValue = null;
+
+    #[Column(type: Types::DATETIME_MUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $datetimeValue = null;
+
+    #[Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $datetimeImmutableValue = null;
+
+    #[Column(type: Types::DATETIMETZ_MUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $datetimetzValue = null;
+
+    #[Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $datetimetzImmutableValue = null;
+
+    #[Column(type: Types::DECIMAL, precision: 10, scale: 2, nullable: true)]
+    #[Encrypt]
+    public mixed $decimalValue = null;
+
+    #[Column(type: Types::NUMBER, precision: 10, scale: 2, nullable: true)]
+    #[Encrypt]
+    public mixed $numberValue = null;
+
+    #[Column(type: Types::FLOAT, nullable: true)]
+    #[Encrypt]
+    public mixed $floatValue = null;
+
+    #[Column(type: Types::ENUM, nullable: true, options: ['values' => ['hearts', 'spades']])]
+    #[Encrypt]
+    public mixed $enumValue = null;
+
+    #[Column(type: Types::GUID, nullable: true)]
+    #[Encrypt]
+    public mixed $guidValue = null;
+
+    #[Column(type: Types::INTEGER, nullable: true)]
+    #[Encrypt]
+    public mixed $integerValue = null;
+
+    #[Column(type: Types::JSON, nullable: true)]
+    #[Encrypt]
+    public mixed $jsonValue = null;
+
+    #[Column(type: Types::JSON_OBJECT, nullable: true)]
+    #[Encrypt]
+    public mixed $jsonObjectValue = null;
+
+    #[Column(type: Types::JSONB, nullable: true)]
+    #[Encrypt]
+    public mixed $jsonbValue = null;
+
+    #[Column(type: Types::JSONB_OBJECT, nullable: true)]
+    #[Encrypt]
+    public mixed $jsonbObjectValue = null;
+
+    #[Column(type: Types::SIMPLE_ARRAY, nullable: true)]
+    #[Encrypt]
+    public mixed $simpleArrayValue = null;
+
+    #[Column(type: Types::SMALLFLOAT, nullable: true)]
+    #[Encrypt]
+    public mixed $smallfloatValue = null;
+
+    #[Column(type: Types::SMALLINT, nullable: true)]
+    #[Encrypt]
+    public mixed $smallintValue = null;
+
+    #[Column(type: Types::STRING, length: 255, nullable: true)]
+    #[Encrypt]
+    public mixed $stringValue = null;
+
+    #[Column(type: Types::TEXT, nullable: true)]
+    #[Encrypt]
+    public mixed $textValue = null;
+
+    #[Column(type: Types::TIME_MUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $timeValue = null;
+
+    #[Column(type: Types::TIME_IMMUTABLE, nullable: true)]
+    #[Encrypt]
+    public mixed $timeImmutableValue = null;
+}

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
+use Doctrine\ORM\Encrypt\KMS\KeyProviderRegistry;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Mapping as MappingNamespace;
@@ -103,6 +105,24 @@ class ConfigurationTest extends TestCase
         $cache = $this->createStub(CacheItemPoolInterface::class);
         $this->configuration->setMetadataCache($cache);
         self::assertSame($cache, $this->configuration->getMetadataCache());
+    }
+
+    public function testSetGetCipherRegistry(): void
+    {
+        self::assertNull($this->configuration->getCipherRegistry()); // defaults
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $this->configuration->setCipherRegistry($cipherRegistry);
+        self::assertSame($cipherRegistry, $this->configuration->getCipherRegistry());
+    }
+
+    public function testSetGetKeyProviderRegistry(): void
+    {
+        self::assertNull($this->configuration->getKeyProviderRegistry()); // defaults
+
+        $keyProviderRegistry = $this->createStub(KeyProviderRegistry::class);
+        $this->configuration->setKeyProviderRegistry($keyProviderRegistry);
+        self::assertSame($keyProviderRegistry, $this->configuration->getKeyProviderRegistry());
     }
 
     public function testAddGetCustomStringFunction(): void

--- a/tests/Tests/ORM/Encrypt/Cipher/AbstractCipherRegistryTest.php
+++ b/tests/Tests/ORM/Encrypt/Cipher/AbstractCipherRegistryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\AbstractCipherRegistry;
+use Doctrine\ORM\Encrypt\Cipher\Exception\UnknownCipher;
+use Doctrine\Tests\Mocks\Encrypt\Cipher\CipherRegistryMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractCipherRegistry::class)]
+final class AbstractCipherRegistryTest extends TestCase
+{
+    public function testGetDefaultCipher(): void
+    {
+        $registry = new CipherRegistryMock();
+
+        self::assertSame('alias', $registry->getDefaultCipherName());
+        self::assertEquals($registry->default, $registry->getCipher());
+    }
+
+    public function testGetCipher(): void
+    {
+        $registry = new CipherRegistryMock();
+
+        self::assertEquals($registry->default, $registry->getCipher('alias'));
+        self::assertEquals($registry->a, $registry->getCipher('alias-a'));
+        self::assertEquals($registry->b, $registry->getCipher('alias-b'));
+    }
+
+    public function testGetCipherUnknown(): void
+    {
+        $this->expectException(UnknownCipher::class);
+        $this->expectExceptionMessage('Unknown cipher "missing". Known ciphers: "alias", "alias-a", "alias-b".');
+
+        (new CipherRegistryMock())->getCipher('missing');
+    }
+
+    public function testGetCipherUnknownDefault(): void
+    {
+        $this->expectException(UnknownCipher::class);
+        $this->expectExceptionMessage('Unknown cipher "missing". Known ciphers: "alias", "alias-a", "alias-b".');
+
+        new CipherRegistryMock('missing');
+    }
+
+    public function testGetCipherNamesReturnsAliases(): void
+    {
+        self::assertSame(['alias', 'alias-a', 'alias-b'], (new CipherRegistryMock())->getCipherNames());
+    }
+
+    public function testGetCiphersReturnsAllIndexedByAlias(): void
+    {
+        $registry = new CipherRegistryMock();
+
+        self::assertSame(
+            ['alias' => $registry->default, 'alias-a' => $registry->a, 'alias-b' => $registry->b],
+            $registry->getCiphers(),
+        );
+    }
+}

--- a/tests/Tests/ORM/Encrypt/Cipher/OpenSSLCipherTest.php
+++ b/tests/Tests/ORM/Encrypt/Cipher/OpenSSLCipherTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt\Cipher;
+
+use Doctrine\ORM\Encrypt\Cipher\Exception\DecryptionFailed;
+use Doctrine\ORM\Encrypt\Cipher\Exception\EncryptionFailed;
+use Doctrine\ORM\Encrypt\Cipher\OpenSSLCipher;
+use Doctrine\ORM\Encrypt\KMS\ArraySymmetricKeyProvider;
+use Doctrine\ORM\Encrypt\KMS\Key;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function random_bytes;
+use function strlen;
+use function substr;
+
+#[CoversClass(OpenSSLCipher::class)]
+final class OpenSSLCipherTest extends TestCase
+{
+    /** @return iterable<string, array{string, int}> */
+    public static function algorithmsProvider(): iterable
+    {
+        yield OpenSSLCipher::AES_128_GCM => [OpenSSLCipher::AES_128_GCM, 16];
+        yield OpenSSLCipher::AES_192_GCM => [OpenSSLCipher::AES_192_GCM, 24];
+        yield OpenSSLCipher::AES_256_GCM => [OpenSSLCipher::AES_256_GCM, 32];
+    }
+
+    /** @param positive-int $keyLength */
+    #[DataProvider('algorithmsProvider')]
+    public function testEncryptDecryptSupportedAlgorithm(string $algorithm, int $keyLength): void
+    {
+        $cipher   = new OpenSSLCipher($algorithm);
+        $provider = $this->getKeyProvider($keyLength);
+
+        $envelope = $cipher->encrypt('hello world', $provider);
+
+        self::assertNotSame('hello world', $envelope);
+        self::assertSame('hello world', $cipher->decrypt($envelope, $provider));
+    }
+
+    public function testNotDeterministic(): void
+    {
+        $cipher   = new OpenSSLCipher(deterministic: false);
+        $provider = $this->getKeyProvider();
+
+        self::assertNotSame(
+            $cipher->encrypt('hello world', $provider),
+            $cipher->encrypt('hello world', $provider),
+        );
+    }
+
+    public function testDeterministic(): void
+    {
+        $cipher   = new OpenSSLCipher(deterministic: true);
+        $provider = $this->getKeyProvider();
+
+        self::assertSame(
+            $cipher->encrypt('hello world', $provider),
+            $cipher->encrypt('hello world', $provider),
+        );
+    }
+
+    public function testDeterministicDifferentPlaintext(): void
+    {
+        $cipher   = new OpenSSLCipher(deterministic: true);
+        $provider = $this->getKeyProvider();
+
+        self::assertNotSame(
+            $cipher->encrypt('hello world', $provider),
+            $cipher->encrypt('goodbye world', $provider),
+        );
+    }
+
+    public function testDecryptAfterRotatedKey(): void
+    {
+        $cipher = new OpenSSLCipher();
+        $keyV1  = new Key('v1', random_bytes(32));
+        $keyV2  = new Key('v2', random_bytes(32));
+
+        $envelope = $cipher->encrypt('hello world', new ArraySymmetricKeyProvider(['v1' => $keyV1]));
+
+        $rotatedProvider = new ArraySymmetricKeyProvider(['v1' => $keyV1, 'v2' => $keyV2]);
+
+        self::assertSame('hello world', $cipher->decrypt($envelope, $rotatedProvider));
+    }
+
+    public function testExtractKeyId(): void
+    {
+        $cipher   = new OpenSSLCipher();
+        $provider = $this->getKeyProvider();
+
+        $envelope = $cipher->encrypt('hello world', $provider);
+
+        self::assertSame('v1', $cipher->extractKeyId($envelope));
+    }
+
+    public function testExtractKeyIdRejectsTooShortEnvelope(): void
+    {
+        $this->expectException(DecryptionFailed::class);
+        $this->expectExceptionMessage('Invalid ciphertext envelope: value is shorter than the minimum envelope size.');
+
+        (new OpenSSLCipher())->extractKeyId('x');
+    }
+
+    public function testConstructorUnsupportedAlgorithm(): void
+    {
+        $this->expectException(LogicException::class);
+
+        new OpenSSLCipher('aes-256-cbc');
+    }
+
+    public function testEncryptWrongKeyLength(): void
+    {
+        $cipher   = new OpenSSLCipher('aes-256-gcm');
+        $provider = new ArraySymmetricKeyProvider(['v1' => new Key('v1', 'too-short')]);
+
+        $this->expectException(EncryptionFailed::class);
+        $this->expectExceptionMessage('Encryption failed: Expected a 32-byte key, got 9 bytes.');
+
+        $cipher->encrypt('hello world', $provider);
+    }
+
+    public function testEncryptEmptyKeyId(): void
+    {
+        $cipher   = new OpenSSLCipher();
+        $provider = new ArraySymmetricKeyProvider(['' => new Key('', random_bytes(32))]);
+
+        $this->expectException(EncryptionFailed::class);
+        $this->expectExceptionMessage('Encryption failed: Key id must be a non-empty string of at most 255 UTF-8 bytes, got 0 bytes.');
+
+        $cipher->encrypt('hello world', $provider);
+    }
+
+    public function testDecryptTooShortEnvelope(): void
+    {
+        $cipher   = new OpenSSLCipher();
+        $provider = $this->getKeyProvider();
+
+        $this->expectException(DecryptionFailed::class);
+        $this->expectExceptionMessage('Invalid ciphertext envelope: value is shorter than the minimum envelope size.');
+
+        $cipher->decrypt('x', $provider);
+    }
+
+    public function testDecryptTamperedCiphertext(): void
+    {
+        $cipher   = new OpenSSLCipher();
+        $provider = $this->getKeyProvider();
+
+        $envelope = $cipher->encrypt('hello world', $provider);
+        $lastByte = $envelope[strlen($envelope) - 1];
+        $flipped  = $lastByte === "\x00" ? "\x01" : "\x00";
+        $tampered = substr($envelope, 0, -1) . $flipped;
+
+        $this->expectException(DecryptionFailed::class);
+        $this->expectExceptionMessage('Decryption failed: unknown error');
+
+        $cipher->decrypt($tampered, $provider);
+    }
+
+    public function testDecryptRejectsWrongKey(): void
+    {
+        $cipher = new OpenSSLCipher();
+
+        $envelope = $cipher->encrypt('hello world', $this->getKeyProvider());
+
+        $wrongKeyProvider = $this->getKeyProvider();
+
+        $this->expectException(DecryptionFailed::class);
+        $this->expectExceptionMessage('Decryption failed: unknown error');
+
+        $cipher->decrypt($envelope, $wrongKeyProvider);
+    }
+
+    public function testIsDeterministic(): void
+    {
+        self::assertFalse((new OpenSSLCipher())->isDeterministic());
+        self::assertFalse((new OpenSSLCipher(deterministic: false))->isDeterministic());
+        self::assertTrue((new OpenSSLCipher(deterministic: true))->isDeterministic());
+    }
+
+    public function testIsBinary(): void
+    {
+        self::assertTrue((new OpenSSLCipher())->isBinary());
+    }
+
+    private function getKeyProvider(int $keyLength = 32): KeyProvider
+    {
+        return new ArraySymmetricKeyProvider(['v1' => new Key('v1', random_bytes($keyLength))]);
+    }
+}

--- a/tests/Tests/ORM/Encrypt/EncryptHelperTest.php
+++ b/tests/Tests/ORM/Encrypt/EncryptHelperTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Encrypt\Cipher\BatchableCipher;
 use Doctrine\ORM\Encrypt\Cipher\Cipher;
 use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
 use Doctrine\ORM\Encrypt\EncryptHelper;
@@ -27,6 +28,8 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+
+use function array_map;
 
 #[CoversClass(EncryptHelper::class)]
 #[CoversClass(EncryptedQuerySetMapping::class)]
@@ -476,6 +479,121 @@ final class EncryptHelperTest extends TestCase
         self::assertSame(['enc(active)', 'enc(joe)'], $params);
     }
 
+    public function testEncryptParametersUsesBatchableCipherEncryptManyWhenAvailable(): void
+    {
+        $cipher = $this->createBatchableEncryptCipher();
+        $cipher->expects(self::once())
+            ->method('encryptMany')
+            ->with(['0' => 'active', '1' => 'joe']);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $classMetadata = $this->createClassMetadata();
+
+        $nameMapping          = new FieldMapping('string', 'name', 'name');
+        $nameMapping->encrypt = new EncryptMapping();
+
+        $classMetadata->fieldMappings['name'] = $nameMapping;
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $classMetadata,
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+        $querySetMapping->addEncryptedParameter(1, CmsUser::class, 'name');
+
+        $params = ['active', 'joe'];
+        $types  = ['string', 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(active)', 'enc(joe)'], $params);
+    }
+
+    public function testEncryptParametersBatchableCipherHandlesArrayExpansionParameters(): void
+    {
+        $cipher = $this->createBatchableEncryptCipher();
+        $cipher->expects(self::once())
+            ->method('encryptMany')
+            ->with(['0:0' => 'active', '0:1' => 'inactive']);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = [['active', 'inactive']];
+        $types  = [ArrayParameterType::STRING];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame([['enc(active)', 'enc(inactive)']], $params);
+    }
+
+    public function testEncryptParametersBatchableCipherSkipsNullValuesInBatchCall(): void
+    {
+        $cipher = $this->createBatchableEncryptCipher();
+        $cipher->expects(self::once())
+            ->method('encryptMany')
+            ->with(['0' => 'active']);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+        $querySetMapping->addEncryptedParameter(1, CmsUser::class, 'status');
+
+        $params = ['active', null];
+        $types  = ['string', 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(active)', null], $params);
+    }
+
+    public function testEncryptParametersBatchableCipherNotCalledWhenAllValuesAreNull(): void
+    {
+        $cipher = $this->createBatchableEncryptCipher();
+        $cipher->expects(self::never())->method('encryptMany');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = [null];
+        $types  = ['string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame([null], $params);
+    }
+
     /** @return iterable<string, array{array<string, mixed>, array<string, mixed>}> */
     public static function decryptRowProvider(): iterable
     {
@@ -571,6 +689,76 @@ final class EncryptHelperTest extends TestCase
         self::assertSame(['status_1' => 'dec(enc(active))', 'name_2' => 'dec(enc(joe))'], $row);
     }
 
+    public function testDecryptRowUsesBatchableCipherDecryptManyWhenAvailable(): void
+    {
+        $cipher = $this->createBatchableDecryptCipher();
+        $cipher->expects(self::once())
+            ->method('decryptMany')
+            ->with(['status_1' => 'enc(active)', 'name_2' => 'enc(joe)']);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+        ));
+
+        $row = ['status_1' => 'enc(active)', 'name_2' => 'enc(joe)'];
+
+        $encryptHelper->decryptRow(
+            ['status_1' => new EncryptMapping(), 'name_2' => new EncryptMapping()],
+            $row,
+        );
+
+        self::assertSame(['status_1' => 'dec(enc(active))', 'name_2' => 'dec(enc(joe))'], $row);
+    }
+
+    public function testDecryptRowBatchableCipherSkipsNullValuesInBatchCall(): void
+    {
+        $cipher = $this->createBatchableDecryptCipher();
+        $cipher->expects(self::once())
+            ->method('decryptMany')
+            ->with(['status_1' => 'enc(active)']);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+        ));
+
+        $row = ['status_1' => 'enc(active)', 'name_2' => null];
+
+        $encryptHelper->decryptRow(
+            ['status_1' => new EncryptMapping(), 'name_2' => new EncryptMapping()],
+            $row,
+        );
+
+        self::assertSame(['status_1' => 'dec(enc(active))', 'name_2' => null], $row);
+    }
+
+    public function testDecryptRowBatchableCipherNotCalledWhenAllValuesAreNull(): void
+    {
+        $cipher = $this->createBatchableDecryptCipher();
+        $cipher->expects(self::never())->method('decryptMany');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+        ));
+
+        $row = ['status_1' => null];
+
+        $encryptHelper->decryptRow(['status_1' => new EncryptMapping()], $row);
+
+        self::assertSame(['status_1' => null], $row);
+    }
+
     public function testDecryptRowThrowsWhenKeyProviderRegistryNotConfigured(): void
     {
         $encryptHelper = new EncryptHelper($this->createEntityManager($this->createDecryptCipherRegistry()));
@@ -626,6 +814,36 @@ final class EncryptHelperTest extends TestCase
         $cipherRegistry->method('getCipher')->willReturn($this->createDecryptCipher());
 
         return $cipherRegistry;
+    }
+
+    private function createBatchableEncryptCipher(): BatchableCipher
+    {
+        $cipher = $this->createMock(BatchableCipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->expects(self::never())->method('encrypt');
+        $cipher->method('encryptMany')->willReturnCallback(
+            static fn (array $plaintexts): array => array_map(
+                static fn (string $plaintext): string => 'enc(' . $plaintext . ')',
+                $plaintexts,
+            ),
+        );
+
+        return $cipher;
+    }
+
+    private function createBatchableDecryptCipher(): BatchableCipher
+    {
+        $cipher = $this->createMock(BatchableCipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->expects(self::never())->method('decrypt');
+        $cipher->method('decryptMany')->willReturnCallback(
+            static fn (array $ciphertexts): array => array_map(
+                static fn (string $ciphertext): string => 'dec(' . $ciphertext . ')',
+                $ciphertexts,
+            ),
+        );
+
+        return $cipher;
     }
 
     private function createKeyProviderRegistry(): KeyProviderRegistry

--- a/tests/Tests/ORM/Encrypt/EncryptHelperTest.php
+++ b/tests/Tests/ORM/Encrypt/EncryptHelperTest.php
@@ -1,0 +1,676 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
+use Doctrine\ORM\Encrypt\EncryptHelper;
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Encrypt\Exception\EncryptConfigurationMissing;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use Doctrine\ORM\Encrypt\KMS\KeyProviderRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\EncryptMapping;
+use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Query\EncryptedQuerySetMapping;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EncryptHelper::class)]
+#[CoversClass(EncryptedQuerySetMapping::class)]
+final class EncryptHelperTest extends TestCase
+{
+    /** @return iterable<string, array{bool, string}> */
+    public static function storageTypeNameProvider(): iterable
+    {
+        yield 'binary cipher' => [true, 'blob'];
+        yield 'non-binary cipher' => [false, 'text'];
+    }
+
+    #[DataProvider('storageTypeNameProvider')]
+    public function testGetStorageTypeName(bool $isBinary, string $expected): void
+    {
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager($this->createCipherRegistry(isBinary: $isBinary)));
+
+        self::assertSame($expected, $fieldEncryptor->getStorageTypeName(new EncryptMapping()));
+    }
+
+    public function testGetStorageTypeNameResolvesCipherByMappingCipherName(): void
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(true);
+
+        $cipherRegistry = $this->createMock(CipherRegistry::class);
+        $cipherRegistry->expects(self::once())
+            ->method('getCipher')
+            ->with('my-cipher')
+            ->willReturn($cipher);
+
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager($cipherRegistry));
+
+        $encryptMapping         = new EncryptMapping();
+        $encryptMapping->cipher = 'my-cipher';
+
+        self::assertSame('blob', $fieldEncryptor->getStorageTypeName($encryptMapping));
+    }
+
+    public function testGetStorageTypeNameCipherRegistryNotConfigured(): void
+    {
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager(null));
+
+        $this->expectException(EncryptConfigurationMissing::class);
+        $this->expectExceptionMessage('Cipher registry is not configured. Call Configuration::setCipherRegistry() to set it.');
+
+        $fieldEncryptor->getStorageTypeName(new EncryptMapping());
+    }
+
+    public function testAssertQueryableThrowsWhenQueryTypeMissing(): void
+    {
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager($this->createCipherRegistry(isBinary: false)));
+
+        $fieldMapping          = new FieldMapping('string', 'status', 'status');
+        $fieldMapping->encrypt = new EncryptMapping();
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage('CmsUser::$status is encrypted; filtering by an encrypted field without queryType set is not supported.');
+
+        $fieldEncryptor->assertQueryable('CmsUser', $fieldMapping);
+    }
+
+    public function testAssertQueryableCipherNotDeterministic(): void
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isDeterministic')->willReturn(false);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager($cipherRegistry));
+
+        $fieldMapping                     = new FieldMapping('string', 'status', 'status');
+        $fieldMapping->encrypt            = new EncryptMapping();
+        $fieldMapping->encrypt->queryType = EncryptQuery::Equality;
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage('CmsUser::$status is encrypted; filtering by an encrypted field using non deterministic cipher is not supported.');
+
+        $fieldEncryptor->assertQueryable('CmsUser', $fieldMapping);
+    }
+
+    public function testAssertQueryable(): void
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isDeterministic')->willReturn(true);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $fieldEncryptor = new EncryptHelper($this->createEntityManager($cipherRegistry));
+
+        $fieldMapping                     = new FieldMapping('string', 'status', 'status');
+        $fieldMapping->encrypt            = new EncryptMapping();
+        $fieldMapping->encrypt->queryType = EncryptQuery::Equality;
+
+        $fieldEncryptor->assertQueryable('CmsUser', $fieldMapping);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testDoesClassContainEncrypt(): void
+    {
+        $statusMapping          = new FieldMapping('string', 'status', 'status');
+        $statusMapping->encrypt = new EncryptMapping();
+
+        $classMetadata                          = new ClassMetadata(CmsUser::class);
+        $classMetadata->fieldMappings['status'] = $statusMapping;
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn($classMetadata);
+
+        $encryptHelper = new EncryptHelper($em);
+
+        self::assertTrue($encryptHelper->doesClassContainEncrypt(CmsUser::class));
+    }
+
+    public function testDoesClassContainEncryptFalse(): void
+    {
+        $classMetadata                            = new ClassMetadata(CmsUser::class);
+        $classMetadata->fieldMappings['username'] = new FieldMapping('string', 'username', 'username');
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn($classMetadata);
+
+        $encryptHelper = new EncryptHelper($em);
+
+        self::assertFalse($encryptHelper->doesClassContainEncrypt(CmsUser::class));
+    }
+
+    public function testDoesRsmContainEncrypt(): void
+    {
+        $classMetadata          = new ClassMetadata(CmsUser::class);
+        $classMetadata->encrypt = new EncryptMapping();
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn($classMetadata);
+
+        $rsm                             = new ResultSetMapping();
+        $rsm->declaringClasses['status'] = CmsUser::class;
+
+        $encryptHelper = new EncryptHelper($em);
+
+        self::assertTrue($encryptHelper->doesRsmContainEncrypt($rsm));
+    }
+
+    public function testDoesRsmContainEncryptFalse(): void
+    {
+        $classMetadata = new ClassMetadata(CmsUser::class);
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn($classMetadata);
+
+        $rsm                               = new ResultSetMapping();
+        $rsm->declaringClasses['username'] = CmsUser::class;
+
+        $encryptHelper = new EncryptHelper($em);
+
+        self::assertFalse($encryptHelper->doesRsmContainEncrypt($rsm));
+    }
+
+    public function testEncryptedQuerySetMappingIsEmptyIsTrueUntilFirstParameter(): void
+    {
+        $querySetMapping = new EncryptedQuerySetMapping();
+
+        self::assertTrue($querySetMapping->isEmpty());
+
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        self::assertFalse($querySetMapping->isEmpty());
+    }
+
+    public function testEncryptedQuerySetMappingAddEncryptedParametersRegistersEachPosition(): void
+    {
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameters([0, 2, 'named'], CmsUser::class, 'status');
+
+        self::assertSame([
+            0 => [CmsUser::class, 'status'],
+            2 => [CmsUser::class, 'status'],
+            'named' => [CmsUser::class, 'status'],
+        ], $querySetMapping->getEncryptedParameters());
+    }
+
+    public function testEncryptParametersEncryptsOnlyMappedIndexesAndSetsStorageType(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = ['active', 'joe'];
+        $types  = ['string', 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(active)', 'joe'], $params);
+        self::assertSame(['text', 'string'], $types);
+    }
+
+    public function testEncryptParametersSupportsColumnNameKeys(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter('status', CmsUser::class, 'status');
+
+        $params = ['status' => 'active', 'username' => 'joe'];
+        $types  = ['status' => 'string', 'username' => 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['status' => 'enc(active)', 'username' => 'joe'], $params);
+        self::assertSame(['status' => 'text', 'username' => 'string'], $types);
+    }
+
+    public function testEncryptParametersEncryptsArrayParameterElements(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = [['active', 'inactive'], 'joe'];
+        $types  = [ArrayParameterType::STRING, 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame([['enc(active)', 'enc(inactive)'], 'joe'], $params);
+        self::assertSame([ArrayParameterType::STRING, 'string'], $types);
+    }
+
+    public function testEncryptParametersSetsArrayParameterTypeToBinaryForBinaryCipher(): void
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(true);
+        $cipher->method('encrypt')->willReturnCallback(static fn (string $plaintext): string => 'enc(' . $plaintext . ')');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = [['active', 'inactive'], 'joe'];
+        $types  = [ArrayParameterType::STRING, 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame([ArrayParameterType::BINARY, 'string'], $types);
+    }
+
+    public function testEncryptParametersThrowsWhenKeyProviderRegistryNotConfigured(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            null,
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = ['active'];
+        $types  = ['string'];
+
+        $this->expectException(EncryptConfigurationMissing::class);
+        $this->expectExceptionMessage('Key provider registry is not configured. Call Configuration::setKeyProviderRegistry() to set it.');
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+    }
+
+    public function testEncryptParametersStringifiesNonStringDatabaseValues(): void
+    {
+        $cipher = $this->createMock(Cipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->expects(self::exactly(2))
+            ->method('encrypt')
+            ->with(self::callback(static fn (string $plaintext): bool => $plaintext === '42' || $plaintext === '1'))
+            ->willReturnCallback(static fn (string $plaintext): string => 'enc(' . $plaintext . ')');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $classMetadata = new ClassMetadata(CmsUser::class);
+
+        $integerMapping          = new FieldMapping('integer', 'age', 'age');
+        $integerMapping->encrypt = new EncryptMapping();
+
+        $booleanMapping          = new FieldMapping('boolean', 'active', 'active');
+        $booleanMapping->encrypt = new EncryptMapping();
+
+        $classMetadata->fieldMappings['age']    = $integerMapping;
+        $classMetadata->fieldMappings['active'] = $booleanMapping;
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $classMetadata,
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'age');
+        $querySetMapping->addEncryptedParameter(1, CmsUser::class, 'active');
+
+        $params = [42, true];
+        $types  = ['integer', 'boolean'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(42)', 'enc(1)'], $params);
+    }
+
+    public function testEncryptParametersPassesNullValuesThroughUnencrypted(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            $this->createKeyProviderRegistry(),
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+        $querySetMapping->addEncryptedParameter(1, CmsUser::class, 'status');
+
+        $params = ['active', null];
+        $types  = ['string', 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(active)', null], $params);
+        self::assertSame(['text', 'text'], $types);
+    }
+
+    public function testEncryptParametersConvertsThroughDbalTypeBeforeEncrypting(): void
+    {
+        $cipher = $this->createMock(Cipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->expects(self::once())
+            ->method('encrypt')
+            ->with('2024-01-15 10:30:00', self::anything())
+            ->willReturn('encrypted');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $classMetadata = new ClassMetadata(CmsUser::class);
+
+        $fieldMapping          = new FieldMapping('datetime_immutable', 'createdAt', 'created_at');
+        $fieldMapping->encrypt = new EncryptMapping();
+
+        $classMetadata->fieldMappings['createdAt'] = $fieldMapping;
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+            $classMetadata,
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'createdAt');
+
+        $params = [new DateTimeImmutable('2024-01-15 10:30:00')];
+        $types  = ['datetime_immutable'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['encrypted'], $params);
+    }
+
+    public function testEncryptParametersResolvesNullCipherAndKeyProviderNamesToNull(): void
+    {
+        $cipherRegistry = $this->createMock(CipherRegistry::class);
+        $cipherRegistry->expects(self::atLeastOnce())
+            ->method('getCipher')
+            ->with(null)
+            ->willReturn($this->createEncryptCipher());
+
+        $keyProviderRegistry = $this->createMock(KeyProviderRegistry::class);
+        $keyProviderRegistry->expects(self::once())
+            ->method('getKeyProvider')
+            ->with(null)
+            ->willReturn($this->createStub(KeyProvider::class));
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $keyProviderRegistry,
+            $this->createClassMetadata(),
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+
+        $params = ['active'];
+        $types  = ['string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+    }
+
+    public function testEncryptParametersBatchesFieldsSharingCipherAndKeyProvider(): void
+    {
+        $keyProviderRegistry = $this->createMock(KeyProviderRegistry::class);
+        $keyProviderRegistry->expects(self::once())
+            ->method('getKeyProvider')
+            ->willReturn($this->createStub(KeyProvider::class));
+
+        $classMetadata = $this->createClassMetadata();
+
+        $nameMapping          = new FieldMapping('string', 'name', 'name');
+        $nameMapping->encrypt = new EncryptMapping();
+
+        $classMetadata->fieldMappings['name'] = $nameMapping;
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createEncryptCipherRegistry(),
+            $keyProviderRegistry,
+            $classMetadata,
+        ));
+
+        $querySetMapping = new EncryptedQuerySetMapping();
+        $querySetMapping->addEncryptedParameter(0, CmsUser::class, 'status');
+        $querySetMapping->addEncryptedParameter(1, CmsUser::class, 'name');
+
+        $params = ['active', 'joe'];
+        $types  = ['string', 'string'];
+
+        $encryptHelper->encryptParameters($querySetMapping, $params, $types);
+
+        self::assertSame(['enc(active)', 'enc(joe)'], $params);
+    }
+
+    /** @return iterable<string, array{array<string, mixed>, array<string, mixed>}> */
+    public static function decryptRowProvider(): iterable
+    {
+        yield 'decrypts only mapped columns' => [
+            ['status_1' => 'enc(active)', 'username_1' => 'joe'],
+            ['status_1' => 'dec(enc(active))', 'username_1' => 'joe'],
+        ];
+
+        yield 'passes null values through undecrypted' => [
+            ['status_1' => null, 'username_1' => 'joe'],
+            ['status_1' => null, 'username_1' => 'joe'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, mixed> $expected
+     */
+    #[DataProvider('decryptRowProvider')]
+    public function testDecryptRow(array $row, array $expected): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createDecryptCipherRegistry(),
+            $this->createKeyProviderRegistry(),
+        ));
+
+        $encryptHelper->decryptRow(['status_1' => new EncryptMapping()], $row);
+
+        self::assertSame($expected, $row);
+    }
+
+    public function testDecryptRowNormalizesBlobStreamsBeforeDecrypting(): void
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(true);
+        $cipher->method('decrypt')->willReturnCallback(static fn (string $envelope): string => 'dec(' . $envelope . ')');
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $cipherRegistry,
+            $this->createKeyProviderRegistry(),
+        ));
+
+        $row = ['status_1' => 'binary-envelope'];
+
+        $encryptHelper->decryptRow(['status_1' => new EncryptMapping()], $row);
+
+        self::assertSame(['status_1' => 'dec(binary-envelope)'], $row);
+    }
+
+    public function testDecryptRowResolvesNullCipherAndKeyProviderNamesToNull(): void
+    {
+        $cipherRegistry = $this->createMock(CipherRegistry::class);
+        $cipherRegistry->expects(self::atLeastOnce())
+            ->method('getCipher')
+            ->with(null)
+            ->willReturn($this->createDecryptCipher());
+
+        $keyProviderRegistry = $this->createMock(KeyProviderRegistry::class);
+        $keyProviderRegistry->expects(self::once())
+            ->method('getKeyProvider')
+            ->with(null)
+            ->willReturn($this->createStub(KeyProvider::class));
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager($cipherRegistry, $keyProviderRegistry));
+
+        $row = ['status_1' => 'enc(active)'];
+
+        $encryptHelper->decryptRow(['status_1' => new EncryptMapping()], $row);
+    }
+
+    public function testDecryptRowBatchesColumnsSharingCipherAndKeyProvider(): void
+    {
+        $keyProviderRegistry = $this->createMock(KeyProviderRegistry::class);
+        $keyProviderRegistry->expects(self::once())
+            ->method('getKeyProvider')
+            ->willReturn($this->createStub(KeyProvider::class));
+
+        $encryptHelper = new EncryptHelper($this->createEntityManager(
+            $this->createDecryptCipherRegistry(),
+            $keyProviderRegistry,
+        ));
+
+        $row = ['status_1' => 'enc(active)', 'name_2' => 'enc(joe)'];
+
+        $encryptHelper->decryptRow(
+            ['status_1' => new EncryptMapping(), 'name_2' => new EncryptMapping()],
+            $row,
+        );
+
+        self::assertSame(['status_1' => 'dec(enc(active))', 'name_2' => 'dec(enc(joe))'], $row);
+    }
+
+    public function testDecryptRowThrowsWhenKeyProviderRegistryNotConfigured(): void
+    {
+        $encryptHelper = new EncryptHelper($this->createEntityManager($this->createDecryptCipherRegistry()));
+
+        $row = ['status_1' => 'enc(active)'];
+
+        $this->expectException(EncryptConfigurationMissing::class);
+        $this->expectExceptionMessage('Key provider registry is not configured. Call Configuration::setKeyProviderRegistry() to set it.');
+
+        $encryptHelper->decryptRow(['status_1' => new EncryptMapping()], $row);
+    }
+
+    private function createCipherRegistry(bool $isBinary): CipherRegistry
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn($isBinary);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        return $cipherRegistry;
+    }
+
+    private function createEncryptCipher(): Cipher
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->method('encrypt')->willReturnCallback(static fn (string $plaintext): string => 'enc(' . $plaintext . ')');
+
+        return $cipher;
+    }
+
+    private function createEncryptCipherRegistry(): CipherRegistry
+    {
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($this->createEncryptCipher());
+
+        return $cipherRegistry;
+    }
+
+    private function createDecryptCipher(): Cipher
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->method('decrypt')->willReturnCallback(static fn (string $envelope): string => 'dec(' . $envelope . ')');
+
+        return $cipher;
+    }
+
+    private function createDecryptCipherRegistry(): CipherRegistry
+    {
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($this->createDecryptCipher());
+
+        return $cipherRegistry;
+    }
+
+    private function createKeyProviderRegistry(): KeyProviderRegistry
+    {
+        $keyProviderRegistry = $this->createStub(KeyProviderRegistry::class);
+        $keyProviderRegistry->method('getKeyProvider')->willReturn($this->createStub(KeyProvider::class));
+
+        return $keyProviderRegistry;
+    }
+
+    /** @return ClassMetadata<CmsUser> */
+    private function createClassMetadata(): ClassMetadata
+    {
+        $classMetadata = new ClassMetadata(CmsUser::class);
+
+        $statusMapping          = new FieldMapping('string', 'status', 'status');
+        $statusMapping->encrypt = new EncryptMapping();
+
+        $classMetadata->fieldMappings['status']   = $statusMapping;
+        $classMetadata->fieldMappings['username'] = new FieldMapping('string', 'username', 'username');
+
+        return $classMetadata;
+    }
+
+    /** @param ClassMetadata<CmsUser>|null $classMetadata */
+    private function createEntityManager(
+        CipherRegistry|null $cipherRegistry,
+        KeyProviderRegistry|null $keyProviderRegistry = null,
+        ClassMetadata|null $classMetadata = null,
+    ): EntityManagerInterface {
+        $configuration = new Configuration();
+        $configuration->setCipherRegistry($cipherRegistry);
+        $configuration->setKeyProviderRegistry($keyProviderRegistry);
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new SQLitePlatform());
+
+        $em = $this->createStub(EntityManagerInterface::class);
+        $em->method('getConfiguration')->willReturn($configuration);
+        $em->method('getConnection')->willReturn($connection);
+
+        if ($classMetadata !== null) {
+            $em->method('getClassMetadata')->willReturn($classMetadata);
+        }
+
+        return $em;
+    }
+}

--- a/tests/Tests/ORM/Encrypt/KMS/AbstractKeyProviderRegistryTest.php
+++ b/tests/Tests/ORM/Encrypt/KMS/AbstractKeyProviderRegistryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\AbstractKeyProviderRegistry;
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKeyProvider;
+use Doctrine\Tests\Mocks\Encrypt\KMS\KeyProviderRegistryMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AbstractKeyProviderRegistry::class)]
+final class AbstractKeyProviderRegistryTest extends TestCase
+{
+    public function testGetDefaultKeyProvider(): void
+    {
+        $registry = new KeyProviderRegistryMock();
+
+        self::assertSame('alias', $registry->getDefaultKeyProviderName());
+        self::assertEquals($registry->default, $registry->getKeyProvider());
+    }
+
+    public function testGetKeyProvider(): void
+    {
+        $registry = new KeyProviderRegistryMock();
+
+        self::assertEquals($registry->default, $registry->getKeyProvider('alias'));
+        self::assertEquals($registry->a, $registry->getKeyProvider('alias-a'));
+        self::assertEquals($registry->b, $registry->getKeyProvider('alias-b'));
+    }
+
+    public function testGetKeyProviderUnknown(): void
+    {
+        $this->expectException(UnknownKeyProvider::class);
+        $this->expectExceptionMessage('Unknown key provider "missing". Known key providers: "alias", "alias-a", "alias-b".');
+
+        (new KeyProviderRegistryMock())->getKeyProvider('missing');
+    }
+
+    public function testConstructorUnknownDefault(): void
+    {
+        $this->expectException(UnknownKeyProvider::class);
+        $this->expectExceptionMessage('Unknown key provider "missing". Known key providers: "alias", "alias-a", "alias-b".');
+
+        new KeyProviderRegistryMock('missing');
+    }
+
+    public function testGetKeyProviderNames(): void
+    {
+        self::assertSame(['alias', 'alias-a', 'alias-b'], (new KeyProviderRegistryMock())->getKeyProviderNames());
+    }
+
+    public function testGetKeyProvidersReturnsAllIndexedByAlias(): void
+    {
+        $registry = new KeyProviderRegistryMock();
+
+        self::assertSame(
+            ['alias' => $registry->default, 'alias-a' => $registry->a, 'alias-b' => $registry->b],
+            $registry->getKeyProviders(),
+        );
+    }
+}

--- a/tests/Tests/ORM/Encrypt/KMS/ArrayKeyProviderRegistryTest.php
+++ b/tests/Tests/ORM/Encrypt/KMS/ArrayKeyProviderRegistryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\ArrayKeyProviderRegistry;
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKeyProvider;
+use Doctrine\Tests\Mocks\Encrypt\KMS\KeyProviderMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArrayKeyProviderRegistry::class)]
+final class ArrayKeyProviderRegistryTest extends TestCase
+{
+    /** @return iterable<string, array{string|null, string}> */
+    public static function defaultNameProvider(): iterable
+    {
+        yield 'no default name given' => [null, 'a'];
+        yield 'explicit default name' => ['b', 'b'];
+    }
+
+    #[DataProvider('defaultNameProvider')]
+    public function testDefaultKeyProviderName(string|null $defaultArg, string $expectedName): void
+    {
+        $providers = ['a' => new KeyProviderMock('first'), 'b' => new KeyProviderMock('second')];
+
+        $registry = $defaultArg === null
+            ? new ArrayKeyProviderRegistry($providers)
+            : new ArrayKeyProviderRegistry($providers, $defaultArg);
+
+        self::assertSame($expectedName, $registry->getDefaultKeyProviderName());
+        self::assertSame($providers[$expectedName], $registry->getKeyProvider());
+    }
+
+    public function testGetKeyProviderByName(): void
+    {
+        $first  = new KeyProviderMock('first');
+        $second = new KeyProviderMock('second');
+
+        $registry = new ArrayKeyProviderRegistry(['a' => $first, 'b' => $second]);
+
+        self::assertSame($first, $registry->getKeyProvider('a'));
+        self::assertSame($second, $registry->getKeyProvider('b'));
+    }
+
+    public function testConstructorUnknownDefaultName(): void
+    {
+        $this->expectException(UnknownKeyProvider::class);
+        $this->expectExceptionMessage('Unknown key provider "missing". Known key providers: "a".');
+
+        new ArrayKeyProviderRegistry(['a' => new KeyProviderMock('first')], 'missing');
+    }
+
+    public function testGetKeyProviderUnknownName(): void
+    {
+        $registry = new ArrayKeyProviderRegistry(['a' => new KeyProviderMock('first')]);
+
+        $this->expectException(UnknownKeyProvider::class);
+        $this->expectExceptionMessage('Unknown key provider "missing". Known key providers: "a".');
+
+        $registry->getKeyProvider('missing');
+    }
+
+    public function testGetKeyProviderNames(): void
+    {
+        $registry = new ArrayKeyProviderRegistry([
+            'a' => new KeyProviderMock('first'),
+            'b' => new KeyProviderMock('second'),
+        ]);
+
+        self::assertSame(['a', 'b'], $registry->getKeyProviderNames());
+    }
+
+    public function testGetKeyProvidersReturns(): void
+    {
+        $first  = new KeyProviderMock('first');
+        $second = new KeyProviderMock('second');
+
+        $registry = new ArrayKeyProviderRegistry(['a' => $first, 'b' => $second]);
+
+        self::assertSame(['a' => $first, 'b' => $second], $registry->getKeyProviders());
+    }
+}

--- a/tests/Tests/ORM/Encrypt/KMS/ArraySymmetricKeyProviderTest.php
+++ b/tests/Tests/ORM/Encrypt/KMS/ArraySymmetricKeyProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Encrypt\KMS;
+
+use Doctrine\ORM\Encrypt\KMS\ArraySymmetricKeyProvider;
+use Doctrine\ORM\Encrypt\KMS\Exception\UnknownKey;
+use Doctrine\ORM\Encrypt\KMS\Key;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function base64_encode;
+
+#[CoversClass(ArraySymmetricKeyProvider::class)]
+final class ArraySymmetricKeyProviderTest extends TestCase
+{
+    public function testConstructorRejectsEmptyKeys(): void
+    {
+        $this->expectException(UnknownKey::class);
+        $this->expectExceptionMessage('Keys cannot be empty.');
+
+        new ArraySymmetricKeyProvider([]);
+    }
+
+    public function testGetEncryptionKeyReturnsLastKey(): void
+    {
+        $provider = new ArraySymmetricKeyProvider([
+            'v1' => new Key('v1', 'first-secret'),
+            'v2' => new Key('v2', 'second-secret'),
+        ]);
+
+        $encryptionKey = $provider->getEncryptionKey();
+
+        self::assertSame('v2', $encryptionKey->id);
+        self::assertSame('second-secret', $encryptionKey->key);
+    }
+
+    public function testGetDecryptionKeyResolvesById(): void
+    {
+        $v1 = new Key('v1', 'first-secret');
+        $v2 = new Key('v2', 'second-secret');
+
+        $provider = new ArraySymmetricKeyProvider(['v1' => $v1, 'v2' => $v2]);
+
+        self::assertSame($v1, $provider->getDecryptionKey('v1'));
+        self::assertSame($v2, $provider->getDecryptionKey('v2'));
+    }
+
+    public function testGetDecryptionKeyUnknownId(): void
+    {
+        $provider = new ArraySymmetricKeyProvider(['v1' => new Key('v1', 'first-secret')]);
+
+        $this->expectException(UnknownKey::class);
+        $this->expectExceptionMessage('Could not resolve a key for id "v2".');
+
+        $provider->getDecryptionKey('v2');
+    }
+
+    public function testFromScalarsDecodesBase64Material(): void
+    {
+        $provider = ArraySymmetricKeyProvider::fromScalars([
+            'v1' => base64_encode('first-secret'),
+            'v2' => base64_encode('second-secret'),
+        ]);
+
+        self::assertSame('first-secret', $provider->getDecryptionKey('v1')->key);
+        self::assertSame('second-secret', $provider->getEncryptionKey()->key);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function invalidBase64Provider(): iterable
+    {
+        yield 'invalid' => ['not-valid-base64!!'];
+        yield 'empty' => [''];
+    }
+
+    #[DataProvider('invalidBase64Provider')]
+    public function testFromScalarsInvalidBase64(string $raw): void
+    {
+        $this->expectException(UnknownKey::class);
+        $this->expectExceptionMessage('Could not init key for id "v1", invalid base64 string.');
+
+        ArraySymmetricKeyProvider::fromScalars(['v1' => $raw]);
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptDqlTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptDqlTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\Tests\Models\Encrypt\EncryptCustomer;
+use Doctrine\Tests\Models\Encrypt\EncryptEmployee;
+use Doctrine\Tests\Models\Encrypt\EncryptGroup;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function sprintf;
+
+class EncryptDqlTest extends EncryptFunctionalTestCase
+{
+    /** @return iterable<string, array{string, int|string}> */
+    public static function equalityProvider(): iterable
+    {
+        yield 'named parameter' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn = :ssn', EncryptCustomer::class),
+            'ssn',
+        ];
+
+        yield 'positional parameter' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn = ?1', EncryptCustomer::class),
+            1,
+        ];
+
+        yield 'parameter on left side' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn = :ssn', EncryptCustomer::class),
+            'ssn',
+        ];
+    }
+
+    #[DataProvider('equalityProvider')]
+    public function testWhereEquality(string $dql, int|string $paramKey): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery($dql)
+            ->setParameter($paramKey, '123-45-6789')
+            ->getResult();
+
+        self::assertCount(2, $result);
+        $this->assertCustomer('joe', $result[0]);
+        $this->assertCustomer('jax', $result[1]);
+    }
+
+    public function testWhereNotEqual(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery(sprintf('SELECT c FROM %s c WHERE c.ssn <> :ssn', EncryptCustomer::class))
+            ->setParameter('ssn', '123-45-6789')
+            ->getResult();
+
+        self::assertCount(2, $result);
+        $this->assertCustomer('jane', $result[0]);
+        $this->assertCustomer('jim', $result[1]);
+    }
+
+    /** @return iterable<string, array{string, array<string, string>}> */
+    public static function inListProvider(): iterable
+    {
+        yield 'single array parameter' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn IN (:ssns)', EncryptCustomer::class),
+            ['ssns' => ['123-45-6789', '987-65-4321']],
+        ];
+
+        yield 'separate scalar parameters' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn IN (:first, :second)', EncryptCustomer::class),
+            ['first' => '123-45-6789', 'second' => '987-65-4321'],
+        ];
+    }
+
+    /** @param array<string, mixed> $params */
+    #[DataProvider('inListProvider')]
+    public function testWhereIn(string $dql, array $params): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $query = $this->_em->createQuery($dql);
+
+        foreach ($params as $name => $value) {
+            $query->setParameter($name, $value);
+        }
+
+        $result = $query->getResult();
+
+        self::assertCount(3, $result);
+        $this->assertCustomer('joe', $result[0]);
+        $this->assertCustomer('jane', $result[1]);
+        $this->assertCustomer('jax', $result[2]);
+    }
+
+    public function testWhereNotInExcludesMatchingRows(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery(sprintf('SELECT c FROM %s c WHERE c.ssn NOT IN (:ssns)', EncryptCustomer::class))
+            ->setParameter('ssns', ['123-45-6789', '987-65-4321'])
+            ->getResult();
+
+        self::assertCount(1, $result);
+        $this->assertCustomer('jim', $result[0]);
+    }
+
+    public function testQueryCacheHitStillEncryptsParameters(): void
+    {
+        $adapter = new ArrayAdapter();
+        $this->_em->getConfiguration()->setQueryCache($adapter);
+
+        $this->initCustomers();
+        $this->_em->clear();
+
+        self::assertCount(0, $adapter->getValues());
+
+        $dql = sprintf('SELECT c FROM %s c WHERE c.ssn = :ssn', EncryptCustomer::class);
+
+        $first = $this->_em->createQuery($dql)
+            ->setParameter('ssn', '123-45-6789')
+            ->getResult();
+
+        self::assertCount(1, $adapter->getValues());
+
+        $second = $this->_em->createQuery($dql)
+            ->setParameter('ssn', '123-45-6789')
+            ->getResult();
+
+        self::assertCount(2, $first);
+        self::assertCount(2, $second);
+
+        $this->assertCustomer('joe', $first[0]);
+        $this->assertCustomer('jax', $first[1]);
+
+        self::assertEquals($first[0], $second[0]);
+        self::assertEquals($first[1], $second[1]);
+    }
+
+    public function testWhereMixesPlainAndEncryptedParameters(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery(sprintf('SELECT c FROM %s c WHERE c.name = :name AND c.ssn = :ssn', EncryptCustomer::class))
+            ->setParameter('name', 'joe')
+            ->setParameter('ssn', '123-45-6789')
+            ->getResult();
+
+        self::assertCount(1, $result);
+        $this->assertCustomer('joe', $result[0]);
+    }
+
+    /** @return iterable<string, array{string, array<string, mixed>, string}> */
+    public static function unsupportedUsageProvider(): iterable
+    {
+        yield 'non-queryable field' => [
+            sprintf('SELECT c FROM %s c WHERE c.note = :note', EncryptCustomer::class),
+            ['note' => 'top secret'],
+            EncryptCustomer::class . '::$note is encrypted; filtering by an encrypted field without queryType set is not supported.',
+        ];
+
+        yield 'non-equality operator' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn > :ssn', EncryptCustomer::class),
+            ['ssn' => '123-45-6789'],
+            EncryptCustomer::class . '::$ssn is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got ">".',
+        ];
+
+        yield 'BETWEEN' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn BETWEEN :low AND :high', EncryptCustomer::class),
+            ['low' => '111-11-1111', 'high' => '999-99-9999'],
+            EncryptCustomer::class . '::$ssn is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got "BETWEEN".',
+        ];
+
+        yield 'LIKE' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn LIKE :pattern', EncryptCustomer::class),
+            ['pattern' => '123-%'],
+            EncryptCustomer::class . '::$ssn is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got "LIKE".',
+        ];
+
+        yield 'literal comparison' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn = \'123-45-6789\'', EncryptCustomer::class),
+            [],
+            EncryptCustomer::class . '::$ssn is encrypted; comparing or assigning a DQL literal is not supported, bind a parameter instead.',
+        ];
+
+        yield 'literal in IN list' => [
+            sprintf('SELECT c FROM %s c WHERE c.ssn IN (\'123-45-6789\')', EncryptCustomer::class),
+            [],
+            EncryptCustomer::class . '::$ssn is encrypted; comparing or assigning a DQL literal is not supported, bind a parameter instead.',
+        ];
+    }
+
+    /** @param array<string, mixed> $params */
+    #[DataProvider('unsupportedUsageProvider')]
+    public function testWhereUnsupportedUsageThrows(string $dql, array $params, string $expectedMessage): void
+    {
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $query = $this->_em->createQuery($dql);
+
+        foreach ($params as $name => $value) {
+            $query->setParameter($name, $value);
+        }
+
+        $query->getResult();
+    }
+
+    public function testDqlUpdateEncryptsSetParameter(): void
+    {
+        [$joe] = $this->initCustomers();
+        $this->_em->clear();
+
+        $affected = $this->_em->createQuery(sprintf('UPDATE %s c SET c.ssn = :ssn WHERE c.id = :id', EncryptCustomer::class))
+            ->setParameter('ssn', '999-99-9999')
+            ->setParameter('id', $joe->id)
+            ->execute();
+
+        self::assertSame(1, $affected);
+
+        $raw = $this->fetchRawColumn('SELECT ssn FROM encrypt_customers WHERE id = ?', [$joe->id]);
+
+        self::assertNotSame('999-99-9999', $raw);
+        self::assertSame('999-99-9999', $this->decrypt($raw));
+    }
+
+    public function testDqlUpdateWritesNonQueryableEncryptedField(): void
+    {
+        $group = $this->persistGroup('admins', 'be kind');
+        $this->_em->clear();
+
+        $affected = $this->_em->createQuery(sprintf('UPDATE %s g SET g.motto = :motto WHERE g.name = :name', EncryptGroup::class))
+            ->setParameter('motto', 'be nice')
+            ->setParameter('name', 'admins')
+            ->execute();
+
+        self::assertSame(1, $affected);
+
+        $raw = $this->fetchRawColumn('SELECT motto FROM encrypt_groups WHERE id = ?', [$group->id]);
+
+        self::assertNotSame('be nice', $raw);
+        self::assertSame('be nice', $this->decrypt($raw));
+    }
+
+    public function testDqlUpdateSetsEncryptedFieldToNull(): void
+    {
+        $group = $this->persistGroup('admins', 'be kind');
+        $this->_em->clear();
+
+        $affected = $this->_em->createQuery(sprintf('UPDATE %s g SET g.motto = NULL WHERE g.name = :name', EncryptGroup::class))
+            ->setParameter('name', 'admins')
+            ->execute();
+
+        self::assertSame(1, $affected);
+        self::assertNull($this->_em->getConnection()->fetchOne('SELECT motto FROM encrypt_groups WHERE id = ?', [$group->id]));
+    }
+
+    public function testDqlUpdateWithLiteralThrows(): void
+    {
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage(EncryptCustomer::class . '::$ssn is encrypted; comparing or assigning a DQL literal is not supported, bind a parameter instead.');
+
+        $this->_em->createQuery(sprintf('UPDATE %s c SET c.ssn = \'999-99-9999\'', EncryptCustomer::class))
+            ->execute();
+    }
+
+    public function testJoinedInheritanceBulkUpdateEncryptsSetParameter(): void
+    {
+        $employee             = new EncryptEmployee();
+        $employee->secret     = 'old secret';
+        $employee->department = 'r&d';
+
+        $this->_em->persist($employee);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $affected = $this->_em->createQuery(sprintf('UPDATE %s e SET e.secret = :secret WHERE e.department = :department', EncryptEmployee::class))
+            ->setParameter('secret', 'new secret')
+            ->setParameter('department', 'r&d')
+            ->execute();
+
+        self::assertSame(1, $affected);
+
+        $raw = $this->fetchRawColumn('SELECT secret FROM encrypt_persons WHERE id = ?', [$employee->id]);
+
+        self::assertNotSame('new secret', $raw);
+        self::assertSame('new secret', $this->decrypt($raw));
+    }
+
+    public function testDqlDeleteByEncryptedField(): void
+    {
+        [, $jane] = $this->initCustomers();
+        $this->_em->clear();
+
+        $affected = $this->_em->createQuery(sprintf('DELETE FROM %s c WHERE c.ssn = :ssn', EncryptCustomer::class))
+            ->setParameter('ssn', '987-65-4321')
+            ->execute();
+
+        self::assertSame(1, $affected);
+        self::assertFalse($this->_em->getConnection()->fetchOne('SELECT id FROM encrypt_customers WHERE id = ?', [$jane->id]));
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
@@ -16,6 +16,7 @@ use Doctrine\Tests\Models\Encrypt\EncryptPerson;
 use Doctrine\Tests\Models\Encrypt\EncryptTypesEntity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function is_array;
 use function is_resource;
 use function stream_get_contents;
 
@@ -138,5 +139,27 @@ abstract class EncryptFunctionalTestCase extends OrmFunctionalTestCase
         $jax  = $this->persistCustomer('jax', '123-45-6789', 'again secret');
 
         return [$joe, $jane, $jim, $jax];
+    }
+
+    protected function assertCustomer(string $name, EncryptCustomer|array $customer): void
+    {
+        if (is_array($customer)) {
+            $customer = (object) $customer;
+        }
+
+        self::assertSame($name, $customer->name);
+
+        self::assertSame(match ($name) {
+            'joe', 'jax' => '123-45-6789',
+            'jane' => '987-65-4321',
+            'jim' => '555-55-5555',
+        }, $customer->ssn);
+
+        self::assertSame(match ($name) {
+            'joe' => 'top secret',
+            'jane' => 'other secret',
+            'jim' => 'third secret',
+            'jax' => 'again secret',
+        }, $customer->note);
     }
 }

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
@@ -128,4 +128,15 @@ abstract class EncryptFunctionalTestCase extends OrmFunctionalTestCase
     {
         return (new OpenSSLCipher())->decrypt($envelope, $this->keyProvider);
     }
+
+    /** @return list{EncryptCustomer, EncryptCustomer, EncryptCustomer} */
+    protected function initCustomers(): array
+    {
+        $joe  = $this->persistCustomer('joe', '123-45-6789', 'top secret');
+        $jane = $this->persistCustomer('jane', '987-65-4321', 'other secret');
+        $jim  = $this->persistCustomer('jim', '555-55-5555', 'third secret');
+        $jax  = $this->persistCustomer('jax', '123-45-6789', 'again secret');
+
+        return [$joe, $jane, $jim, $jax];
+    }
 }

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptFunctionalTestCase.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Encrypt\Cipher\OpenSSLCipher;
+use Doctrine\ORM\Encrypt\KMS\ArrayKeyProviderRegistry;
+use Doctrine\ORM\Encrypt\KMS\ArraySymmetricKeyProvider;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use Doctrine\Tests\Models\Encrypt\EncryptCustomer;
+use Doctrine\Tests\Models\Encrypt\EncryptEmployee;
+use Doctrine\Tests\Models\Encrypt\EncryptGroup;
+use Doctrine\Tests\Models\Encrypt\EncryptPerson;
+use Doctrine\Tests\Models\Encrypt\EncryptTypesEntity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function is_resource;
+use function stream_get_contents;
+
+/**
+ * Base class for the end-to-end encryption suites, running the real crypto stack
+ * (OpenSSLCipher + ArraySymmetricKeyProvider) against a real database, no mocks.
+ */
+abstract class EncryptFunctionalTestCase extends OrmFunctionalTestCase
+{
+    protected const KEY_MATERIAL = 'BRi18ItE5BIL8+XPzXkws6vK3iJQPw198fiy67E7YMw=';
+
+    protected KeyProvider $keyProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->keyProvider = ArraySymmetricKeyProvider::fromScalars(['k1' => self::KEY_MATERIAL]);
+
+        $config = $this->_em->getConfiguration();
+        $config->setCipherRegistry(new EncryptTestCipherRegistry(
+            [
+                'random' => new OpenSSLCipher(),
+                'deterministic' => new OpenSSLCipher(deterministic: true),
+            ],
+            'random',
+        ));
+        $config->setKeyProviderRegistry(new ArrayKeyProviderRegistry(['main' => $this->keyProvider]));
+
+        $this->setUpEntitySchema([
+            EncryptCustomer::class,
+            EncryptGroup::class,
+            EncryptPerson::class,
+            EncryptEmployee::class,
+            EncryptTypesEntity::class,
+        ]);
+
+        $connection = $this->_em->getConnection();
+        $connection->executeStatement('DELETE FROM encrypt_customers_groups');
+        $connection->executeStatement('DELETE FROM encrypt_groups');
+        $connection->executeStatement('DELETE FROM encrypt_employees');
+        $connection->executeStatement('DELETE FROM encrypt_persons');
+        $connection->executeStatement('DELETE FROM encrypt_customers');
+        $connection->executeStatement('DELETE FROM encrypt_types');
+    }
+
+    protected function persistCustomer(string $name, string $ssn, string $note): EncryptCustomer
+    {
+        $customer       = new EncryptCustomer();
+        $customer->name = $name;
+        $customer->ssn  = $ssn;
+        $customer->note = $note;
+
+        $this->_em->persist($customer);
+        $this->_em->flush();
+
+        return $customer;
+    }
+
+    protected function persistGroup(string $name, string|null $motto): EncryptGroup
+    {
+        $group        = new EncryptGroup();
+        $group->name  = $name;
+        $group->motto = $motto;
+
+        $this->_em->persist($group);
+        $this->_em->flush();
+
+        return $group;
+    }
+
+    protected function persistCustomerWithGroups(EncryptGroup ...$groups): EncryptCustomer
+    {
+        $customer = $this->persistCustomer('joe', '123-45-6789', 'top secret');
+
+        foreach ($groups as $group) {
+            $customer->groups->add($group);
+        }
+
+        $this->_em->flush();
+
+        return $customer;
+    }
+
+    /** @return Collection<int, EncryptGroup> */
+    protected function loadGroups(EncryptCustomer $customer): Collection
+    {
+        $reloaded = $this->_em->find(EncryptCustomer::class, $customer->id);
+
+        self::assertFalse($reloaded->groups->isInitialized());
+
+        return $reloaded->groups;
+    }
+
+    /** @param list<mixed> $params */
+    protected function fetchRawColumn(string $sql, array $params): string
+    {
+        $value = $this->_em->getConnection()->fetchOne($sql, $params);
+
+        if (is_resource($value)) {
+            $value = stream_get_contents($value);
+        }
+
+        self::assertIsString($value);
+
+        return $value;
+    }
+
+    protected function decrypt(string $envelope): string
+    {
+        return (new OpenSSLCipher())->decrypt($envelope, $this->keyProvider);
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptHydrationTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptHydrationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\Tests\Models\Encrypt\EncryptCustomer;
+use Doctrine\Tests\Models\Encrypt\EncryptGroup;
+
+use function sprintf;
+
+class EncryptHydrationTest extends EncryptFunctionalTestCase
+{
+    public function testFindReturnsDecryptedFieldValues(): void
+    {
+        [$joe] = $this->initCustomers();
+        $this->_em->clear();
+
+        $found = $this->_em->find(EncryptCustomer::class, $joe->id);
+
+        self::assertNotNull($found);
+        $this->assertCustomer('joe', $found);
+    }
+
+    public function testDqlObjectHydrationDecryptsEncryptedFields(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery(sprintf('SELECT c FROM %s c', EncryptCustomer::class))->getResult();
+
+        self::assertCount(4, $result);
+
+        $this->assertCustomer('joe', $result[0]);
+        $this->assertCustomer('jane', $result[1]);
+        $this->assertCustomer('jim', $result[2]);
+        $this->assertCustomer('jax', $result[3]);
+    }
+
+    public function testDqlArrayHydrationDecryptsEncryptedFields(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $result = $this->_em->createQuery(sprintf('SELECT c FROM %s c', EncryptCustomer::class))->getArrayResult();
+
+        self::assertCount(4, $result);
+
+        $this->assertCustomer('joe', $result[0]);
+        $this->assertCustomer('jane', $result[1]);
+        $this->assertCustomer('jim', $result[2]);
+        $this->assertCustomer('jax', $result[3]);
+    }
+
+    public function testNullEncryptedFieldHydratesAsNull(): void
+    {
+        $group = $this->persistGroup('anonymous', null);
+        $this->_em->clear();
+
+        $found = $this->_em->find(EncryptGroup::class, $group->id);
+
+        self::assertNotNull($found);
+        self::assertNull($found->motto);
+    }
+
+    public function testDisableDecryptHydratesCiphertext(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $rsm = new ResultSetMappingBuilder($this->_em);
+        $rsm->addRootEntityFromClassMetadata(EncryptCustomer::class, 'c');
+        $rsm->disableDecrypt();
+
+        $result = $this->_em->createNativeQuery('SELECT * FROM encrypt_customers', $rsm)->getArrayResult();
+
+        self::assertCount(4, $result);
+        self::assertNotSame('123-45-6789', $result[0]['ssn']);
+        self::assertSame('123-45-6789', $this->decrypt($result[0]['ssn']));
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptManyToManyTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptManyToManyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\Tests\Models\Encrypt\EncryptGroup;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Extra-lazy many-to-many collections: matching() by encrypted target fields goes through
+ * ManyToManyPersister::loadCriteria() with encrypted parameters.
+ */
+class EncryptManyToManyTest extends EncryptFunctionalTestCase
+{
+    public function testMatchingManyToManyCollectionByEncryptedFieldFindsElement(): void
+    {
+        $admins = $this->persistGroup('admins', 'be kind');
+        $users  = $this->persistGroup('users', 'be nice');
+
+        $customer = $this->persistCustomerWithGroups($admins, $users);
+        $this->_em->clear();
+
+        $found = $this->loadGroups($customer)->matching(
+            Criteria::create()->where(Criteria::expr()->eq('name', 'admins')),
+        );
+
+        self::assertCount(1, $found);
+        self::assertSame($admins->id, $found->first()->id);
+    }
+
+    /** @return iterable<string, array{Criteria, string}> */
+    public static function throwingCriteriaProvider(): iterable
+    {
+        yield 'non-equality operator' => [
+            Criteria::create()->where(Criteria::expr()->gt('name', 'a')),
+            EncryptGroup::class . '::$name is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got ">".',
+        ];
+
+        yield 'ordering by encrypted field' => [
+            Criteria::create()->orderBy(['name' => Order::Ascending]),
+            EncryptGroup::class . '::$name is encrypted; ordering by an encrypted field is not supported.',
+        ];
+
+        yield 'non-queryable field' => [
+            Criteria::create()->where(Criteria::expr()->eq('motto', 'be kind')),
+            EncryptGroup::class . '::$motto is encrypted; filtering by an encrypted field without queryType set is not supported.',
+        ];
+    }
+
+    #[DataProvider('throwingCriteriaProvider')]
+    public function testMatchingManyToManyCollectionThrows(Criteria $criteria, string $expectedMessage): void
+    {
+        $customer = $this->persistCustomerWithGroups($this->persistGroup('admins', 'be kind'));
+        $this->_em->clear();
+
+        $groups = $this->loadGroups($customer);
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $groups->matching($criteria);
+    }
+
+    public function testMatchingManyToManyCollectionWithIsNullOnEncryptedFieldFindsElement(): void
+    {
+        $anonymous = $this->persistGroup('anonymous', null);
+        $admins    = $this->persistGroup('admins', 'be kind');
+
+        $customer = $this->persistCustomerWithGroups($anonymous, $admins);
+        $this->_em->clear();
+
+        $found = $this->loadGroups($customer)->matching(
+            Criteria::create()->where(Criteria::expr()->isNull('motto')),
+        );
+
+        self::assertCount(1, $found);
+        self::assertSame($anonymous->id, $found->first()->id);
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptQueryTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\Tests\Models\Encrypt\EncryptCustomer;
+
+/**
+ * Query path: filtering by deterministic equality-queryable encrypted fields through the
+ * repository APIs, and the rejections for unsupported usages.
+ */
+class EncryptQueryTest extends EncryptFunctionalTestCase
+{
+    public function testFindOneByEncryptedEqualityField(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $found = $this->_em->getRepository(EncryptCustomer::class)->findOneBy(['ssn' => '987-65-4321']);
+
+        self::assertNotNull($found);
+        $this->assertCustomer('jane', $found);
+    }
+
+    public function testFindByEncryptedFieldWithInList(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $founds = $this->_em->getRepository(EncryptCustomer::class)->findBy(['ssn' => ['555-55-5555', '987-65-4321']]);
+
+        self::assertCount(2, $founds);
+        $this->assertCustomer('jane', $founds[0]);
+        $this->assertCustomer('jim', $founds[1]);
+    }
+
+    public function testMatchingCriteriaWithDuplicatedEncryptedField(): void
+    {
+        $this->initCustomers();
+        $this->_em->clear();
+
+        $criteria = Criteria::create()->where(
+            Criteria::expr()->orX(
+                Criteria::expr()->eq('ssn', '555-55-5555'),
+                Criteria::expr()->eq('ssn', '987-65-4321'),
+            ),
+        );
+
+        $founds = $this->_em->getRepository(EncryptCustomer::class)->matching($criteria);
+
+        self::assertCount(2, $founds);
+        $this->assertCustomer('jane', $founds[0]);
+        $this->assertCustomer('jim', $founds[1]);
+    }
+
+    public function testFilteringByNonQueryableEncryptedFieldThrows(): void
+    {
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage(EncryptCustomer::class . '::$note is encrypted; filtering by an encrypted field without queryType set is not supported.');
+
+        $this->_em->getRepository(EncryptCustomer::class)->findOneBy(['note' => 'top secret']);
+    }
+
+    public function testMatchingCriteriaWithNonEqualityOperatorOnEncryptedFieldThrows(): void
+    {
+        $criteria = Criteria::create()->where(Criteria::expr()->gt('ssn', '123-45-6789'));
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage(EncryptCustomer::class . '::$ssn is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got ">".');
+
+        $this->_em->getRepository(EncryptCustomer::class)->matching($criteria)->toArray();
+    }
+
+    public function testOrderingByEncryptedFieldThrows(): void
+    {
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage(EncryptCustomer::class . '::$ssn is encrypted; ordering by an encrypted field is not supported.');
+
+        $this->_em->getRepository(EncryptCustomer::class)->findBy([], ['ssn' => 'ASC']);
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptSchemaTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptSchemaTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\Tests\Models\Encrypt\EncryptCustomer;
+
+/**
+ * Schema generation for encrypted fields: the column uses the cipher's storage type,
+ * not the mapped field type.
+ */
+class EncryptSchemaTest extends EncryptFunctionalTestCase
+{
+    public function testSchemaGeneratesBlobColumnForEncryptedField(): void
+    {
+        $table = $this->getSchemaForModels(EncryptCustomer::class)->getTable('encrypt_customers');
+
+        self::assertInstanceOf(BlobType::class, $table->getColumn('ssn')->getType());
+        self::assertInstanceOf(BlobType::class, $table->getColumn('note')->getType());
+        self::assertInstanceOf(StringType::class, $table->getColumn('name')->getType());
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptTestCipherRegistry.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptTestCipherRegistry.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use Doctrine\ORM\Encrypt\Cipher\AbstractCipherRegistry;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+
+use function array_combine;
+use function array_keys;
+
+final class EncryptTestCipherRegistry extends AbstractCipherRegistry
+{
+    /** @param non-empty-array<string, Cipher> $ciphers */
+    public function __construct(
+        private readonly array $ciphers,
+        string $defaultCipherName,
+    ) {
+        parent::__construct(
+            array_combine($names = array_keys($this->ciphers), $names),
+            $defaultCipherName,
+        );
+    }
+
+    protected function getService(string $name): Cipher
+    {
+        return $this->ciphers[$name];
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptTypesTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptTypesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+use BcMath\Number;
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Tests\Models\Encrypt\EncryptTypesEntity;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function class_exists;
+use function get_debug_type;
+use function is_resource;
+use function sprintf;
+use function stream_get_contents;
+
+class EncryptTypesTest extends EncryptFunctionalTestCase
+{
+    /** @return iterable<string, array{string, string, mixed}> */
+    public static function builtInTypeProvider(): iterable
+    {
+        yield Types::ASCII_STRING => ['asciiStringValue', Types::ASCII_STRING, 'ascii-only'];
+        yield Types::BIGINT => ['bigintValue', Types::BIGINT, 4294967295];
+        yield Types::BINARY => ['binaryValue', Types::BINARY, "\x00\x01binary-data"];
+        yield Types::BLOB => ['blobValue', Types::BLOB, "\x00blob-data"];
+        yield Types::BOOLEAN => ['booleanValue', Types::BOOLEAN, true];
+        yield Types::DATE_MUTABLE => ['dateValue', Types::DATE_MUTABLE, new DateTime('2024-01-15')];
+        yield Types::DATE_IMMUTABLE => ['dateImmutableValue', Types::DATE_IMMUTABLE, new DateTimeImmutable('2024-01-15')];
+        yield Types::DATEINTERVAL => ['dateintervalValue', Types::DATEINTERVAL, new DateInterval('P2Y4DT6H8M')];
+        yield Types::DATETIME_MUTABLE => ['datetimeValue', Types::DATETIME_MUTABLE, new DateTime('2024-01-15 10:30:00')];
+        yield Types::DATETIME_IMMUTABLE => ['datetimeImmutableValue', Types::DATETIME_IMMUTABLE, new DateTimeImmutable('1990-06-15 08:30:00')];
+        yield Types::DATETIMETZ_MUTABLE => ['datetimetzValue', Types::DATETIMETZ_MUTABLE, new DateTime('2024-01-15 10:30:00+02:00')];
+        yield Types::DATETIMETZ_IMMUTABLE => ['datetimetzImmutableValue', Types::DATETIMETZ_IMMUTABLE, new DateTimeImmutable('2024-01-15 10:30:00+02:00')];
+        yield Types::DECIMAL => ['decimalValue', Types::DECIMAL, '123.45'];
+
+        if (class_exists(Number::class)) {
+            yield Types::NUMBER => ['numberValue', Types::NUMBER, new Number('123.45')];
+        }
+
+        yield Types::FLOAT => ['floatValue', Types::FLOAT, 1.5];
+        yield Types::ENUM => ['enumValue', Types::ENUM, 'hearts'];
+        yield Types::GUID => ['guidValue', Types::GUID, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'];
+        yield Types::INTEGER => ['integerValue', Types::INTEGER, 42];
+        yield Types::JSON => ['jsonValue', Types::JSON, ['a' => 1, 'b' => ['c' => true]]];
+        yield Types::JSON_OBJECT => ['jsonObjectValue', Types::JSON_OBJECT, (object) ['a' => 1]];
+        yield Types::JSONB => ['jsonbValue', Types::JSONB, ['a' => 1]];
+        yield Types::JSONB_OBJECT => ['jsonbObjectValue', Types::JSONB_OBJECT, (object) ['b' => 2]];
+        yield Types::SIMPLE_ARRAY => ['simpleArrayValue', Types::SIMPLE_ARRAY, ['a', 'b', 'c']];
+        yield Types::SMALLFLOAT => ['smallfloatValue', Types::SMALLFLOAT, 1.25];
+        yield Types::SMALLINT => ['smallintValue', Types::SMALLINT, 7];
+        yield Types::STRING => ['stringValue', Types::STRING, 'plain-string'];
+        yield Types::TEXT => ['textValue', Types::TEXT, 'long text value'];
+        yield Types::TIME_MUTABLE => ['timeValue', Types::TIME_MUTABLE, new DateTime('15:30:00')];
+        yield Types::TIME_IMMUTABLE => ['timeImmutableValue', Types::TIME_IMMUTABLE, new DateTimeImmutable('15:30:00')];
+    }
+
+    #[DataProvider('builtInTypeProvider')]
+    public function testBuiltInTypeRoundTrips(string $property, string $typeName, mixed $value): void
+    {
+        $type     = Type::getType($typeName);
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        $dbValue = self::normalize($type->convertToDatabaseValue($value, $platform));
+        self::assertNotNull($dbValue);
+
+        // Mirrors EncryptHelper::encryptMany(): the database value is stringified before encryption.
+        $expectedDbValue  = (string) $dbValue;
+        $expectedPhpValue = self::normalize($type->convertToPHPValue($expectedDbValue, $platform));
+
+        $entity            = new EncryptTypesEntity();
+        $entity->$property = $value;
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $raw = $this->fetchRawColumn(sprintf('SELECT %s FROM encrypt_types WHERE id = ?', $property), [$entity->id]);
+
+        self::assertNotSame($expectedDbValue, $raw);
+        self::assertSame($expectedDbValue, $this->decrypt($raw));
+
+        $this->_em->clear();
+
+        $found = $this->_em->find(EncryptTypesEntity::class, $entity->id);
+
+        self::assertNotNull($found);
+
+        $hydrated = self::normalize($found->$property);
+
+        self::assertEquals($expectedPhpValue, $hydrated);
+        self::assertSame(get_debug_type($expectedPhpValue), get_debug_type($hydrated));
+    }
+
+    private static function normalize(mixed $value): mixed
+    {
+        return is_resource($value) ? stream_get_contents($value) : $value;
+    }
+}

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptWriteTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptWriteTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Encrypt;
 
+use Doctrine\Tests\Models\Encrypt\EncryptEmployee;
+
 class EncryptWriteTest extends EncryptFunctionalTestCase
 {
     public function testInsertStoresCiphertextInDatabase(): void
@@ -43,5 +45,28 @@ class EncryptWriteTest extends EncryptFunctionalTestCase
         $jaxRawNote = $this->fetchRawColumn('SELECT note FROM encrypt_customers WHERE id = ?', [$jax->id]);
 
         self::assertNotSame($joeRawNote, $jaxRawNote);
+    }
+
+    public function testJoinedInheritanceStoresCiphertextUnderParentTable(): void
+    {
+        $employee             = new EncryptEmployee();
+        $employee->secret     = 'classified';
+        $employee->department = 'r&d';
+
+        $this->_em->persist($employee);
+        $this->_em->flush();
+
+        $rawSecret = $this->fetchRawColumn('SELECT secret FROM encrypt_persons WHERE id = ?', [$employee->id]);
+
+        self::assertNotSame('classified', $rawSecret);
+        self::assertSame('classified', $this->decrypt($rawSecret));
+
+        $this->_em->clear();
+
+        $found = $this->_em->getRepository(EncryptEmployee::class)->findOneBy(['secret' => 'classified']);
+
+        self::assertNotNull($found);
+        self::assertSame($employee->id, $found->id);
+        self::assertSame('classified', $found->secret);
     }
 }

--- a/tests/Tests/ORM/Functional/Encrypt/EncryptWriteTest.php
+++ b/tests/Tests/ORM/Functional/Encrypt/EncryptWriteTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Encrypt;
+
+class EncryptWriteTest extends EncryptFunctionalTestCase
+{
+    public function testInsertStoresCiphertextInDatabase(): void
+    {
+        [$joe] = $this->initCustomers();
+
+        $rawSsn = $this->fetchRawColumn('SELECT ssn FROM encrypt_customers WHERE id = ?', [$joe->id]);
+
+        self::assertNotSame('123-45-6789', $rawSsn);
+        self::assertSame('123-45-6789', $this->decrypt($rawSsn));
+        self::assertSame('joe', $this->fetchRawColumn('SELECT name FROM encrypt_customers WHERE id = ?', [$joe->id]));
+    }
+
+    public function testUpdateReEncryptsChangedValue(): void
+    {
+        [$joe] = $this->initCustomers();
+
+        $joe->ssn = '999-99-9999';
+        $this->_em->flush();
+
+        $rawSsn = $this->fetchRawColumn('SELECT ssn FROM encrypt_customers WHERE id = ?', [$joe->id]);
+
+        self::assertNotSame('999-99-9999', $rawSsn);
+        self::assertSame('999-99-9999', $this->decrypt($rawSsn));
+    }
+
+    public function testDeterministicCipherProducesIdenticalCiphertextForEqualPlaintextAndRandomCipherDoesNot(): void
+    {
+        [$joe, , , $jax] = $this->initCustomers();
+
+        $joeRawSsn = $this->fetchRawColumn('SELECT ssn FROM encrypt_customers WHERE id = ?', [$joe->id]);
+        $jaxRawSsn = $this->fetchRawColumn('SELECT ssn FROM encrypt_customers WHERE id = ?', [$jax->id]);
+
+        self::assertSame($joeRawSsn, $jaxRawSsn);
+
+        $joeRawNote = $this->fetchRawColumn('SELECT note FROM encrypt_customers WHERE id = ?', [$joe->id]);
+        $jaxRawNote = $this->fetchRawColumn('SELECT note FROM encrypt_customers WHERE id = ?', [$jax->id]);
+
+        self::assertNotSame($joeRawNote, $jaxRawNote);
+    }
+}

--- a/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\ORM\Encrypt\EncryptHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
@@ -51,6 +52,9 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
         $mockEntityManagerInterface
             ->method('getConnection')
             ->willReturn($mockConnection);
+        $mockEntityManagerInterface
+            ->method('getEncryptHelper')
+            ->willReturn(new EncryptHelper($mockEntityManagerInterface));
         $this->mockResult
             ->method('fetchAssociative')
             ->willReturn(false);

--- a/tests/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -91,6 +91,15 @@ class ResultSetMappingTest extends OrmTestCase
         self::assertTrue($rms->isMixedResult());
     }
 
+    public function testDisableDecrypt(): void
+    {
+        self::assertFalse($this->_rsm->isDecryptDisabled());
+
+        self::assertSame($this->_rsm, $this->_rsm->disableDecrypt());
+
+        self::assertTrue($this->_rsm->isDecryptDisabled());
+    }
+
     #[Group('DDC-117')]
     public function testIndexByMetadataColumn(): void
     {

--- a/tests/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -6,10 +6,12 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Encrypt\EncryptQuery;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
 use Doctrine\ORM\Mapping\MappingAttribute;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\Driver\ClassNames;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Mocks\AttributeDriverFactory;
@@ -17,6 +19,7 @@ use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\ORM\Mapping\Fixtures\AttributeEntityWithNestedJoinColumns;
 use Doctrine\Tests\ORM\Mapping\Fixtures\CompositeIdWithPosition;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class AttributeDriverTest extends MappingDriverTestCase
@@ -120,6 +123,202 @@ class AttributeDriverTest extends MappingDriverTestCase
 
         new AttributeDriver([], false);
     }
+
+    public function testClassLevelEncryptAttributeSetsMetadataEncrypt(): void
+    {
+        $factory  = $this->createClassMetadataFactory();
+        $metadata = $factory->getMetadataFor(AttributeEntityWithClassLevelEncrypt::class);
+
+        self::assertNotNull($metadata->encrypt);
+        self::assertNotNull($metadata->fieldMappings['name']->encrypt);
+    }
+
+    public function testClassLevelEncryptAttributeWithSecondLevelCacheThrowsException(): void
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            'Because encrypted entity "Doctrine\Tests\ORM\Mapping\AttributeEntityWithClassLevelEncryptAndCache", second level cache is not supported on entity.',
+        );
+
+        $this->createClassMetadataFactory()->getMetadataFor(AttributeEntityWithClassLevelEncryptAndCache::class);
+    }
+
+    public function testFieldLevelEncryptAttributeSetsFieldEncrypt(): void
+    {
+        $factory  = $this->createClassMetadataFactory();
+        $metadata = $factory->getMetadataFor(AttributeEntityWithFieldLevelEncrypt::class);
+
+        self::assertNotNull($metadata->fieldMappings['secret']->encrypt);
+        self::assertNull($metadata->fieldMappings['name']->encrypt);
+    }
+
+    public function testEncryptAttributeConstructorArgumentsArePropagatedToTheFieldMapping(): void
+    {
+        $factory  = $this->createClassMetadataFactory();
+        $metadata = $factory->getMetadataFor(AttributeEntityWithConfiguredFieldLevelEncrypt::class);
+
+        $encrypt = $metadata->fieldMappings['secret']->encrypt;
+
+        self::assertNotNull($encrypt);
+        self::assertSame('my-cipher', $encrypt->cipher);
+        self::assertSame('my-key-provider', $encrypt->keyProvider);
+        self::assertSame(EncryptQuery::Equality, $encrypt->queryType);
+    }
+
+    /** @return iterable<string, array{class-string}> */
+    public static function encryptOnAssociationEntitiesProvider(): iterable
+    {
+        yield 'OneToOne' => [AttributeEntityWithEncryptOnOneToOne::class];
+        yield 'OneToMany' => [AttributeEntityWithEncryptOnOneToMany::class];
+        yield 'ManyToOne' => [AttributeEntityWithEncryptOnManyToOne::class];
+        yield 'ManyToMany' => [AttributeEntityWithEncryptOnManyToMany::class];
+    }
+
+    /** @param class-string $className */
+    #[DataProvider('encryptOnAssociationEntitiesProvider')]
+    public function testEncryptAttributeOnAssociationThrowsException(string $className): void
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Encrypted association "assoc" on entity "' . $className . '" is not allowed.');
+
+        $this->createClassMetadataFactory()->getMetadataFor($className);
+    }
+
+    public function testEncryptAttributeOnEmbeddedIsCarriedThroughToEmbeddedMapping(): void
+    {
+        $factory  = $this->createClassMetadataFactory();
+        $metadata = $factory->getMetadataFor(AttributeEntityWithEncryptOnEmbedded::class);
+
+        self::assertNotNull($metadata->embeddedClasses['contact']->encrypt);
+        self::assertNotNull($metadata->getFieldMapping('contact.email')->encrypt);
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Encrypt]
+class AttributeEntityWithClassLevelEncrypt
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Column]
+    public string $name;
+}
+
+#[ORM\Entity]
+#[ORM\Cache]
+#[ORM\Encrypt]
+class AttributeEntityWithClassLevelEncryptAndCache
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithFieldLevelEncrypt
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Column]
+    #[ORM\Encrypt]
+    public string $secret;
+
+    #[ORM\Column]
+    public string $name;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithConfiguredFieldLevelEncrypt
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Column]
+    #[ORM\Encrypt(cipher: 'my-cipher', keyProvider: 'my-key-provider', queryType: EncryptQuery::Equality)]
+    public string $secret;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithEncryptOnOneToOne
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\OneToOne(targetEntity: self::class)]
+    #[ORM\Encrypt]
+    public self|null $assoc = null;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithEncryptOnOneToMany
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    /** @var Collection<int, AttributeEntityWithEncryptOnOneToMany> */
+    #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'assoc')]
+    #[ORM\Encrypt]
+    public Collection $assoc;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithEncryptOnManyToOne
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\Encrypt]
+    public self|null $assoc = null;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithEncryptOnManyToMany
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    /** @var Collection<int, AttributeEntityWithEncryptOnManyToMany> */
+    #[ORM\ManyToMany(targetEntity: self::class)]
+    #[ORM\Encrypt]
+    public Collection $assoc;
+}
+
+#[ORM\Embeddable]
+class AttributeEncryptableEmbeddable
+{
+    #[ORM\Column]
+    public string|null $email = null;
+}
+
+#[ORM\Entity]
+class AttributeEntityWithEncryptOnEmbedded
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int $id;
+
+    #[ORM\Embedded(class: AttributeEncryptableEmbeddable::class)]
+    #[ORM\Encrypt]
+    public AttributeEncryptableEmbeddable|null $contact = null;
 }
 
 #[ORM\Entity]

--- a/tests/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultTypedFieldMapper;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMapping;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use Doctrine\ORM\Mapping\EncryptMapping;
 use Doctrine\ORM\Mapping\JoinTableMapping;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\ORM\Mapping\MappingException;
@@ -1242,6 +1243,188 @@ class ClassMetadataTest extends OrmTestCase
 
         self::assertSame(['username', 'name'], $cm->identifier);
         self::assertSame(['username' => 0, 'name' => 0], $cm->identifierPositions);
+    }
+
+    public function testMapFieldWithEncryptSetsEncryptMapping(): void
+    {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'name', 'encrypt' => []]);
+
+        $fieldMapping = $cm->getFieldMapping('name');
+
+        self::assertNotNull($fieldMapping->encrypt);
+    }
+
+    #[DataProvider('mapFieldWithEncryptThrowsExceptionProvider')]
+    public function testMapFieldWithEncryptThrowsException(
+        array $fieldMapping,
+        string $expectedExceptionMessage,
+    ): void {
+        $cm = new ClassMetadata(CmsUser::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+        $cm->mapField($fieldMapping);
+    }
+
+    /** @return iterable<string, array{array<string, mixed>, string}> */
+    public static function mapFieldWithEncryptThrowsExceptionProvider(): iterable
+    {
+        yield 'encrypt on identifier' => [
+            ['fieldName' => 'id', 'id' => true, 'encrypt' => []],
+            'Encrypted identifier "id" on entity "Doctrine\Tests\Models\CMS\CmsUser" is not allowed.',
+        ];
+
+        yield 'encrypt on generated' => [
+            ['fieldName' => 'status', 'generated' => ClassMetadata::GENERATED_ALWAYS, 'encrypt' => []],
+            'Encrypted generated field "status" on entity "Doctrine\Tests\Models\CMS\CmsUser" is not allowed.',
+        ];
+
+        yield 'encrypt on version field' => [
+            ['fieldName' => 'status', 'version' => true, 'type' => 'integer', 'encrypt' => []],
+            'Encrypted version field "status" on entity "Doctrine\Tests\Models\CMS\CmsUser" is not allowed.',
+        ];
+
+        yield 'encrypt on immutable field (not updatable)' => [
+            ['fieldName' => 'name', 'notUpdatable' => true, 'encrypt' => []],
+            'Encrypted immutable field "name" on entity "Doctrine\Tests\Models\CMS\CmsUser" is not supported.',
+        ];
+
+        yield 'encrypt on immutable field (not insertable)' => [
+            ['fieldName' => 'name', 'notInsertable' => true, 'encrypt' => []],
+            'Encrypted immutable field "name" on entity "Doctrine\Tests\Models\CMS\CmsUser" is not supported.',
+        ];
+    }
+
+    public function testMapFieldWithEncryptAndSecondLevelCacheThrowsException(): void
+    {
+        $cm        = new ClassMetadata(CmsUser::class);
+        $cm->cache = ['usage' => ClassMetadata::CACHE_USAGE_READ_ONLY, 'region' => 'my_region'];
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Because encrypted field "name" on entity "Doctrine\Tests\Models\CMS\CmsUser", second level cache is not supported on entity.');
+        $cm->mapField(['fieldName' => 'name', 'encrypt' => []]);
+    }
+
+    public function testClassLevelEncryptIsClonedOntoEligibleFields(): void
+    {
+        $cm          = new ClassMetadata(CmsUser::class);
+        $cm->encrypt = new EncryptMapping();
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'name']);
+        $cm->mapField(['fieldName' => 'username']);
+
+        self::assertNotNull($cm->fieldMappings['name']->encrypt);
+        self::assertNotNull($cm->fieldMappings['username']->encrypt);
+
+        // Each field must get its own clone, not a shared reference.
+        self::assertNotSame($cm->fieldMappings['name']->encrypt, $cm->fieldMappings['username']->encrypt);
+        self::assertEquals($cm->fieldMappings['name']->encrypt, $cm->fieldMappings['username']->encrypt);
+
+        self::assertNotSame($cm->encrypt, $cm->fieldMappings['name']->encrypt);
+        self::assertEquals($cm->encrypt, $cm->fieldMappings['name']->encrypt);
+
+        self::assertNotSame($cm->encrypt, $cm->fieldMappings['username']->encrypt);
+        self::assertEquals($cm->encrypt, $cm->fieldMappings['username']->encrypt);
+    }
+
+    #[DataProvider('classLevelEncryptIsNotAppliedToIneligibleFieldsProvider')]
+    public function testClassLevelEncryptIsNotAppliedToIneligibleFields(array $fieldMapping): void
+    {
+        $cm          = new ClassMetadata(CmsUser::class);
+        $cm->encrypt = new EncryptMapping();
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField($fieldMapping);
+
+        self::assertNull($cm->fieldMappings['name']->encrypt);
+    }
+
+    /** @return iterable<string, array{array<string, mixed>}> */
+    public static function classLevelEncryptIsNotAppliedToIneligibleFieldsProvider(): iterable
+    {
+        yield 'class encrypt on identifier' => [
+            ['fieldName' => 'name', 'id' => true],
+        ];
+
+        yield 'class encrypt on generated' => [
+            ['fieldName' => 'name', 'generated' => ClassMetadata::GENERATED_ALWAYS],
+        ];
+
+        yield 'class encrypt on version field' => [
+            ['fieldName' => 'name', 'version' => true, 'type' => 'integer'],
+        ];
+
+        yield 'class encrypt on immutable field (not updatable)' => [
+            ['fieldName' => 'name', 'notUpdatable' => true],
+        ];
+
+        yield 'class encrypt on immutable field (not insertable)' => [
+            ['fieldName' => 'name', 'notInsertable' => true],
+        ];
+    }
+
+    public function testFieldLevelEncryptOverridesClassLevelEncrypt(): void
+    {
+        $cm          = new ClassMetadata(CmsUser::class);
+        $cm->encrypt = EncryptMapping::fromMappingArray(['cipher' => 'class-cipher']);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapField(['fieldName' => 'name', 'encrypt' => ['cipher' => 'field-cipher']]);
+
+        self::assertNotEquals($cm->encrypt, $cm->fieldMappings['name']->encrypt);
+        self::assertSame('field-cipher', $cm->fieldMappings['name']->encrypt->cipher);
+    }
+
+    public function testMapEmbeddedCarriesEncryptMapping(): void
+    {
+        $cm = new ClassMetadata(UserTyped::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapEmbedded([
+            'fieldName' => 'contact',
+            'class' => Contact::class,
+            'encrypt' => [],
+        ]);
+
+        self::assertNotNull($cm->embeddedClasses['contact']->encrypt);
+    }
+
+    public function testInlineEmbeddableAppliesEmbeddableClassLevelEncryptToInlinedFields(): void
+    {
+        $embeddableMetadata          = new ClassMetadata(Contact::class);
+        $embeddableMetadata->encrypt = EncryptMapping::fromMappingArray(['cipher' => 'embedded-cipher']);
+        $embeddableMetadata->initializeReflection(new RuntimeReflectionService());
+        $embeddableMetadata->mapField(['fieldName' => 'email']);
+
+        $cm = new ClassMetadata(UserTyped::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->mapEmbedded(['fieldName' => 'contact', 'class' => Contact::class]);
+
+        $cm->inlineEmbeddable('contact', $embeddableMetadata);
+
+        self::assertNotNull($cm->fieldMappings['contact.email']->encrypt);
+        self::assertSame('embedded-cipher', $cm->fieldMappings['contact.email']->encrypt->cipher);
+    }
+
+    public function testInlineEmbeddablePreservesFieldLevelEncryptFromEmbeddable(): void
+    {
+        $embeddableMetadata = new ClassMetadata(Contact::class);
+        $embeddableMetadata->initializeReflection(new RuntimeReflectionService());
+        $embeddableMetadata->mapField(['fieldName' => 'email', 'encrypt' => ['cipher' => 'field-cipher']]);
+
+        $cm = new ClassMetadata(UserTyped::class);
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->mapEmbedded(['fieldName' => 'contact', 'class' => Contact::class, 'encrypt' => ['cipher' => 'embedded-cipher']]);
+
+        $cm->inlineEmbeddable('contact', $embeddableMetadata);
+
+        self::assertSame('field-cipher', $cm->fieldMappings['contact.email']->encrypt->cipher);
     }
 }
 

--- a/tests/Tests/ORM/Mapping/EmbeddedClassMappingTest.php
+++ b/tests/Tests/ORM/Mapping/EmbeddedClassMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\EmbeddedClassMapping;
+use Doctrine\ORM\Mapping\EncryptMapping;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
@@ -21,6 +22,7 @@ final class EmbeddedClassMappingTest extends TestCase
         $mapping->originalField = 'make';
         $mapping->inherited     = self::class; // no
         $mapping->declared      = self::class; // sense
+        $mapping->encrypt       = EncryptMapping::fromMappingArray(['cipher' => 'default_cipher']);
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof EmbeddedClassMapping);
@@ -30,5 +32,6 @@ final class EmbeddedClassMappingTest extends TestCase
         self::assertSame('make', $resurrectedMapping->originalField);
         self::assertSame(self::class, $resurrectedMapping->inherited);
         self::assertSame(self::class, $resurrectedMapping->declared);
+        self::assertEquals(EncryptMapping::fromMappingArray(['cipher' => 'default_cipher']), $resurrectedMapping->encrypt);
     }
 }

--- a/tests/Tests/ORM/Mapping/EncryptMappingTest.php
+++ b/tests/Tests/ORM/Mapping/EncryptMappingTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Mapping\Encrypt;
+use Doctrine\ORM\Mapping\EncryptMapping;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function serialize;
+use function unserialize;
+
+final class EncryptMappingTest extends TestCase
+{
+    public function testFromAttribute(): void
+    {
+        $mapping = EncryptMapping::fromAttribute(new Encrypt(
+            cipher: 'default_cipher',
+            keyProvider: 'default_key_provider',
+            queryType: EncryptQuery::Equality,
+        ));
+
+        self::assertSame('default_cipher', $mapping->cipher);
+        self::assertSame('default_key_provider', $mapping->keyProvider);
+        self::assertSame(EncryptQuery::Equality, $mapping->queryType);
+    }
+
+    /** @return iterable<string, array{array<string, string>, string|null, string|null, EncryptQuery|null}> */
+    public static function mappingArrayProvider(): iterable
+    {
+        yield 'all keys present' => [
+            [
+                'cipher' => 'default_cipher',
+                'keyProvider' => 'default_key_provider',
+                'queryType' => 'equality',
+            ],
+            'default_cipher',
+            'default_key_provider',
+            EncryptQuery::Equality,
+        ];
+
+        yield 'missing keys default to null' => [[], null, null, null];
+    }
+
+    /** @param array<string, string> $in */
+    #[DataProvider('mappingArrayProvider')]
+    public function testFromMappingArray(
+        array $in,
+        string|null $expectedCipher,
+        string|null $expectedKeyProvider,
+        EncryptQuery|null $expectedQueryType,
+    ): void {
+        $mapping = EncryptMapping::fromMappingArray($in);
+
+        self::assertSame($expectedCipher, $mapping->cipher);
+        self::assertSame($expectedKeyProvider, $mapping->keyProvider);
+        self::assertSame($expectedQueryType, $mapping->queryType);
+    }
+
+    public function testToArray(): void
+    {
+        $mapping = EncryptMapping::fromMappingArray([
+            'cipher' => 'default_cipher',
+            'keyProvider' => 'default_key_provider',
+            'queryType' => 'equality',
+        ]);
+
+        self::assertSame([
+            'cipher' => 'default_cipher',
+            'keyProvider' => 'default_key_provider',
+            'queryType' => EncryptQuery::Equality,
+        ], (array) $mapping);
+    }
+
+    public function testItSurvivesSerialization(): void
+    {
+        $mapping              = new EncryptMapping();
+        $mapping->cipher      = 'default_cipher';
+        $mapping->keyProvider = 'default_key_provider';
+        $mapping->queryType   = EncryptQuery::Equality;
+
+        $resurrectedMapping = unserialize(serialize($mapping));
+
+        self::assertInstanceOf(EncryptMapping::class, $resurrectedMapping);
+
+        self::assertSame('default_cipher', $resurrectedMapping->cipher);
+        self::assertSame('default_key_provider', $resurrectedMapping->keyProvider);
+        self::assertSame(EncryptQuery::Equality, $resurrectedMapping->queryType);
+    }
+}

--- a/tests/Tests/ORM/Mapping/EncryptTest.php
+++ b/tests/Tests/ORM/Mapping/EncryptTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Mapping\Encrypt;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EncryptTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $encrypt = new Encrypt();
+
+        self::assertNull($encrypt->cipher);
+        self::assertNull($encrypt->keyProvider);
+        self::assertNull($encrypt->queryType);
+    }
+
+    /** @return iterable<string, array{Encrypt, array<string, string|null>}> */
+    public static function toArrayProvider(): iterable
+    {
+        yield 'explicit values' => [
+            new Encrypt(
+                cipher: 'default_cipher',
+                keyProvider: 'default_key_provider',
+                queryType: EncryptQuery::Equality,
+            ),
+            [
+                'cipher' => 'default_cipher',
+                'keyProvider' => 'default_key_provider',
+                'queryType' => EncryptQuery::Equality,
+            ],
+        ];
+
+        yield 'defaults' => [
+            new Encrypt(),
+            [
+                'cipher' => null,
+                'keyProvider' => null,
+                'queryType' => null,
+            ],
+        ];
+    }
+
+    /** @param array<string, string|null> $expected */
+    #[DataProvider('toArrayProvider')]
+    public function testCastArray(Encrypt $attribute, array $expected): void
+    {
+        self::assertSame($expected, (array) $attribute);
+    }
+}

--- a/tests/Tests/ORM/Mapping/FieldMappingTest.php
+++ b/tests/Tests/ORM/Mapping/FieldMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\EncryptMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
 use PHPUnit\Framework\TestCase;
 
@@ -44,6 +45,7 @@ final class FieldMappingTest extends TestCase
         $mapping->options          = ['foo' => 'bar'];
         $mapping->version          = true;
         $mapping->default          = 'foo';
+        $mapping->encrypt          = EncryptMapping::fromMappingArray(['cipher' => 'default_cipher']);
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof FieldMapping);
@@ -70,5 +72,6 @@ final class FieldMappingTest extends TestCase
         self::assertSame(['foo' => 'bar'], $resurrectedMapping->options);
         self::assertTrue($resurrectedMapping->version);
         self::assertSame('foo', $resurrectedMapping->default);
+        self::assertEquals(EncryptMapping::fromMappingArray(['cipher' => 'default_cipher']), $resurrectedMapping->encrypt);
     }
 }

--- a/tests/Tests/ORM/Persisters/BasicEntityPersisterEncryptTest.php
+++ b/tests/Tests/ORM/Persisters/BasicEntityPersisterEncryptTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
+use Doctrine\ORM\Encrypt\EncryptQuery;
+use Doctrine\ORM\Encrypt\Exception\UnsupportedEncryptedFieldUsage;
+use Doctrine\ORM\Encrypt\KMS\KeyProvider;
+use Doctrine\ORM\Encrypt\KMS\KeyProviderRegistry;
+use Doctrine\ORM\Mapping\EncryptMapping;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\Tests\Mocks\EntityManagerMock;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+
+use function sprintf;
+
+class BasicEntityPersisterEncryptTest extends OrmTestCase
+{
+    private EntityManagerMock $entityManager;
+    private BasicEntityPersister $persister;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityManager = $this->getTestEntityManager();
+        $this->persister     = new BasicEntityPersister($this->entityManager, $this->entityManager->getClassMetadata(CmsUser::class));
+    }
+
+    /** @return iterable<string, array{array<string, mixed>, array<int, mixed>, array<int, string>}> */
+    public static function expandParametersProvider(): iterable
+    {
+        yield 'scalar' => [
+            ['status' => 'active', 'username' => 'joe'],
+            ['enc(active)', 'joe'],
+            ['text', 'string'],
+        ];
+
+        yield 'IN list' => [
+            ['status' => ['a', 'b'], 'username' => 'joe'],
+            ['enc(a)', 'enc(b)', 'joe'],
+            ['text', 'text', 'string'],
+        ];
+
+        yield 'all-null IN list' => [
+            ['status' => [null], 'username' => 'joe'],
+            ['joe'],
+            ['string'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $criteria
+     * @param array<int, mixed>    $expectedParams
+     * @param array<int, string>   $expectedTypes
+     */
+    #[DataProvider('expandParametersProvider')]
+    public function testExpandParameters(array $criteria, array $expectedParams, array $expectedTypes): void
+    {
+        $this->encryptCmsUserStatus();
+
+        [$params, $types] = $this->persister->expandParameters($criteria);
+
+        self::assertSame($expectedParams, $params);
+        self::assertSame($expectedTypes, $types);
+    }
+
+    public function testExpandCriteriaParametersEncryptsBothOccurrencesOfADuplicatedEncryptedField(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $criteria = Criteria::create()->where(
+            Criteria::expr()->orX(
+                Criteria::expr()->eq('status', 'a'),
+                Criteria::expr()->eq('status', 'b'),
+            ),
+        );
+
+        [$params] = $this->persister->expandCriteriaParameters($criteria);
+
+        self::assertSame(['enc(a)', 'enc(b)'], $params);
+    }
+
+    public function testExpandCriteriaParametersEncryptsNotEqualComparison(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $criteria = Criteria::create()->where(Criteria::expr()->neq('status', 'a'));
+
+        [$params, $types] = $this->persister->expandCriteriaParameters($criteria);
+
+        self::assertSame(['enc(a)'], $params);
+        self::assertSame(['text'], $types);
+    }
+
+    public function testExpandCriteriaParametersEncryptsNotInList(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $criteria = Criteria::create()->where(Criteria::expr()->notIn('status', ['a', 'b']));
+
+        [$params, $types] = $this->persister->expandCriteriaParameters($criteria);
+
+        self::assertSame(['enc(a)', 'enc(b)'], $params);
+        self::assertSame(['text', 'text'], $types);
+    }
+
+    public function testExpandCriteriaParametersOnAssociationFieldDoesNotEncrypt(): void
+    {
+        $criteria = Criteria::create()->where(Criteria::expr()->eq('email', 3));
+
+        [$params, $types] = $this->persister->expandCriteriaParameters($criteria);
+
+        self::assertEquals([3], $params);
+
+        self::assertEquals(['integer'], $types);
+    }
+
+    public function testExpandCriteriaParametersWithEmptyInListDoesNotEncryptNeighboringField(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $criteria = Criteria::create()->where(
+            Criteria::expr()->andX(
+                Criteria::expr()->in('status', []),
+                Criteria::expr()->eq('username', 'joe'),
+            ),
+        );
+
+        [$params, $types] = $this->persister->expandCriteriaParameters($criteria);
+
+        self::assertSame(['joe'], $params);
+        self::assertSame(['string'], $types);
+    }
+
+    /** @return iterable<string, array{Comparison, string}> */
+    public static function unsupportedOperatorProvider(): iterable
+    {
+        yield 'greater than' => [Criteria::expr()->gt('status', 'a'), '>'];
+        yield 'contains' => [Criteria::expr()->contains('status', 'a'), 'CONTAINS'];
+    }
+
+    #[DataProvider('unsupportedOperatorProvider')]
+    public function testExpandCriteriaParametersThrowsForNonEqualityOperatorOnEncryptedField(Comparison $comparison, string $operator): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage(sprintf(
+            'Doctrine\Tests\Models\CMS\CmsUser::$status is encrypted; filtering by an encrypted field only supports equality operators (=, <>, IN, NIN), got "%s".',
+            $operator,
+        ));
+
+        $this->persister->expandCriteriaParameters(Criteria::create()->where($comparison));
+    }
+
+    /** @return iterable<string, array{bool, EncryptQuery|null, string}> */
+    public static function nonQueryableFieldProvider(): iterable
+    {
+        yield 'missing queryType' => [
+            true,
+            null,
+            'Doctrine\Tests\Models\CMS\CmsUser::$status is encrypted; filtering by an encrypted field without queryType set is not supported.',
+        ];
+
+        yield 'non deterministic cipher' => [
+            false,
+            EncryptQuery::Equality,
+            'Doctrine\Tests\Models\CMS\CmsUser::$status is encrypted; filtering by an encrypted field using non deterministic cipher is not supported.',
+        ];
+    }
+
+    #[DataProvider('nonQueryableFieldProvider')]
+    public function testExpandParametersThrowsWhenEncryptedFieldIsNotQueryable(bool $deterministic, EncryptQuery|null $queryType, string $expectedMessage): void
+    {
+        $this->encryptCmsUserStatus($deterministic, $queryType);
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->persister->expandParameters(['status' => 'active']);
+    }
+
+    public function testGetSelectSQLThrowsWhenOrderingByEncryptedField(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage('Doctrine\Tests\Models\CMS\CmsUser::$status is encrypted; ordering by an encrypted field is not supported.');
+
+        $this->persister->getSelectSQL([], null, null, null, null, ['status' => 'ASC']);
+    }
+
+    public function testPrepareInsertDataEncryptsFieldAndLeavesOtherColumnsUntouched(): void
+    {
+        $this->encryptCmsUserStatus();
+
+        $user           = new CmsUser();
+        $user->status   = 'active';
+        $user->username = 'joe';
+
+        $this->entityManager->getUnitOfWork()->registerManaged($user, ['id' => 1], ['status' => null, 'username' => null]);
+        $this->entityManager->getUnitOfWork()->propertyChanged($user, 'status', null, 'active');
+        $this->entityManager->getUnitOfWork()->propertyChanged($user, 'username', null, 'joe');
+
+        $data = $this->invokeMethod($this->persister, 'prepareInsertData', $user);
+
+        self::assertSame('enc(active)', $data['cms_users']['status']);
+        self::assertSame('joe', $data['cms_users']['username']);
+    }
+
+    public function testPrepareInsertDataEncryptsFieldUnderItsOwningTableForJoinedInheritance(): void
+    {
+        $this->configureEncryption();
+        $this->encryptField(CompanyEmployee::class, 'name');
+
+        $employee = new CompanyEmployee();
+        $employee->setName('secret-name');
+
+        $this->entityManager->getUnitOfWork()->registerManaged($employee, ['id' => 1], ['name' => null]);
+        $this->entityManager->getUnitOfWork()->propertyChanged($employee, 'name', null, 'secret-name');
+
+        $persister = $this->entityManager->getUnitOfWork()->getEntityPersister(CompanyEmployee::class);
+        $data      = $this->invokeMethod($persister, 'prepareInsertData', $employee);
+
+        self::assertSame('enc(secret-name)', $data['company_persons']['name']);
+    }
+
+    public function testExpandToManyParametersUsesTheCriterionsOwnClassForQueryabilityChecks(): void
+    {
+        $this->configureEncryption();
+        $this->encryptField(CmsAddress::class, 'city', null);
+
+        $this->expectException(UnsupportedEncryptedFieldUsage::class);
+        $this->expectExceptionMessage('Doctrine\Tests\Models\CMS\CmsAddress::$city is encrypted; filtering by an encrypted field without queryType set is not supported.');
+
+        $this->invokeMethod($this->persister, 'expandToManyParameters', [
+            ['field' => 'city', 'value' => 'Paris', 'class' => $this->entityManager->getClassMetadata(CmsAddress::class)],
+        ]);
+    }
+
+    private function createCipher(bool $deterministic): Cipher
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn(false);
+        $cipher->method('isDeterministic')->willReturn($deterministic);
+        $cipher->method('encrypt')->willReturnCallback(static fn (string $plaintext): string => 'enc(' . $plaintext . ')');
+
+        return $cipher;
+    }
+
+    private function configureEncryption(bool $deterministic = true): void
+    {
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($this->createCipher($deterministic));
+
+        $keyProviderRegistry = $this->createStub(KeyProviderRegistry::class);
+        $keyProviderRegistry->method('getKeyProvider')->willReturn($this->createStub(KeyProvider::class));
+
+        $this->entityManager->getConfiguration()->setCipherRegistry($cipherRegistry);
+        $this->entityManager->getConfiguration()->setKeyProviderRegistry($keyProviderRegistry);
+    }
+
+    /** @param class-string $className */
+    private function encryptField(string $className, string $fieldName, EncryptQuery|null $queryType = EncryptQuery::Equality): void
+    {
+        $encrypt            = new EncryptMapping();
+        $encrypt->queryType = $queryType;
+
+        $this->entityManager->getClassMetadata($className)->fieldMappings[$fieldName]->encrypt = $encrypt;
+    }
+
+    private function encryptCmsUserStatus(bool $deterministic = true, EncryptQuery|null $queryType = EncryptQuery::Equality): void
+    {
+        $this->configureEncryption($deterministic);
+        $this->encryptField(CmsUser::class, 'status', $queryType);
+    }
+
+    private function invokeMethod(object $object, string $method, mixed ...$args): mixed
+    {
+        return (new ReflectionMethod($object, $method))->invoke($object, ...$args);
+    }
+}

--- a/tests/Tests/ORM/Query/EncryptedQuerySetMappingTest.php
+++ b/tests/Tests/ORM/Query/EncryptedQuerySetMappingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query;
+
+use Doctrine\ORM\Query\EncryptedQuerySetMapping;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EncryptedQuerySetMapping::class)]
+final class EncryptedQuerySetMappingTest extends TestCase
+{
+    public function testEmptyByDefault(): void
+    {
+        $eqsm = new EncryptedQuerySetMapping();
+
+        self::assertTrue($eqsm->isEmpty());
+        self::assertSame([], $eqsm->getEncryptedParameters());
+    }
+
+    public function testAddEncryptedParameter(): void
+    {
+        $eqsm = new EncryptedQuerySetMapping();
+
+        $eqsm->addEncryptedParameter(1, CmsUser::class, 'name');
+        $eqsm->addEncryptedParameter('city', CmsAddress::class, 'city');
+
+        self::assertFalse($eqsm->isEmpty());
+        self::assertSame(
+            [
+                1 => [CmsUser::class, 'name'],
+                'city' => [CmsAddress::class, 'city'],
+            ],
+            $eqsm->getEncryptedParameters(),
+        );
+    }
+
+    public function testAddEncryptedParameters(): void
+    {
+        $eqsm = new EncryptedQuerySetMapping();
+
+        $eqsm->addEncryptedParameters([1, 3, 'name'], CmsUser::class, 'name');
+
+        self::assertSame(
+            [
+                1 => [CmsUser::class, 'name'],
+                3 => [CmsUser::class, 'name'],
+                'name' => [CmsUser::class, 'name'],
+            ],
+            $eqsm->getEncryptedParameters(),
+        );
+    }
+
+    public function testAddEncryptedParameterOverridesSamePosition(): void
+    {
+        $eqsm = new EncryptedQuerySetMapping();
+
+        $eqsm->addEncryptedParameter(1, CmsUser::class, 'name');
+        $eqsm->addEncryptedParameter(1, CmsAddress::class, 'city');
+
+        self::assertSame([1 => [CmsAddress::class, 'city']], $eqsm->getEncryptedParameters());
+    }
+}

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -14,10 +14,17 @@ use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraintEditor;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table as DbalTable;
+use Doctrine\DBAL\Types\BlobType;
 use Doctrine\DBAL\Types\EnumType;
+use Doctrine\DBAL\Types\TextType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Encrypt\Cipher\Cipher;
+use Doctrine\ORM\Encrypt\Cipher\CipherRegistry;
+use Doctrine\ORM\Encrypt\Exception\EncryptConfigurationMissing;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\EncryptMapping;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Index;
@@ -53,6 +60,7 @@ use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\GH10288\GH10288People;
 use Doctrine\Tests\Models\NullDefault\NullDefaultColumn;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 
@@ -583,6 +591,71 @@ class SchemaToolTest extends OrmTestCase
             $schema->hasTable('cms_address'),
             'The original table should have been overwritten by the listener, so cms_address table should not exist.',
         );
+    }
+
+    /** @return iterable<string, array{bool, class-string}> */
+    public static function encryptedFieldColumnTypeProvider(): iterable
+    {
+        yield 'binary cipher' => [true, BlobType::class];
+        yield 'non-binary cipher' => [false, TextType::class];
+    }
+
+    /** @param class-string $expectedType */
+    #[DataProvider('encryptedFieldColumnTypeProvider')]
+    public function testEncryptedFieldUsesColumnTypeMatchingCipherBinaryness(bool $cipherIsBinary, string $expectedType): void
+    {
+        $em = $this->createEntityManagerWithEncryptedCmsUserStatus($cipherIsBinary);
+
+        $schema = (new SchemaTool($em))->getSchemaFromMetadata([$em->getClassMetadata(CmsUser::class)]);
+
+        self::assertInstanceOf($expectedType, $schema->getTable('cms_users')->getColumn('status')->getType());
+    }
+
+    public function testEncryptedFieldStripsPlaintextColumnOptions(): void
+    {
+        $em = $this->createEntityManagerWithEncryptedCmsUserStatus(cipherIsBinary: true);
+
+        $statusMapping            = $em->getClassMetadata(CmsUser::class)->fieldMappings['status'];
+        $statusMapping->precision = 10;
+        $statusMapping->scale     = 2;
+        $statusMapping->options   = ['fixed' => true, 'default' => 'foo'];
+
+        $schema = (new SchemaTool($em))->getSchemaFromMetadata([$em->getClassMetadata(CmsUser::class)]);
+        $column = $schema->getTable('cms_users')->getColumn('status');
+
+        // The fixture maps status with length 50; the ciphertext column must not inherit it.
+        self::assertNull($column->getLength());
+        self::assertNull($column->getPrecision());
+        self::assertSame(0, $column->getScale());
+        self::assertFalse($column->getFixed());
+        self::assertNull($column->getDefault());
+    }
+
+    public function testEncryptedFieldWithoutCipherRegistryConfiguredThrowsException(): void
+    {
+        $em = $this->getTestEntityManager();
+
+        $em->getClassMetadata(CmsUser::class)->fieldMappings['status']->encrypt = new EncryptMapping();
+
+        $this->expectException(EncryptConfigurationMissing::class);
+        $this->expectExceptionMessage('Cipher registry is not configured. Call Configuration::setCipherRegistry() to set it.');
+
+        (new SchemaTool($em))->getSchemaFromMetadata([$em->getClassMetadata(CmsUser::class)]);
+    }
+
+    private function createEntityManagerWithEncryptedCmsUserStatus(bool $cipherIsBinary): EntityManagerInterface
+    {
+        $cipher = $this->createStub(Cipher::class);
+        $cipher->method('isBinary')->willReturn($cipherIsBinary);
+
+        $cipherRegistry = $this->createStub(CipherRegistry::class);
+        $cipherRegistry->method('getCipher')->willReturn($cipher);
+
+        $em = $this->getTestEntityManager();
+        $em->getConfiguration()->setCipherRegistry($cipherRegistry);
+        $em->getClassMetadata(CmsUser::class)->fieldMappings['status']->encrypt = new EncryptMapping();
+
+        return $em;
     }
 
     /** @return string[] */


### PR DESCRIPTION
# Add transparent field encryption, with queryable capability

This PR is about adding Client-Side Encryption to ORM, big inspiration from [MongoDB and ODM](https://www.doctrine-project.org/projects/doctrine-mongodb-odm/en/2.16/cookbook/queryable-encryption.html) (***cc & thanks to @GromNaN***)

Goals:
- Encrypted data between your app & DBMS
- Plain data in your entities
- Possible to flag an entity's field to be queryable
- Simple DX as possible
- Fully additive code and opt-in - nothing changes for entities that don't use (the PR is mainly only added code)
- No use of any Custom/Encrypt DBAL Types

Limitations (working on it, future PRs):
- Attribute mapping only, no XML (in coming)
- Command to plan (CRON) re-encrypt values on key rotation
- Harden scope context for key provider & cipher: scope to a row/cell (currently best is scope to column), but with lower performances
- Equality is the only supported query type (no range/`LIKE`/ordering on encrypted fields).
- Equality is only against deterministic cipher
- No second-level cache on entities with encrypted fields.

Futures possibilities too (working on some too):
- Update documentation (but only after the merge on this PR :crossed_fingers:)
- PR to Symfony's Doctrine bundle incoming
- Implementing some concrete Cipher and KeyProvider (e.g. for Hashicorp, Bridge for future [KMS Symfony component](https://github.com/symfony/symfony/pull/64052), etc...) but maybe not in doctrine/orm => additional dependency?

## DX

### Mapping on Entity

```php
#[Entity]
class Customer
{
    #[Column(type: 'string', length: 255)]
    #[Encrypt(cipher: 'deterministic', keyProvider: 'main', queryType: EncryptQuery::Equality)]
    public string $ssn;

    #[Column(type: 'string', length: 255)]
    #[Encrypt]
    public string $note;

    #[Column(type: Types::DATETIMETZ_IMMUTABLE)]
    #[Encrypt(queryType: EncryptQuery::Equality)]
    public ?\DateTimeImmutable $startAt = null;
}
```

`#[Encrypt]` also works at the class level, applying to every eligible scalar field that doesn't declare its own.

### Configuration

Two registries, wired once on `Configuration`:

```php
$config->setCipherRegistry(new MyCipherRegistry([
    'random' => new OpenSSLCipher(),
    'deterministic' => new OpenSSLCipher(deterministic: true),
], default: 'random'));

$config->setKeyProviderRegistry(new ArrayKeyProviderRegistry([
    'main' => ArraySymmetricKeyProvider::fromScalars(['k1' => $base64KeyMaterial]),
]));
```

You may want to use your own KeyProviderRegistry in your app, not the `ArrayKeyProviderRegistry`.

### Reading and writing

no API changes; `persist()`/`flush()` encrypt automatically, every hydration mode (`find()`, DQL, native queries)
decrypts automatically:

```php
$customer = new Customer();
$customer->ssn = '123-45-6789';
$em->persist($customer);
$em->flush(); // stored as ciphertext

$customers = $em->getRepository(Customer::class)->findAll(); // Entities got plain data
```

### Querying

Equality work as normal on encrypted fields, but only with QueryType set:

```php
$em->createQuery('SELECT c FROM Customer c WHERE c.ssn = :ssn')
    ->setParameter('ssn', '123-45-6789')
    ->getResult();

$em->getRepository(Customer::class)->findOneBy(['ssn' => '123-45-6789']);

$em->createQueryBuilder('c')
    ->where('c.ssn = :ssn')
    ->setParameter('ssn', '123-45-6789')
    ->getQuery()
    ->getResult();
// You can also use other hydratation mode, like array. ->getArrayResult()
```

The parameter is encrypted client-side before the SQL runs. Range operators, `LIKE`, `ORDER BY`
and literal comparisons on encrypted fields are rejected with `UnsupportedEncryptedFieldUsage`
(equality is the only supported query type for now).

### Key rotation

If a field value changed, its automatically encrypt with the latest rotated key from your KeyProvider.
For now, there is no tools to automatically re-encrypt a table when key rotation occurred.
(work in progress, PR in future)

### Getting encrypted raw data

You can get encrypted raw data by disabling decrypt calling `ResultSetMapping::disableDecrypt()` and using
NativeQuery.

```php
$rsm = new ResultSetMapping();
$rsm->disableDecrypt();
// build rsm here
$query = $em->createNativeQuery('SELECT id, name, ssn FROM customer WHERE name = ?', $rsm);
$query->setParameter(1, 'joe');
$customers = $query->getResult();

```

## Architecture

### KMS

A small KMS system is added, to permit doctrine to get key for cipher.

### Cipher system

Services that handle encrypt/decrypt. A cipher can read/output binary or string value, base on that, it will be
store in DB using binary or string type (e.g. `BLOB` or `TEXT`)

Cipher can implement `BatchableCipher` to batch encrypt/decrypt call, useful when using HTTP cipher like hashicorp.

Only one build-in cipher for basic usage: `OpenSSLCipher`.

### Introduce EncryptQuerySetMapping

Introducing a similar concept as `ResultSetMapping`: `EncryptQuerySetMapping`. It is used by the parser to keep
track of bind parameters that are used to filter a query and need to by encrypt before executing a query.

### 

## **!!! DISCLAIMER !!!**

**This encrypt feature does not provide any guarantees against adversaries attack, especially (not exhaustive)
those with access to your keys or to your app runtime environment.**

## Review info

For readability, I tried to scope steps commit per commit:
- Each commit cover a part, tests/cs/etc... should work per commit
- Some commits may contain stuffs used in next commits (I did my best to scope, but its not perfect)
- Still, this PR must be handled as one whole feature.

I target `3.7.x` but I can rebase on `4.0.x` if needed :wink:

## Questions I asked myself

- I add `ArraySymmetricKeyProvider` and `ArrayKeyProviderRegistry` but its maybe better to remove them it let
implements to dev or framework bridge.
- WDYT of adding a `disableDecrypt` to `Query` (that call the one from RSM)? Used with non object hydratation,
It can allow to use Query and QueryBuilder to request encrypt raw data.
- Maybe renaming `EncryptQuerySetMapping` into `QuerySetMapping` and make it track all query set, not only
the encrypted ones? Useless for the encrypt feature but can be useful for other features

