### PR TITLE
Inherit sequence generator definitions from mapped superclasses

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -499,7 +499,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * </code>
      *
      * @var array<string, mixed>|null
-     * @phpstan-var array{sequenceName: string, allocationSize: string, initialValue: string, quoted?: mixed}|null
+     * @phpstan-var array{sequenceName: string, allocationSize: string, initialValue: string, quoted?: mixed, implicit?: bool}|null
      * @todo Merge with tableGeneratorDefinition into generic generatorDefinition
      */
     public array|null $sequenceGeneratorDefinition = null;
@@ -2467,7 +2467,7 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
      * )
      * </code>
      *
-     * @phpstan-param array{sequenceName?: string, allocationSize?: int|string, initialValue?: int|string, quoted?: mixed} $definition
+     * @phpstan-param array{sequenceName?: string, allocationSize?: int|string, initialValue?: int|string, quoted?: mixed, implicit?: bool} $definition
      *
      * @throws MappingException
      */

--- a/src/Mapping/ClassMetadataFactory.php
+++ b/src/Mapping/ClassMetadataFactory.php
@@ -168,7 +168,14 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         // If this class has a parent the id generator strategy is inherited.
         // However this is only true if the hierarchy of parents contains the root entity,
         // if it consists of mapped superclasses these don't necessarily include the id field.
-        if ($parent && $rootEntityFound) {
+        if (
+            $parent
+            && (
+                $rootEntityFound
+                || $parent->sequenceGeneratorDefinition !== null
+                && ! isset($parent->sequenceGeneratorDefinition['implicit'])
+            )
+        ) {
             $this->inheritIdGeneratorMapping($class, $parent);
         } else {
             $this->completeIdGeneratorMapping($class);
@@ -574,6 +581,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         'sequenceName'      => $this->truncateSequenceName($sequenceName),
                         'allocationSize'    => 1,
                         'initialValue'      => 1,
+                        'implicit'          => true,
                     ];
 
                     if ($quoted) {

--- a/tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -157,6 +157,19 @@ class BasicInheritanceMappingTest extends OrmTestCase
         self::assertArrayHasKey('id', $class->fieldMappings);
     }
 
+    #[Group('GH-12390')]
+    public function testSequenceDefinitionFromMappedSuperclassIsInherited(): void
+    {
+        $class = $this->cmf->getMetadataFor(SuperclassEntity::class);
+        assert($class instanceof ClassMetadata);
+
+        self::assertInstanceOf(IdSequenceGenerator::class, $class->idGenerator);
+        self::assertSame(
+            ['sequenceName' => 'foo', 'allocationSize' => '1', 'initialValue' => '10'],
+            $class->sequenceGeneratorDefinition,
+        );
+    }
+
     #[Group('DDC-1156')]
     #[Group('DDC-1218')]
     #[Group('GH-10927')]


### PR DESCRIPTION
## Summary

- inherit explicit sequence generator definitions from mapped superclasses
- keep generating class-specific defaults when no explicit definition is configured
- add a regression test for the inherited sequence name and generator configuration

## Problem

`ClassMetadataFactory` inherited the identifier generator type from a mapped superclass, but not its sequence generator definition. As a result, completing the child entity metadata synthesized a default sequence name instead of using the explicitly configured name from the mapped superclass.

The generated default definition is now marked as implicit. Explicit definitions are inherited unchanged, while implicit definitions continue to be regenerated for each entity class.

Fixes #12390

## Validation

- `vendor/bin/phpunit --filter testSequenceDefinitionFromMappedSuperclassIsInherited tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php`
- `vendor/bin/phpunit tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php`
- verified the existing GH10927 sequence names for implicit definitions
- PHP syntax checks for all changed files
- `vendor/bin/phpcs src/Mapping/ClassMetadata.php src/Mapping/ClassMetadataFactory.php tests/Tests/ORM/Mapping/BasicInheritanceMappingTest.php`
- `vendor/bin/phpstan analyse --no-progress src/Mapping/ClassMetadata.php src/Mapping/ClassMetadataFactory.php`
