### PR TITLE
Make `LockMode::NONE` a no-op

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -48,6 +48,13 @@ Both now do nothing, which is consistent with `EntityManager::refresh()` and
 `Query::setLockMode()`. If you relied on `find()` reloading the entity, call
 `EntityManager::refresh()` explicitly.
 
+## Deprecated passing `null` as lock mode
+
+Since `LockMode::NONE` is now a no-op, passing `null` as lock mode to
+`EntityManager::find()`, `EntityManager::refresh()` or `EntityRepository::find()`
+is deprecated as it is equivalent to passing `LockMode::NONE`. Omit the argument
+or pass `LockMode::NONE` instead.
+
 ## Deprecated `Doctrine\ORM\Query\AST\TypedExpression`
 
 Implement `Doctrine\ORM\Query\AST\ExpressionWithReturnType` instead, which exposes

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,6 +34,20 @@ and directly start using native lazy objects.
 Using it has no effect, it should have been removed in 3.0.0. Instead, use the
 `Doctrine\ORM\Mapping\JoinColumn` attribute multiple times.
 
+## `LockMode::NONE` is now a no-op
+
+`LockMode::NONE` means "no lock", but it used to be handled like a pessimistic
+lock mode in two places:
+
+- `EntityManager::find()` refreshed an entity that was already in the identity
+  map, discarding any in-memory changes.
+- `EntityManager::lock()` required an active transaction and ran a `SELECT`
+  statement without any lock hint.
+
+Both now do nothing, which is consistent with `EntityManager::refresh()` and
+`Query::setLockMode()`. If you relied on `find()` reloading the entity, call
+`EntityManager::refresh()` explicitly.
+
 ## Deprecated `Doctrine\ORM\Query\AST\TypedExpression`
 
 Implement `Doctrine\ORM\Query\AST\ExpressionWithReturnType` instead, which exposes

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -112,12 +112,12 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
         $this->wrapped->lock($entity, $lockMode, $lockVersion);
     }
 
-    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
         return $this->wrapped->find($className, $id, $lockMode, $lockVersion);
     }
 
-    public function refresh(object $object, LockMode|int|null $lockMode = null): void
+    public function refresh(object $object, LockMode|int|null $lockMode = LockMode::NONE): void
     {
         $this->wrapped->refresh($object, $lockMode);
     }

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -10,6 +10,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;
@@ -272,13 +273,22 @@ class EntityManager implements EntityManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function find($className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find($className, mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
+        if ($lockMode === null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12548',
+                'Passing null as lock mode to %s() is deprecated and will not be possible in Doctrine ORM 4.0, pass LockMode::NONE instead.',
+                __METHOD__,
+            );
+
+            $lockMode = LockMode::NONE;
+        }
+
         $class = $this->metadataFactory->getMetadataFor(ltrim($className, '\\'));
 
-        if ($lockMode !== null) {
-            $this->checkLockRequirements($lockMode, $class);
-        }
+        $this->checkLockRequirements($lockMode, $class);
 
         if (! is_array($id)) {
             if ($class->isIdentifierComposite) {
@@ -459,8 +469,19 @@ class EntityManager implements EntityManagerInterface
         $this->unitOfWork->remove($object);
     }
 
-    public function refresh(object $object, LockMode|int|null $lockMode = null): void
+    public function refresh(object $object, LockMode|int|null $lockMode = LockMode::NONE): void
     {
+        if ($lockMode === null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/12548',
+                'Passing null as lock mode to %s() is deprecated and will not be possible in Doctrine ORM 4.0, pass LockMode::NONE instead.',
+                __METHOD__,
+            );
+
+            $lockMode = LockMode::NONE;
+        }
+
         $this->errorIfClosed();
 
         $this->unitOfWork->refresh($object, $lockMode);

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -336,7 +336,6 @@ class EntityManager implements EntityManagerInterface
                     $this->lock($entity, $lockMode, $lockVersion);
                     break;
 
-                case $lockMode === LockMode::NONE:
                 case $lockMode === LockMode::PESSIMISTIC_READ:
                 case $lockMode === LockMode::PESSIMISTIC_WRITE:
                     $persister = $unitOfWork->getEntityPersister($class->name);

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -113,9 +113,9 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @param string            $className   The class name of the entity to find.
      * @param mixed             $id          The identity of the entity to find.
-     * @param LockMode|int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
-     *                                       or NULL if no specific lock mode should be used
-     *                                       during the search.
+     * @param LockMode|int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants.
+     *                                       Passing NULL is deprecated, use LockMode::NONE
+     *                                       instead.
      * @param int|null          $lockVersion The version of the entity to find when using
      *                                       optimistic locking.
      * @phpstan-param class-string<T> $className
@@ -131,22 +131,22 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @template T of object
      */
-    public function find(string $className, mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null;
+    public function find(string $className, mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null;
 
     /**
      * Refreshes the persistent state of an object from the database,
      * overriding any local changes that have not yet been persisted.
      *
-     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                                    or NULL if no specific lock mode should be used
-     *                                    during the search.
+     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
+     *                                    Passing NULL is deprecated, use LockMode::NONE
+     *                                    instead.
      * @phpstan-param LockMode::*|null $lockMode
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
      * @throws TransactionRequiredException
      */
-    public function refresh(object $object, LockMode|int|null $lockMode = null): void;
+    public function refresh(object $object, LockMode|int|null $lockMode = LockMode::NONE): void;
 
     /**
      * Gets a reference to the entity identified by the given type and identifier

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -74,15 +74,15 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Finds an entity by its primary key / identifier.
      *
-     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                                    or NULL if no specific lock mode should be used
-     *                                    during the search.
+     * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
+     *                                    Passing NULL is deprecated, use LockMode::NONE
+     *                                    instead.
      * @phpstan-param LockMode::*|null $lockMode
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @phpstan-return ?T
      */
-    public function find(mixed $id, LockMode|int|null $lockMode = null, int|null $lockVersion = null): object|null
+    public function find(mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
         return $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
     }

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2320,7 +2320,6 @@ class UnitOfWork implements PropertyChangedListener
 
                 break;
 
-            case $lockMode === LockMode::NONE:
             case $lockMode === LockMode::PESSIMISTIC_READ:
             case $lockMode === LockMode::PESSIMISTIC_WRITE:
                 if (! $this->em->getConnection()->isTransactionActive()) {

--- a/tests/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Tests/ORM/Functional/Locking/LockTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\TransactionRequiredException;
@@ -16,10 +17,13 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 #[Group('locking')]
 class LockTest extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $this->useModelSet('cms');
@@ -122,6 +126,54 @@ class LockTest extends OrmFunctionalTestCase
         self::assertSame($article, $found);
         self::assertSame('Changed in memory', $found->topic);
         $this->assertQueryCount(0);
+    }
+
+    #[Group('locking')]
+    #[IgnoreDeprecations]
+    public function testFindWithNullLockModeIsDeprecated(): void
+    {
+        $article        = new CmsArticle();
+        $article->text  = 'my article';
+        $article->topic = 'Hello';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
+
+        $this->_em->find(CmsArticle::class, $article->id, null);
+    }
+
+    #[Group('locking')]
+    #[IgnoreDeprecations]
+    public function testRefreshWithNullLockModeIsDeprecated(): void
+    {
+        $article        = new CmsArticle();
+        $article->text  = 'my article';
+        $article->topic = 'Hello';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
+
+        $this->_em->refresh($article, null);
+    }
+
+    #[Group('locking')]
+    public function testFindWithoutLockModeIsNotDeprecated(): void
+    {
+        $article        = new CmsArticle();
+        $article->text  = 'my article';
+        $article->topic = 'Hello';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
+
+        $this->_em->find(CmsArticle::class, $article->id);
+        $this->_em->refresh($article);
     }
 
     #[Group('DDC-178')]

--- a/tests/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Tests/ORM/Functional/Locking/LockTest.php
@@ -86,6 +86,44 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
+    #[Group('locking')]
+    public function testLockWithLockModeNoneDoesNotRequireTransaction(): void
+    {
+        $article        = new CmsArticle();
+        $article->text  = 'my article';
+        $article->topic = 'Hello';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->lock($article, LockMode::NONE);
+
+        $this->assertQueryCount(0);
+    }
+
+    #[Group('locking')]
+    public function testFindWithLockModeNoneDoesNotRefreshManagedEntity(): void
+    {
+        $article        = new CmsArticle();
+        $article->text  = 'my article';
+        $article->topic = 'Hello';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $article->topic = 'Changed in memory';
+
+        $this->getQueryLog()->reset()->enable();
+
+        $found = $this->_em->find(CmsArticle::class, $article->id, LockMode::NONE);
+
+        self::assertSame($article, $found);
+        self::assertSame('Changed in memory', $found->topic);
+        $this->assertQueryCount(0);
+    }
+
     #[Group('DDC-178')]
     #[Group('locking')]
     public function testLockPessimisticReadNoTransactionThrowsException(): void


### PR DESCRIPTION
`LockMode::NONE` means "no lock", yet two code paths still treated it like a pessimistic lock mode:

- `EntityManager::find()` refreshed an entity that was already in the identity map, silently discarding in-memory changes. A caller asking for "no lock" has no reason to expect a reload.
- `UnitOfWork::lock()` demanded an active transaction and then executed `SELECT 1 FROM <table> WHERE id = ?` with no lock hint at all — a query that locks nothing.

Both are leftovers from doctrine/orm#932 (2014), when `LockMode::NONE` made SQL Server emit `WITH (NOLOCK)` and therefore did affect isolation. DBAL removed that hint in doctrine/dbal#4400 because it "is not the contract of `LockMode::NONE`", so nothing is left to guard.

`EntityManager::refresh()`, `checkLockRequirements()` and (since #12516) `Query::setLockMode()` already ignore `NONE`. This aligns the last two.

Follow-up to #12516, and picks up the remainder of the closed #8341.