### PR TITLE
[GH-12403] Fix stale original-data tracking for native lazy objects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3430,12 +3430,6 @@ parameters:
 			path: src/UnitOfWork.php
 
 		-
-			message: '#^Property Doctrine\\ORM\\UnitOfWork\:\:\$entityChangeSets \(array\<int, array\<string, array\{mixed, mixed\}\>\>\) does not accept non\-empty\-array\<int, array\<string, array\{mixed, mixed\}\|Doctrine\\ORM\\PersistentCollection\>\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/UnitOfWork.php
-
-		-
 			message: '#^Unable to resolve the template type T in call to method static method Symfony\\Component\\VarExporter\\Hydrator\:\:hydrate\(\)$#'
 			identifier: argument.templateType
 			count: 1

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -666,7 +666,7 @@ class UnitOfWork implements PropertyChangedListener
             $originalData = $this->originalEntityData[$oid];
             $changeSet    = [];
 
-            if ($originalData === [] && ! $this->isUninitializedObject($entity)) {
+            if (PHP_VERSION_ID >= 80400 && $originalData === [] && ! $this->isUninitializedObject($entity)) {
                 $this->reconcileStalePartialLoadTracking($oid, $class, $actualData, $originalData, $changeSet);
             }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -666,6 +666,38 @@ class UnitOfWork implements PropertyChangedListener
             $originalData = $this->originalEntityData[$oid];
             $changeSet    = [];
 
+            if ($originalData === [] && ! $this->isUninitializedObject($entity)) {
+                // A native lazy association proxy is registered with an empty data
+                // snapshot (see registerManaged() callers below) until it is fully
+                // hydrated through UnitOfWork::createEntity(). But PHP can complete
+                // such an object's initialization without ever going through that
+                // method — e.g. hydrating the owning side of a to-one association
+                // assigns the inverse-side property directly onto the still-lazy
+                // proxy, and if that happens to be the proxy's only remaining
+                // property, PHP marks it fully initialized right there. When that
+                // happens this entity is no longer "uninitialized" per
+                // isUninitializedObject(), yet originalEntityData was never
+                // populated, so every field below would be silently and
+                // permanently treated as "a partially omitted one" and skipped
+                // forever. We have no reliable prior value for any of these
+                // fields, so force them into this change set (mirroring how
+                // brand-new entities are treated above) to make sure the entity's
+                // current value reaches the database, then adopt it as the
+                // baseline for future comparisons.
+                foreach ($actualData as $propName => $actualValue) {
+                    if (
+                        ! isset($class->associationMappings[$propName])
+                        || $class->associationMappings[$propName]->isToOneOwningSide()
+                    ) {
+                        $changeSet[$propName] = [null, $actualValue];
+                    }
+
+                    $originalData[$propName] = $actualValue;
+                }
+
+                $this->originalEntityData[$oid] = $originalData;
+            }
+
             foreach ($actualData as $propName => $actualValue) {
                 // skip field, its a partially omitted one!
                 if (! (isset($originalData[$propName]) || array_key_exists($propName, $originalData))) {

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -666,6 +666,10 @@ class UnitOfWork implements PropertyChangedListener
             $originalData = $this->originalEntityData[$oid];
             $changeSet    = [];
 
+            if (PHP_VERSION_ID >= 80400 && $originalData === [] && ! $this->isUninitializedObject($entity)) {
+                $this->reconcileStalePartialLoadTracking($oid, $class, $actualData, $originalData, $changeSet);
+            }
+
             foreach ($actualData as $propName => $actualValue) {
                 // skip field, its a partially omitted one!
                 if (! (isset($originalData[$propName]) || array_key_exists($propName, $originalData))) {
@@ -774,6 +778,51 @@ class UnitOfWork implements PropertyChangedListener
                 $this->entityUpdates[$oid]      = $entity;
             }
         }
+    }
+
+    /**
+     * A native lazy association proxy is registered with an empty data
+     * snapshot (see registerManaged() callers below) until it is fully
+     * hydrated through UnitOfWork::createEntity(). But PHP can complete
+     * such an object's initialization without ever going through that
+     * method — e.g. hydrating the owning side of a to-one association
+     * assigns the inverse-side property directly onto the still-lazy
+     * proxy, and if that happens to be the proxy's only remaining
+     * property, PHP marks it fully initialized right there. When that
+     * happens this entity is no longer "uninitialized" per
+     * isUninitializedObject(), yet originalEntityData was never
+     * populated, so every field would be silently and permanently
+     * treated as "a partially omitted one" and skipped forever. We have
+     * no reliable prior value for any of these fields, so force them
+     * into this change set (mirroring how brand-new entities are
+     * treated in computeChangeSet()) to make sure the entity's current
+     * value reaches the database, then adopt it as the baseline for
+     * future comparisons.
+     *
+     * @param ClassMetadata<object> $class
+     * @param array<string, mixed>  $actualData
+     * @param array<string, mixed>  $originalData
+     * @param array<string, mixed>  $changeSet
+     */
+    private function reconcileStalePartialLoadTracking(
+        int $oid,
+        ClassMetadata $class,
+        array $actualData,
+        array &$originalData,
+        array &$changeSet,
+    ): void {
+        foreach ($actualData as $propName => $actualValue) {
+            if (
+                ! isset($class->associationMappings[$propName])
+                || $class->associationMappings[$propName]->isToOneOwningSide()
+            ) {
+                $changeSet[$propName] = [null, $actualValue];
+            }
+
+            $originalData[$propName] = $actualValue;
+        }
+
+        $this->originalEntityData[$oid] = $originalData;
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -667,35 +667,7 @@ class UnitOfWork implements PropertyChangedListener
             $changeSet    = [];
 
             if ($originalData === [] && ! $this->isUninitializedObject($entity)) {
-                // A native lazy association proxy is registered with an empty data
-                // snapshot (see registerManaged() callers below) until it is fully
-                // hydrated through UnitOfWork::createEntity(). But PHP can complete
-                // such an object's initialization without ever going through that
-                // method — e.g. hydrating the owning side of a to-one association
-                // assigns the inverse-side property directly onto the still-lazy
-                // proxy, and if that happens to be the proxy's only remaining
-                // property, PHP marks it fully initialized right there. When that
-                // happens this entity is no longer "uninitialized" per
-                // isUninitializedObject(), yet originalEntityData was never
-                // populated, so every field below would be silently and
-                // permanently treated as "a partially omitted one" and skipped
-                // forever. We have no reliable prior value for any of these
-                // fields, so force them into this change set (mirroring how
-                // brand-new entities are treated above) to make sure the entity's
-                // current value reaches the database, then adopt it as the
-                // baseline for future comparisons.
-                foreach ($actualData as $propName => $actualValue) {
-                    if (
-                        ! isset($class->associationMappings[$propName])
-                        || $class->associationMappings[$propName]->isToOneOwningSide()
-                    ) {
-                        $changeSet[$propName] = [null, $actualValue];
-                    }
-
-                    $originalData[$propName] = $actualValue;
-                }
-
-                $this->originalEntityData[$oid] = $originalData;
+                $this->reconcileStalePartialLoadTracking($oid, $class, $actualData, $originalData, $changeSet);
             }
 
             foreach ($actualData as $propName => $actualValue) {
@@ -806,6 +778,51 @@ class UnitOfWork implements PropertyChangedListener
                 $this->entityUpdates[$oid]      = $entity;
             }
         }
+    }
+
+    /**
+     * A native lazy association proxy is registered with an empty data
+     * snapshot (see registerManaged() callers below) until it is fully
+     * hydrated through UnitOfWork::createEntity(). But PHP can complete
+     * such an object's initialization without ever going through that
+     * method — e.g. hydrating the owning side of a to-one association
+     * assigns the inverse-side property directly onto the still-lazy
+     * proxy, and if that happens to be the proxy's only remaining
+     * property, PHP marks it fully initialized right there. When that
+     * happens this entity is no longer "uninitialized" per
+     * isUninitializedObject(), yet originalEntityData was never
+     * populated, so every field would be silently and permanently
+     * treated as "a partially omitted one" and skipped forever. We have
+     * no reliable prior value for any of these fields, so force them
+     * into this change set (mirroring how brand-new entities are
+     * treated in computeChangeSet()) to make sure the entity's current
+     * value reaches the database, then adopt it as the baseline for
+     * future comparisons.
+     *
+     * @param ClassMetadata<object> $class
+     * @param array<string, mixed>  $actualData
+     * @param array<string, mixed>  $originalData
+     * @param array<string, mixed>  $changeSet
+     */
+    private function reconcileStalePartialLoadTracking(
+        int $oid,
+        ClassMetadata $class,
+        array $actualData,
+        array &$originalData,
+        array &$changeSet,
+    ): void {
+        foreach ($actualData as $propName => $actualValue) {
+            if (
+                ! isset($class->associationMappings[$propName])
+                || $class->associationMappings[$propName]->isToOneOwningSide()
+            ) {
+                $changeSet[$propName] = [null, $actualValue];
+            }
+
+            $originalData[$propName] = $actualValue;
+        }
+
+        $this->originalEntityData[$oid] = $originalData;
     }
 
     /**

--- a/tests/Tests/Models/GH12403/GH12403ScalarEntity.php
+++ b/tests/Tests/Models/GH12403/GH12403ScalarEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH12403;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'gh12403_scalar_entity')]
+class GH12403ScalarEntity
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int|null $id = null;
+
+    #[Column(type: 'string', length: 50)]
+    public string $name = '';
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -15,11 +15,11 @@ class GH12403Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
         if (PHP_VERSION_ID < 80400 || !$this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
             $this->markTestSkipped('Test requires PHP 8.4+ and native lazy objects enabled.');
         }
-
-        parent::setUp();
 
         $this->createSchemaForModels(GH12403ScalarEntity::class, OwningSide::class, InverseSide::class);
     }

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -15,8 +15,8 @@ class GH12403Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
-        if (PHP_VERSION_ID < 80400) {
-            $this->markTestSkipped('Test requires PHP 8.4+');
+        if (PHP_VERSION_ID < 80400 || !$this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $this->markTestSkipped('Test requires PHP 8.4+ and native lazy objects enabled.');
         }
 
         parent::setUp();

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -8,6 +8,7 @@ use Doctrine\Tests\Models\GH12403\GH12403ScalarEntity;
 use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
 use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
 use Doctrine\Tests\OrmFunctionalTestCase;
+
 use const PHP_VERSION_ID;
 
 /** @see https://github.com/doctrine/orm/issues/12403 */
@@ -17,7 +18,7 @@ class GH12403Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        if (PHP_VERSION_ID < 80400 || !$this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+        if (PHP_VERSION_ID < 80400 || ! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
             $this->markTestSkipped('Test requires PHP 8.4+ and native lazy objects enabled.');
         }
 
@@ -53,10 +54,18 @@ class GH12403Test extends OrmFunctionalTestCase
 
         $target = $reloadedOwner->inverse;
 
-        self::assertFalse(
-            $this->isUninitializedObject($target),
-            'InverseSide has no scalar fields of its own, so hydrating the owning side leaves it fully assigned and therefore no longer "uninitialized" per PHP, despite never being loaded through UnitOfWork::createEntity().',
-        );
+        if ($this->_em->getConfiguration()->isSecondLevelCacheEnabled()) {
+            // With the Second Level Cache enabled, association hydration takes a
+            // different path (through UnitOfWork::createEntity() via the cache
+            // hydrator) that does not trigger the silent auto-initialization
+            // below, so the target legitimately stays lazy here.
+            self::assertTrue($this->isUninitializedObject($target));
+        } else {
+            self::assertFalse(
+                $this->isUninitializedObject($target),
+                'InverseSide has no scalar fields of its own, so hydrating the owning side leaves it fully assigned and therefore no longer "uninitialized" per PHP, despite never being loaded through UnitOfWork::createEntity().',
+            );
+        }
 
         // A flush must not error out or otherwise mishandle this entity, even
         // though it is now included in change-tracking despite having never

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -8,12 +8,17 @@ use Doctrine\Tests\Models\GH12403\GH12403ScalarEntity;
 use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
 use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use const PHP_VERSION_ID;
 
 /** @see https://github.com/doctrine/orm/issues/12403 */
 class GH12403Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
+        if (PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Test requires PHP 8.4+');
+        }
+
         parent::setUp();
 
         $this->createSchemaForModels(GH12403ScalarEntity::class, OwningSide::class, InverseSide::class);

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH12403\GH12403ScalarEntity;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/** @see https://github.com/doctrine/orm/issues/12403 */
+class GH12403Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(GH12403ScalarEntity::class, OwningSide::class, InverseSide::class);
+    }
+
+    /**
+     * A to-one association's target proxy can end up with every one of its
+     * properties assigned (identifier at proxy-creation time, remaining
+     * properties as a side effect of hydrating the owning side, e.g. the
+     * inverse-association sync) without ever running the proxy's registered
+     * initializer. PHP then reports such an object as no longer uninitialized,
+     * even though UnitOfWork::createEntity() never ran for it and never
+     * recorded a snapshot of its data.
+     */
+    public function testAssociationTargetCanSilentlyCompleteNativeLazyInitialization(): void
+    {
+        $owner   = new OwningSide();
+        $inverse = new InverseSide();
+
+        $owner->id       = 'gh12403-owner';
+        $inverse->id     = 'gh12403-inverse';
+        $owner->inverse  = $inverse;
+        $inverse->owning = $owner;
+
+        $this->_em->persist($owner);
+        $this->_em->persist($inverse);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reloadedOwner = $this->_em->find(OwningSide::class, 'gh12403-owner');
+        self::assertNotNull($reloadedOwner);
+
+        $target = $reloadedOwner->inverse;
+
+        self::assertFalse(
+            $this->isUninitializedObject($target),
+            'InverseSide has no scalar fields of its own, so hydrating the owning side leaves it fully assigned and therefore no longer "uninitialized" per PHP, despite never being loaded through UnitOfWork::createEntity().',
+        );
+
+        // A flush must not error out or otherwise mishandle this entity, even
+        // though it is now included in change-tracking despite having never
+        // gone through the ORM's own hydration bookkeeping.
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $checked = $this->_em->find(InverseSide::class, 'gh12403-inverse');
+        self::assertNotNull($checked);
+        self::assertInstanceOf(OwningSide::class, $checked->owning);
+        self::assertSame('gh12403-owner', $checked->owning->id);
+    }
+
+    /**
+     * Direct reproduction of the reported symptom: once an entity's native
+     * lazy object is completed by some means other than
+     * UnitOfWork::createEntity(), its changes used to be silently and
+     * permanently dropped from every future flush(), because the entity's
+     * empty original-data snapshot was trusted forever.
+     */
+    public function testChangeIsPersistedAfterEntityIsInitializedWithoutGoingThroughCreateEntity(): void
+    {
+        $entity       = new GH12403ScalarEntity();
+        $entity->name = 'old name';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $id        = $entity->id;
+        $reference = $this->_em->getReference(GH12403ScalarEntity::class, $id);
+
+        self::assertTrue($this->isUninitializedObject($reference));
+
+        // Simulate the object becoming initialized through a path other than
+        // UnitOfWork::createEntity(), as observed for association proxies
+        // above.
+        $this->_em->getClassMetadata(GH12403ScalarEntity::class)->reflClass->markLazyObjectAsInitialized($reference);
+        self::assertFalse($this->isUninitializedObject($reference));
+
+        $reference->name = 'new name';
+        $this->_em->flush();
+
+        $name = $this->_em->getConnection()->fetchOne(
+            'SELECT name FROM gh12403_scalar_entity WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame('new name', $name);
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH12403Test.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH12403\GH12403ScalarEntity;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+/** @see https://github.com/doctrine/orm/issues/12403 */
+#[RequiresPhp('>=8.4.0')]
+class GH12403Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $this->markTestSkipped('Test requires native lazy objects enabled.');
+        }
+
+        $this->createSchemaForModels(GH12403ScalarEntity::class, OwningSide::class, InverseSide::class);
+    }
+
+    /**
+     * A to-one association's target proxy can end up with every one of its
+     * properties assigned (identifier at proxy-creation time, remaining
+     * properties as a side effect of hydrating the owning side, e.g. the
+     * inverse-association sync) without ever running the proxy's registered
+     * initializer. PHP then reports such an object as no longer uninitialized,
+     * even though UnitOfWork::createEntity() never ran for it and never
+     * recorded a snapshot of its data.
+     */
+    public function testAssociationTargetCanSilentlyCompleteNativeLazyInitialization(): void
+    {
+        $owner   = new OwningSide();
+        $inverse = new InverseSide();
+
+        $owner->id       = 'gh12403-owner';
+        $inverse->id     = 'gh12403-inverse';
+        $owner->inverse  = $inverse;
+        $inverse->owning = $owner;
+
+        $this->_em->persist($owner);
+        $this->_em->persist($inverse);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reloadedOwner = $this->_em->find(OwningSide::class, 'gh12403-owner');
+        self::assertNotNull($reloadedOwner);
+
+        $target = $reloadedOwner->inverse;
+
+        if ($this->_em->getConfiguration()->isSecondLevelCacheEnabled()) {
+            // With the Second Level Cache enabled, association hydration takes a
+            // different path (through UnitOfWork::createEntity() via the cache
+            // hydrator) that does not trigger the silent auto-initialization
+            // below, so the target legitimately stays lazy here.
+            self::assertTrue($this->isUninitializedObject($target));
+        } else {
+            self::assertFalse(
+                $this->isUninitializedObject($target),
+                'InverseSide has no scalar fields of its own, so hydrating the owning side leaves it fully assigned and therefore no longer "uninitialized" per PHP, despite never being loaded through UnitOfWork::createEntity().',
+            );
+        }
+
+        // A flush must not error out or otherwise mishandle this entity, even
+        // though it is now included in change-tracking despite having never
+        // gone through the ORM's own hydration bookkeeping.
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $checked = $this->_em->find(InverseSide::class, 'gh12403-inverse');
+        self::assertNotNull($checked);
+        self::assertInstanceOf(OwningSide::class, $checked->owning);
+        self::assertSame('gh12403-owner', $checked->owning->id);
+    }
+
+    /**
+     * Direct reproduction of the reported symptom: once an entity's native
+     * lazy object is completed by some means other than
+     * UnitOfWork::createEntity(), its changes used to be silently and
+     * permanently dropped from every future flush(), because the entity's
+     * empty original-data snapshot was trusted forever.
+     */
+    public function testChangeIsPersistedAfterEntityIsInitializedWithoutGoingThroughCreateEntity(): void
+    {
+        $entity       = new GH12403ScalarEntity();
+        $entity->name = 'old name';
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $id        = $entity->id;
+        $reference = $this->_em->getReference(GH12403ScalarEntity::class, $id);
+
+        self::assertTrue($this->isUninitializedObject($reference));
+
+        // Simulate the object becoming initialized through a path other than
+        // UnitOfWork::createEntity(), as observed for association proxies
+        // above.
+        $this->_em->getClassMetadata(GH12403ScalarEntity::class)->reflClass->markLazyObjectAsInitialized($reference);
+        self::assertFalse($this->isUninitializedObject($reference));
+
+        $reference->name = 'new name';
+        $this->_em->flush();
+
+        $name = $this->_em->getConnection()->fetchOne(
+            'SELECT name FROM gh12403_scalar_entity WHERE id = ?',
+            [$id],
+        );
+
+        self::assertSame('new name', $name);
+    }
+}


### PR DESCRIPTION
The fix in #12556 is a bit complicated, this is a simpler version.

Fixes #12403 