### PR TITLE
Check useDbalEditorApi once in getSchemaFromMedata()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2997,7 +2997,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Doctrine\\ORM\\Mapping\\ManyToManyInverseSideMapping\|Doctrine\\ORM\\Mapping\\ManyToManyOwningSideMapping\|Doctrine\\ORM\\Mapping\\ManyToOneAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToManyAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToOneInverseSideMapping\|Doctrine\\ORM\\Mapping\\OneToOneOwningSideMapping\:\:\$joinColumns\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 5
 			path: src/Tools/SchemaTool.php
 
 		-
@@ -3059,6 +3059,12 @@ parameters:
 
 		-
 			message: '#^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:dropSchema\(\) has parameter \$classes with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Method Doctrine\\ORM\\Tools\\SchemaTool\:\:experimentalGetSchemaFromMetadata\(\) has parameter \$classes with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Tools/SchemaTool.php
@@ -3154,9 +3160,27 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
-			message: '#^Parameter \#2 \$columns of class Doctrine\\DBAL\\Schema\\Index constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			message: '#^Parameter \#1 \$columnName of method Doctrine\\DBAL\\Schema\\TableEditor\:\:modifyColumnByUnquotedName\(\) expects non\-empty\-string, string given\.$#'
 			identifier: argument.type
 			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addIndex\(\) expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \#1 \$columnNames of method Doctrine\\DBAL\\Schema\\Table\:\:addUniqueIndex\(\) expects non\-empty\-list\<string\>, array\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
+			message: '#^Parameter \#2 \$columns of class Doctrine\\DBAL\\Schema\\Index constructor expects non\-empty\-list\<string\>, list\<string\> given\.$#'
+			identifier: argument.type
+			count: 2
 			path: src/Tools/SchemaTool.php
 
 		-
@@ -3166,15 +3190,21 @@ parameters:
 			path: src/Tools/SchemaTool.php
 
 		-
+			message: '#^Parameter \#2 \$modification of method Doctrine\\DBAL\\Schema\\TableEditor\:\:modifyColumnByUnquotedName\(\) expects callable\(Doctrine\\DBAL\\Schema\\ColumnEditor\)\: void, Closure\(Doctrine\\DBAL\\Schema\\ColumnEditor\)\: Doctrine\\DBAL\\Schema\\ColumnEditor given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Tools/SchemaTool.php
+
+		-
 			message: '#^Parameter \#2 \$primaryKeyColumns of method Doctrine\\ORM\\Tools\\SchemaTool\:\:addPrimaryKeyConstraint\(\) expects non\-empty\-array\<non\-empty\-string\>, list\<string\> given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 3
 			path: src/Tools/SchemaTool.php
 
 		-
 			message: '#^Parameter \#2 \$primaryKeyColumns of method Doctrine\\ORM\\Tools\\SchemaTool\:\:addPrimaryKeyConstraint\(\) expects non\-empty\-array\<non\-empty\-string\>, non\-empty\-list\<string\> given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Tools/SchemaTool.php
 
 		-

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -196,11 +196,13 @@ class SchemaTool
      */
     public function getSchemaFromMetadata(array $classes): Schema
     {
-        if (! $this->useDbalEditorApi) {
-            Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7373');
-            Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7381');
-            Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7389');
+        if ($this->useDbalEditorApi) {
+            return $this->experimentalGetSchemaFromMetadata($classes);
         }
+
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7373');
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7381');
+        Deprecation::ignoreDeprecations('https://github.com/doctrine/dbal/pull/7389');
 
         // Reminder for processed classes, used for hierarchies
         $processedClasses     = [];
@@ -219,15 +221,7 @@ class SchemaTool
 
             $tableName = $this->quoteStrategy->getTableName($class, $this->platform);
 
-            if ($this->useDbalEditorApi) {
-                $table = new Table(
-                    name: $tableName,
-                    configuration: $metadataSchemaConfig->toTableConfiguration(),
-                    options: $metadataSchemaConfig->getDefaultTableOptions(),
-                );
-            } else {
-                $table = $schema->createTable($tableName);
-            }
+            $table = $schema->createTable($tableName);
 
             if ($class->isInheritanceTypeSingleTable()) {
                 // For new schema API: collect join tables to add after this entity table
@@ -306,16 +300,7 @@ class SchemaTool
                                 $this->platform,
                             );
                             // TODO: This seems rather hackish, can we optimize it?
-                            if ($this->useDbalEditorApi) {
-                                // New API: modify column using table editor (creates new table object)
-                                // This is safe because we'll add the table to schema later after all modifications
-                                $table = $table->edit()->modifyColumnByUnquotedName(
-                                    $columnName,
-                                    static fn (ColumnEditor $column) => $column->setAutoincrement(false),
-                                )->create();
-                            } else {
-                                $table->getColumn($columnName)->setAutoincrement(false);
-                            }
+                            $table->getColumn($columnName)->setAutoincrement(false);
 
                             $pkColumns[]           = $columnName;
                             $inheritedKeyColumns[] = $columnName;
@@ -443,31 +428,12 @@ class SchemaTool
             }
 
             if (isset($class->table['options'])) {
-                if ($this->useDbalEditorApi) {
-                    $table = $table->edit()->setOptions($class->table['options'])->create();
-                } else {
-                    foreach ($class->table['options'] as $key => $val) {
-                        $table->addOption($key, $val);
-                    }
+                foreach ($class->table['options'] as $key => $val) {
+                    $table->addOption($key, $val);
                 }
             }
 
             $processedClasses[$class->name] = true;
-
-            // Add the fully populated table to the schema
-            if ($this->useDbalEditorApi) {
-                // @phpstan-ignore method.notFound (Using unreleased Schema::edit() API)
-                $schemaEditor = $schema->edit();
-                $schemaEditor->addTable($table);
-
-                // Add any join tables collected during relation processing
-                // This ensures join tables appear right after their owning entity table
-                foreach ($joinTablesToAdd as $joinTable) {
-                    $schemaEditor->addTable($joinTable);
-                }
-
-                $schema = $schemaEditor->create();
-            }
 
             if ($class->isIdGeneratorSequence() && $class->name === $class->rootEntityName) {
                 $seqDef     = $class->sequenceGeneratorDefinition;
@@ -513,31 +479,351 @@ class SchemaTool
                 continue;
             }
 
-            if ($this->useDbalEditorApi) {
-                // the table might have been dropped by a listener, so we ignore this error
-                if ($schema->hasTable($fkData['table']->getObjectName()->toString())) {
-                    $schema = $schema->edit()->modifyTable(
-                        $fkData['table']->getObjectName(),
-                        static function (TableEditor $tableEditor) use ($fkData): void {
-                            $tableEditor->addForeignKeyConstraint(new ForeignKeyConstraint(
-                                localColumnNames: $fkData['localColumns'],
-                                foreignTableName: $fkData['foreignTableName'],
-                                foreignColumnNames: $fkData['foreignColumns'],
-                                options: $fkData['fkOptions'],
-                                name: $fkData['name'] ?? '',
-                            ));
-                        },
-                    )->create();
+            // Add the FK constraint to the table
+            $fkData['table']->addForeignKeyConstraint(
+                $fkData['foreignTableName'],
+                $fkData['localColumns'],
+                $fkData['foreignColumns'],
+                $fkData['fkOptions'],
+                $fkData['name'],
+            );
+        }
+
+        $schemaEventArgs = new GenerateSchemaEventArgs($this->em, $schema);
+        $eventManager->dispatchEvent(
+            ToolEvents::postGenerateSchema,
+            $schemaEventArgs,
+        );
+
+        // Always retrieve the schema (listener may have mutated it)
+        $schema = $schemaEventArgs->getSchema();
+
+        $eventManager->dispatchEvent(
+            ToolEvents::postGenerateSchema,
+            new GenerateSchemaEventArgs($this->em, $schema),
+        );
+
+        return $schema;
+    }
+
+    /**
+     * Creates a Schema instance from a given set of metadata classes, using the DBAL editor API
+     *
+     * @phpstan-param list<ClassMetadata> $classes
+     *
+     * @throws NotSupported
+     */
+    private function experimentalGetSchemaFromMetadata(array $classes): Schema
+    {
+        // Reminder for processed classes, used for hierarchies
+        $processedClasses     = [];
+        $eventManager         = $this->em->getEventManager();
+        $metadataSchemaConfig = $this->schemaManager->createSchemaConfig();
+
+        $schema = new Schema([], [], $metadataSchemaConfig);
+
+        $addedFks       = [];
+        $blacklistedFks = [];
+
+        foreach ($classes as $class) {
+            if ($this->processingNotRequired($class, $processedClasses)) {
+                continue;
+            }
+
+            $tableName = $this->quoteStrategy->getTableName($class, $this->platform);
+
+            $table = new Table(
+                name: $tableName,
+                configuration: $metadataSchemaConfig->toTableConfiguration(),
+                options: $metadataSchemaConfig->getDefaultTableOptions(),
+            );
+
+            if ($class->isInheritanceTypeSingleTable()) {
+                // For new schema API: collect join tables to add after this entity table
+                $joinTablesToAdd = [];
+
+                $this->gatherColumns($class, $table);
+                $this->gatherRelationsSql(
+                    $class,
+                    $table,
+                    $schema,
+                    $addedFks,
+                    $blacklistedFks,
+                    $metadataSchemaConfig,
+                    $joinTablesToAdd,
+                );
+
+                // Add the discriminator column
+                $this->addDiscriminatorColumnDefinition($class, $table);
+
+                // Aggregate all the information from all classes in the hierarchy
+                foreach ($class->parentClasses as $parentClassName) {
+                    // Parent class information is already contained in this class
+                    $processedClasses[$parentClassName] = true;
+                }
+
+                foreach ($class->subClasses as $subClassName) {
+                    $subClass = $this->em->getClassMetadata($subClassName);
+                    $this->gatherColumns($subClass, $table);
+                    $this->gatherRelationsSql(
+                        $subClass,
+                        $table,
+                        $schema,
+                        $addedFks,
+                        $blacklistedFks,
+                        $metadataSchemaConfig,
+                        $joinTablesToAdd,
+                    );
+                    $processedClasses[$subClassName] = true;
+                }
+            } elseif ($class->isInheritanceTypeJoined()) {
+                // For new schema API: collect join tables to add after this entity table
+                $joinTablesToAdd = [];
+
+                // Add all non-inherited fields as columns
+                foreach ($class->fieldMappings as $fieldName => $mapping) {
+                    if (! isset($mapping->inherited)) {
+                        $this->gatherColumn($class, $mapping, $table);
+                    }
+                }
+
+                $this->gatherRelationsSql(
+                    $class,
+                    $table,
+                    $schema,
+                    $addedFks,
+                    $blacklistedFks,
+                    $metadataSchemaConfig,
+                    $joinTablesToAdd,
+                );
+
+                // Add the discriminator column only to the root table
+                if ($class->name === $class->rootEntityName) {
+                    $this->addDiscriminatorColumnDefinition($class, $table);
+                } else {
+                    // Add an ID FK column to child tables
+                    $pkColumns           = [];
+                    $inheritedKeyColumns = [];
+
+                    foreach ($class->identifier as $identifierField) {
+                        if (isset($class->fieldMappings[$identifierField]->inherited)) {
+                            $idMapping = $class->fieldMappings[$identifierField];
+                            $this->gatherColumn($class, $idMapping, $table);
+                            $columnName = $this->quoteStrategy->getColumnName(
+                                $identifierField,
+                                $class,
+                                $this->platform,
+                            );
+                            // TODO: This seems rather hackish, can we optimize it?
+                            // New API: modify column using table editor (creates new table object)
+                            // This is safe because we'll add the table to schema later after all modifications
+                            $table = $table->edit()->modifyColumnByUnquotedName(
+                                $columnName,
+                                static fn (ColumnEditor $column) => $column->setAutoincrement(false),
+                            )->create();
+
+                            $pkColumns[]           = $columnName;
+                            $inheritedKeyColumns[] = $columnName;
+
+                            continue;
+                        }
+
+                        if (isset($class->associationMappings[$identifierField]->inherited)) {
+                            $idMapping = $class->associationMappings[$identifierField];
+                            assert($idMapping->isToOneOwningSide());
+
+                            $targetEntity = current(
+                                array_filter(
+                                    $classes,
+                                    static fn (ClassMetadata $class): bool => $class->name === $idMapping->targetEntity,
+                                ),
+                            );
+
+                            foreach ($idMapping->joinColumns as $joinColumn) {
+                                if (isset($targetEntity->fieldMappings[$joinColumn->referencedColumnName])) {
+                                    $columnName = $this->quoteStrategy->getJoinColumnName(
+                                        $joinColumn,
+                                        $class,
+                                        $this->platform,
+                                    );
+
+                                    $pkColumns[]           = $columnName;
+                                    $inheritedKeyColumns[] = $columnName;
+                                }
+                            }
+                        }
+                    }
+
+                    if ($inheritedKeyColumns !== []) {
+                        // Add a FK constraint on the ID column
+                        $table->addForeignKeyConstraint(
+                            $this->quoteStrategy->getTableName(
+                                $this->em->getClassMetadata($class->rootEntityName),
+                                $this->platform,
+                            ),
+                            $inheritedKeyColumns,
+                            $inheritedKeyColumns,
+                            ['onDelete' => 'CASCADE'],
+                        );
+                    }
+
+                    if ($pkColumns !== []) {
+                        self::addPrimaryKeyConstraint($table, $pkColumns);
+                    }
                 }
             } else {
-                // Add the FK constraint to the table
-                $fkData['table']->addForeignKeyConstraint(
-                    $fkData['foreignTableName'],
-                    $fkData['localColumns'],
-                    $fkData['foreignColumns'],
-                    $fkData['fkOptions'],
-                    $fkData['name'],
+                // For new schema API: collect join tables to add after this entity table
+                $joinTablesToAdd = [];
+
+                $this->gatherColumns($class, $table);
+                $this->gatherRelationsSql(
+                    $class,
+                    $table,
+                    $schema,
+                    $addedFks,
+                    $blacklistedFks,
+                    $metadataSchemaConfig,
+                    $joinTablesToAdd,
                 );
+            }
+
+            $pkColumns = [];
+
+            foreach ($class->identifier as $identifierField) {
+                if (isset($class->fieldMappings[$identifierField])) {
+                    $pkColumns[] = $this->quoteStrategy->getColumnName($identifierField, $class, $this->platform);
+                } elseif (isset($class->associationMappings[$identifierField])) {
+                    $assoc = $class->associationMappings[$identifierField];
+                    assert($assoc->isToOneOwningSide());
+
+                    foreach ($assoc->joinColumns as $joinColumn) {
+                        $pkColumns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
+                    }
+                }
+            }
+
+            if (! $table->hasIndex('primary')) {
+                self::addPrimaryKeyConstraint($table, $pkColumns);
+            }
+
+            // there can be unique indexes automatically created for join column
+            // if join column is also primary key we should keep only primary key on this column
+            // so, remove indexes overruled by primary key
+            $primaryKey = $table->getIndex('primary');
+
+            foreach ($table->getIndexes() as $idxKey => $existingIndex) {
+                if ($existingIndex !== $primaryKey && $primaryKey->spansColumns(self::getIndexedColumns($existingIndex))) {
+                    $table->dropIndex($idxKey);
+                }
+            }
+
+            if (isset($class->table['indexes'])) {
+                foreach ($class->table['indexes'] as $indexName => $indexData) {
+                    if (! isset($indexData['flags'])) {
+                        $indexData['flags'] = [];
+                    }
+
+                    $table->addIndex(
+                        $this->getIndexColumns($class, $indexData),
+                        is_numeric($indexName) ? null : $indexName,
+                        (array) $indexData['flags'],
+                        $indexData['options'] ?? [],
+                    );
+                }
+            }
+
+            if (isset($class->table['uniqueConstraints'])) {
+                foreach ($class->table['uniqueConstraints'] as $indexName => $indexData) {
+                    $uniqIndex = new Index('tmp__' . $indexName, $this->getIndexColumns($class, $indexData), true, false, [], $indexData['options'] ?? []);
+
+                    foreach ($table->getIndexes() as $tableIndexName => $tableIndex) {
+                        if ($tableIndex->isFulfilledBy($uniqIndex)) {
+                            $table->dropIndex($tableIndexName);
+                            break;
+                        }
+                    }
+
+                    $table->addUniqueIndex(self::getIndexedColumns($uniqIndex), is_numeric($indexName) ? null : $indexName, $indexData['options'] ?? []);
+                }
+            }
+
+            if (isset($class->table['options'])) {
+                $table = $table->edit()->setOptions($class->table['options'])->create();
+            }
+
+            $processedClasses[$class->name] = true;
+
+            // Add the fully populated table to the schema
+            // @phpstan-ignore method.notFound (Using unreleased Schema::edit() API)
+            $schemaEditor = $schema->edit();
+            $schemaEditor->addTable($table);
+
+            // Add any join tables collected during relation processing
+            // This ensures join tables appear right after their owning entity table
+            foreach ($joinTablesToAdd as $joinTable) {
+                $schemaEditor->addTable($joinTable);
+            }
+
+            $schema = $schemaEditor->create();
+
+            if ($class->isIdGeneratorSequence() && $class->name === $class->rootEntityName) {
+                $seqDef     = $class->sequenceGeneratorDefinition;
+                $quotedName = $this->quoteStrategy->getSequenceName($seqDef, $class, $this->platform);
+                if (! $schema->hasSequence($quotedName)) {
+                    $schema->createSequence(
+                        $quotedName,
+                        (int) $seqDef['allocationSize'],
+                        (int) $seqDef['initialValue'],
+                    );
+                }
+            }
+
+            $tableEventArgs = new GenerateSchemaTableEventArgs($class, $schema, $table);
+            $eventManager->dispatchEvent(
+                ToolEvents::postGenerateSchemaTable,
+                $tableEventArgs,
+            );
+
+            // Always retrieve the schema (listener may have mutated it)
+            $schema = $tableEventArgs->getSchema();
+
+                // If the listener mutated the table, we need to replace it in the schema
+            if ($tableEventArgs->classTableWasMutated()) {
+                $originalTableName = $table->getObjectName();
+                $newTable          = $tableEventArgs->getClassTable();
+
+                // @phpstan-ignore method.notFound (Using unreleased Schema::edit() API)
+                $schema = $schema->edit()
+                    ->dropTable($originalTableName)
+                    ->addTable($newTable)
+                    ->create();
+
+                $table = $newTable;
+            }
+        }
+
+        // After all classes have been processed and all FK metadata collected,
+        // apply the non-conflicting FK constraints to their respective tables
+        foreach ($addedFks as $compositeName => $fkData) {
+            // Skip if this composite key was blacklisted due to conflicts
+            if (isset($blacklistedFks[$compositeName])) {
+                continue;
+            }
+
+            // the table might have been dropped by a listener, so we ignore this error
+            if ($schema->hasTable($fkData['table']->getObjectName()->toString())) {
+                $schema = $schema->edit()->modifyTable(
+                    $fkData['table']->getObjectName(),
+                    static function (TableEditor $tableEditor) use ($fkData): void {
+                        $tableEditor->addForeignKeyConstraint(new ForeignKeyConstraint(
+                            localColumnNames: $fkData['localColumns'],
+                            foreignTableName: $fkData['foreignTableName'],
+                            foreignColumnNames: $fkData['foreignColumns'],
+                            options: $fkData['fkOptions'],
+                            name: $fkData['name'] ?? '',
+                        ));
+                    },
+                )->create();
             }
         }
 


### PR DESCRIPTION
Follow up to https://github.com/doctrine/orm/pull/12554

That method was riddled with such checks, and that situation is going to
get worse. Let us duplicate it, so that it is easier to read.

There is another method that also contains such checks, but for now it contains only 2.
