### PR TITLE
Add `OffsetPaginator` and align `CursorPaginator` on an immutable page API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -55,6 +55,39 @@ Since `LockMode::NONE` is now a no-op, passing `null` as lock mode to
 is deprecated as it is equivalent to passing `LockMode::NONE`. Omit the argument
 or pass `LockMode::NONE` instead.
 
+## Deprecated `Doctrine\ORM\Tools\Pagination\Paginator`
+
+Use `Doctrine\ORM\Tools\Pagination\OffsetPaginator` instead. The first result and
+the maximum number of results are no longer read implicitly from the query: they
+are passed together as a `Window` value object to `paginate()`, which returns an
+immutable, iterable `WindowPage`.
+
+```diff
+-use Doctrine\ORM\Tools\Pagination\Paginator;
++use Doctrine\ORM\Tools\Pagination\OffsetPaginator;
++use Doctrine\ORM\Tools\Pagination\Window;
+
+-$query = $entityManager->createQuery($dql)
+-    ->setFirstResult(0)
+-    ->setMaxResults(25);
++$query = $entityManager->createQuery($dql);
+
+-$paginator = new Paginator($query, fetchJoinCollection: true);
++$page = (new OffsetPaginator(fetchJoinCollection: true))
++    ->paginate($query, new Window(0, 25));
+
+-$total = count($paginator);
++$total = $page->getTotalCount();
+
+-foreach ($paginator as $post) {
++foreach ($page as $post) {
+     // ...
+ }
+```
+
+`Paginator::setUseOutputWalkers()` becomes the `useOutputWalkers` constructor
+argument of `OffsetPaginator`.
+
 ## Deprecated `Doctrine\ORM\Query\AST\TypedExpression`
 
 Implement `Doctrine\ORM\Query\AST\ExpressionWithReturnType` instead, which exposes

--- a/docs/en/tutorials/pagination.rst
+++ b/docs/en/tutorials/pagination.rst
@@ -8,7 +8,7 @@ the low-level SQL plumbing, but they make different trade-offs:
    :header-rows: 1
 
    * - Feature
-     - Offset ``Paginator``
+     - ``OffsetPaginator``
      - ``CursorPaginator``
    * - Total count
      - Yes (extra query)
@@ -37,9 +37,148 @@ cost of an extra ``COUNT`` query.
 Offset-Based Pagination
 -----------------------
 
-Doctrine ORM ships with a Paginator for DQL queries. It
-has a very simple API and implements the SPL interfaces ``Countable`` and
-``IteratorAggregate``.
+Doctrine ORM ships with the ``OffsetPaginator`` for offset-based pagination of
+DQL queries. The query and the pagination position — a ``Window`` value object,
+which carries both a first result and a page size — are both passed to
+``paginate()``, which returns an immutable, iterable ``WindowPage``. This mirrors
+the ``CursorPaginator`` API.
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Tools\Pagination\OffsetPaginator;
+    use Doctrine\ORM\Tools\Pagination\Window;
+
+    $dql   = 'SELECT p, c FROM BlogPost p JOIN p.comments c ORDER BY p.id ASC';
+    $query = $entityManager->createQuery($dql);
+
+    // new Window($firstResult, $maxResults), or Window::fromPageNumberAndSize($pageNumber, $pageSize)
+    $page = (new OffsetPaginator())->paginate($query, Window::fromPageNumberAndSize(1, 25));
+
+    echo $page->getTotalCount() . " result(s), page {$page->getPageNumber()} of {$page->getPageCount()}\n";
+
+    foreach ($page as $post) {
+        echo $post->getHeadline() . "\n";
+    }
+
+    if ($page->hasNextPage()) {
+        $nextWindow = $page->getNextWindow(); // Window for the next page
+    }
+
+The paginator itself holds no query and no position, only configuration: a
+single instance is stateless and can be reused — or registered as a service —
+for any query and any page.
+
+.. code-block:: php
+
+    <?php
+    $paginator = new OffsetPaginator();
+
+    $firstPage  = $paginator->paginate($query, Window::fromPageNumberAndSize(1, 25));
+    $secondPage = $paginator->paginate($query, $firstPage->getNextWindow());
+
+Because the returned ``WindowPage`` is immutable and carries no temporal
+coupling, its accessors can be called in any order, and building another page
+never affects a page you already hold.
+
+How Offset Pagination Works
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Paginating Doctrine queries is not as simple as you might think in the
+beginning. If you have complex fetch-join scenarios with one-to-many or
+many-to-many associations using the "default" LIMIT functionality of database
+vendors is not sufficient to get the correct results.
+
+By default the paginator does the following steps to compute the correct result:
+
+- Perform a Count query using ``DISTINCT`` keyword.
+- Perform a Limit Subquery with ``DISTINCT`` to find all ids of the entity in from on the current page.
+- Perform a WHERE IN query to get all results for the current page.
+
+This behavior is only necessary if you actually fetch join a to-many
+collection. You can disable it by setting the ``fetchJoinCollection``
+constructor argument to ``false``; in that case only 2 instead of the 3
+queries described are executed.
+
+.. note::
+
+    ``fetchJoinCollection`` set to ``true`` might affect results if you use
+    aggregations in your query.
+
+Alternatively, the ``Paginator::HINT_ENABLE_DISTINCT`` query hint instructs
+Doctrine that the query will not produce "duplicate" rows (only to-one relations
+are joined), so the ``DISTINCT`` keyword is omitted, which can bring important
+performance improvements:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Tools\Pagination\OffsetPaginator;
+    use Doctrine\ORM\Tools\Pagination\Paginator;
+    use Doctrine\ORM\Tools\Pagination\Window;
+
+    $dql   = 'SELECT u, p FROM User u JOIN u.mainPicture p ORDER BY u.id ASC';
+    $query = $entityManager->createQuery($dql)
+                           ->setHint(Paginator::HINT_ENABLE_DISTINCT, false);
+
+    $page = (new OffsetPaginator())->paginate($query, new Window(0, 100));
+
+API Reference
+~~~~~~~~~~~~~
+
+``OffsetPaginator::paginate(Query|QueryBuilder $query, Window $position): WindowPage``
+    Executes the query for the given ``Window`` and returns an immutable
+    ``WindowPage``. All page accessors below live on the returned page. Throws an
+    ``InvalidArgumentException`` if ``$position`` is not a ``Window``.
+
+``WindowPage::getItems(): array``
+    Returns the raw entity array for the current page.
+
+``WindowPage::count(): int``
+    Returns the number of items on the current page (SPL ``Countable``).
+
+``WindowPage::getTotalCount(): int``
+    Returns the total number of matching root entities, ignoring the window.
+
+``WindowPage::getPageNumber(): int`` / ``WindowPage::getPageCount(): int``
+    Return the 1-based number of the current page and the total number of pages.
+    ``getPageCount()`` is at least ``1``, even for an empty result set.
+
+``WindowPage::hasNextPage(): bool`` / ``WindowPage::hasPreviousPage(): bool``
+    Return whether a next / previous page is available.
+
+``WindowPage::hasToPaginate(): bool``
+    Returns whether the result set spans more than one page.
+
+``WindowPage::getNextWindow(): Window`` / ``WindowPage::getPreviousWindow(): Window``
+    Return the ``Window`` for the next / previous page. Throw a ``LogicException``
+    if there is none — call ``hasNextPage()`` / ``hasPreviousPage()`` first.
+
+``WindowPage::getLastWindow(): Window``
+    Returns the ``Window`` of the last page, keeping the same page size. Unlike
+    the two methods above, it never throws: an empty result set has a single,
+    empty first page.
+
+``WindowPage::getWindow(): Window``
+    Returns the ``Window`` that produced this page.
+
+``Window::fromPageNumberAndSize(int $pageNumber, int $pageSize): Window``
+    Builds a ``Window`` from a 1-based page number and a page size.
+
+``Window::getPageNumber(): int``
+    Returns the 1-based page number the window points at.
+
+Legacy ``Paginator``
+~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 3.7
+
+    The ``Paginator`` class is deprecated in favor of ``OffsetPaginator`` and
+    will be removed in 4.0.
+
+The legacy ``Paginator`` reads the offset implicitly from the query
+(``setFirstResult()`` / ``setMaxResults()``) and implements the SPL interfaces
+``Countable`` and ``IteratorAggregate``:
 
 .. code-block:: php
 
@@ -57,43 +196,6 @@ has a very simple API and implements the SPL interfaces ``Countable`` and
     foreach ($paginator as $post) {
         echo $post->getHeadline() . "\n";
     }
-
-Paginating Doctrine queries is not as simple as you might think in the
-beginning. If you have complex fetch-join scenarios with one-to-many or
-many-to-many associations using the "default" LIMIT functionality of database
-vendors is not sufficient to get the correct results.
-
-By default the pagination extension does the following steps to compute the
-correct result:
-
-- Perform a Count query using `DISTINCT` keyword.
-- Perform a Limit Subquery with `DISTINCT` to find all ids of the entity in from on the current page.
-- Perform a WHERE IN query to get all results for the current page.
-
-This behavior is only necessary if you actually fetch join a to-many
-collection. You can disable this behavior by setting the
-``fetchJoinCollection`` argument to ``false``; in that case only 2 instead of the 3 queries
-described are executed. We hope to automate the detection for this in
-the future.
-
-.. note::
-
-    ``fetchJoinCollection`` argument set to ``true`` might affect results if you use aggregations in your query.
-
-By using the ``Paginator::HINT_ENABLE_DISTINCT`` you can instruct doctrine that the query to be executed
-will not produce "duplicate" rows (only to-one relations are joined), thus the SQL limit will work as expected.
-In this way the `DISTINCT` keyword will be omitted and can bring important performance improvements.
-
-.. code-block:: php
-
-    <?php
-    use Doctrine\ORM\Tools\Pagination\Paginator;
-
-    $dql = "SELECT u, p FROM User u JOIN u.mainPicture p";
-    $query = $entityManager->createQuery($dql)
-                           ->setHint(Paginator::HINT_ENABLE_DISTINCT, false)
-                           ->setFirstResult(0)
-                           ->setMaxResults(100);
 
 Cursor-Based Pagination
 -----------------------
@@ -117,9 +219,19 @@ Constructor
 
     <?php
     new CursorPaginator(
-        Query|QueryBuilder $query,
+        int $limit,
         bool $queryProducesDuplicates = true,
     )
+
+The paginator only holds configuration: the query and the cursor are passed to
+``paginate()``, which returns an immutable ``CursorPage`` — symmetric with the
+offset-based ``OffsetPaginator``. A single instance is stateless and can be
+reused, or registered as a service, for any query and any page.
+
+``$limit``
+    The maximum number of results per page. Unlike ``Window``, which carries its
+    own page size, a ``Cursor`` is a pure position: the page size is paginator
+    configuration and therefore never comes from user input.
 
 ``$queryProducesDuplicates``
     Set to ``true`` (default) when the query joins a to-many collection.
@@ -127,7 +239,7 @@ Constructor
     to return the correct number of root entities despite duplicate rows.
     Set to ``false`` when only to-one joins are present — this avoids the
     subquery overhead and is equivalent to passing ``fetchJoinCollection: false``
-    to the offset-based ``Paginator``.
+    to the ``OffsetPaginator``.
     However, passing ``false`` on a query that joins a to-many relation is not
     detected — arbitrary joins can produce duplicate root entities silently,
     leading to a corrupt result set.
@@ -135,7 +247,7 @@ Constructor
 Basic Usage
 ~~~~~~~~~~~
 
-The ``$cursor`` parameter accepts either an encoded string produced by a previous call to
+The ``$position`` parameter of ``paginate()`` accepts either an encoded string produced by a previous call to
 ``getNextCursorAsString()`` or ``getPreviousCursorAsString()``, or a ``Cursor`` instance
 returned by ``getNextCursor()`` or ``getPreviousCursor()``. On the first request it is
 ``null`` or an empty string ``''`` — both are treated identically as the first page.
@@ -153,83 +265,83 @@ It is typically read from the incoming HTTP query string:
     $dql = 'SELECT p FROM BlogPost p ORDER BY p.createdAt DESC, p.id DESC';
     $query = $entityManager->createQuery($dql);
 
-    $paginator = (new CursorPaginator($query))
-        ->paginate(cursor: $cursor, limit: 15);
+    $paginator = new CursorPaginator(limit: 15);
+    $page      = $paginator->paginate($query, $cursor);
 
-    foreach ($paginator as $post) {
+    foreach ($page as $post) {
         echo $post->getTitle() . "\n";
     }
 
-    echo $paginator->getPreviousCursorAsString(); // previous encoded cursor string
-    echo $paginator->getNextCursorAsString();     // next encoded cursor string
+    echo $page->getPreviousCursorAsString(); // previous encoded cursor string
+    echo $page->getNextCursorAsString();     // next encoded cursor string
 
 Navigating Pages
 ~~~~~~~~~~~~~~~~
 
-Pass the encoded cursor back on subsequent requests to move forward or backward:
+Pass the encoded cursor back on subsequent requests to move forward or backward,
+reusing the same paginator:
 
 .. code-block:: php
 
     <?php
     // Next page
-    $paginator->paginate(cursor: $nextCursor, limit: 15);
+    $page = $paginator->paginate($query, $nextCursor);
 
     // Previous page
-    $paginator->paginate(cursor: $previousCursor, limit: 15);
+    $page = $paginator->paginate($query, $previousCursor);
 
 The cursor is an encoded string containing the location at which the next query should begin fetching results, along with the navigation direction.
 
 API Reference
 ~~~~~~~~~~~~~
 
-``CursorPaginator::paginate(Cursor|string|null $cursor, int $limit): self``
-    Executes the query and stores the results. Accepts either an encoded cursor
-    string or a ``Cursor`` instance directly. Fetches ``$limit + 1`` rows to
-    detect whether a further page exists, then trims the extra row. Returns
-    ``$this`` for chaining.
+``CursorPaginator::paginate(Query|QueryBuilder $query, Cursor|string|null $position): CursorPage``
+    Executes the query for the given cursor and returns an immutable
+    ``CursorPage``. Fetches ``$limit + 1`` rows to detect whether a further page
+    exists, then trims the extra row. All accessors below live on the returned
+    ``CursorPage``.
 
-``CursorPaginator::getNextCursor(): Cursor``
+``CursorPage::getNextCursor(): Cursor``
     Returns the ``Cursor`` object for the next page. Throws a ``LogicException``
     if there is no next page — call ``hasNextPage()`` first.
 
-``CursorPaginator::getPreviousCursor(): Cursor``
+``CursorPage::getPreviousCursor(): Cursor``
     Returns the ``Cursor`` object for the previous page. Throws a ``LogicException``
     if there is no previous page — call ``hasPreviousPage()`` first.
 
-``CursorPaginator::getNextCursorAsString(): string``
+``CursorPage::getNextCursorAsString(): string``
     Returns the encoded cursor to retrieve the next page. Throws a
     ``LogicException`` if there is no next page — call ``hasNextPage()`` first.
 
-``CursorPaginator::getPreviousCursorAsString(): string``
+``CursorPage::getPreviousCursorAsString(): string``
     Returns the encoded cursor to retrieve the previous page. Throws a
     ``LogicException`` if there is no previous page — call ``hasPreviousPage()`` first.
 
-``CursorPaginator::hasNextPage(): bool``
+``CursorPage::hasNextPage(): bool``
     Returns whether a next page is available.
 
-``CursorPaginator::hasPreviousPage(): bool``
+``CursorPage::hasPreviousPage(): bool``
     Returns whether a previous page is available.
 
-``CursorPaginator::hasToPaginate(): bool``
+``CursorPage::hasToPaginate(): bool``
     Returns whether either a next or previous page exists (i.e. the result
     set spans more than one page).
 
-``CursorPaginator::getValues(): array``
+``CursorPage::getItems(): array``
     Returns the raw entity array for the current page.
 
-``CursorPaginator::getItems(): array``
+``CursorPage::getItemsWithCursors(): array``
     Returns an array of ``CursorItem`` objects, each wrapping an entity and its
     individual ``Cursor``. Useful when you need per-row cursors.
 
-``CursorPaginator::getCursorForItem(mixed $item, bool $isNext = true): Cursor``
+``CursorPage::getCursorForItem(mixed $item, bool $isNext = true): Cursor``
     Builds a ``Cursor`` pointing at a specific entity. ``$isNext = true`` means
     "start *after* this item"; ``false`` means "start *before* this item".
 
-``CursorPaginator::countPageItems(): int``
-    Returns the number of items on the current page. Throws a ``LogicException``
-    if ``paginate()`` has not been called yet.
+``CursorPage::count(): int``
+    Returns the number of items on the current page.
 
-``CursorPaginator::getTotalCount(): int``
+``CursorPage::getTotalCount(): int``
     Executes an extra ``COUNT`` query and returns the total number of matching
     root entities, ignoring the cursor and limit. Use this when you need to
     display a total result count alongside previous/next navigation.
@@ -296,3 +408,44 @@ Limitations
   computed columns in ``ORDER BY`` are not supported.
 - The query must have at least one ``ORDER BY`` item; the paginator throws a
   ``LogicException`` otherwise.
+
+Writing Strategy-Agnostic Code
+------------------------------
+
+Both strategies share two interfaces, so code that only lists results can be
+written once and work with either one:
+
+``PaginatorInterface<T, TPosition>``
+    Implemented by ``OffsetPaginator`` (a ``PaginatorInterface<T, Window>``) and
+    ``CursorPaginator`` (a ``PaginatorInterface<T, Cursor|string|null>``). Its
+    single method is
+    ``paginate(Query|QueryBuilder $query, mixed $position = null): Page``.
+    The native type of ``$position`` is ``mixed`` because the position type is
+    strategy specific; the ``TPosition`` template parameter narrows it for static
+    analysis.
+
+``Page<T>``
+    Implemented by ``WindowPage`` and ``CursorPage``. It extends ``Countable`` and
+    ``IteratorAggregate`` and exposes ``getItems()``, ``getTotalCount()``,
+    ``hasPreviousPage()``, ``hasNextPage()`` and ``hasToPaginate()``.
+
+Navigating to another page is deliberately left out of ``Page``, since
+the position types differ: ``WindowPage::getNextWindow()`` returns a ``Window``,
+``CursorPage::getNextCursor()`` a ``Cursor``.
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\Query;
+    use Doctrine\ORM\Tools\Pagination\PaginatorInterface;
+
+    function renderTitles(PaginatorInterface $paginator, Query $query, mixed $position): void
+    {
+        $page = $paginator->paginate($query, $position);
+
+        echo $page->getTotalCount() . " result(s), " . count($page) . " on this page\n";
+
+        foreach ($page as $post) {
+            echo $post->getTitle() . "\n";
+        }
+    }

--- a/docs/en/tutorials/pagination/cursor-pagination.php
+++ b/docs/en/tutorials/pagination/cursor-pagination.php
@@ -7,25 +7,26 @@ $cursor = $_GET['cursor'] ?? null;
 $query = $entityManager->createQuery('SELECT p FROM BlogPost p ORDER BY p.createdAt DESC, p.id DESC');
 
 /** @var CursorPaginator<BlogPost> $paginator */
-$paginator = (new CursorPaginator($query))
-    ->paginate(cursor: $cursor, limit: 15);
+$paginator = new CursorPaginator(limit: 15);
+
+$page = $paginator->paginate($query, $cursor);
 ?>
-<p><?= $paginator->getTotalCount() ?> result(s) in total, <?= $paginator->countPageItems() ?> on this page.</p>
+<p><?= $page->getTotalCount() ?> result(s) in total, <?= $page->count() ?> on this page.</p>
 
 <ul>
-    <?php foreach ($paginator as $post): ?>
+    <?php foreach ($page as $post): ?>
         <li><?= escape($post->getTitle()) ?></li>
     <?php endforeach ?>
 </ul>
 
-<?php if ($paginator->hasToPaginate()): ?>
+<?php if ($page->hasToPaginate()): ?>
     <nav>
-        <?php if ($paginator->hasPreviousPage()): ?>
-            <a href="?cursor=<?= escape($paginator->getPreviousCursorAsString()) ?>">Previous</a>
+        <?php if ($page->hasPreviousPage()): ?>
+            <a href="?cursor=<?= escape($page->getPreviousCursorAsString()) ?>">Previous</a>
         <?php endif ?>
 
-        <?php if ($paginator->hasNextPage()): ?>
-            <a href="?cursor=<?= escape($paginator->getNextCursorAsString()) ?>">Next</a>
+        <?php if ($page->hasNextPage()): ?>
+            <a href="?cursor=<?= escape($page->getNextCursorAsString()) ?>">Next</a>
         <?php endif ?>
     </nav>
 <?php endif ?>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -159,6 +159,8 @@
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
         <exclude-pattern>src/EntityManagerInterface.php</exclude-pattern>
+        <!-- the Paginator name is taken by the deprecated class until its removal in 4.0 -->
+        <exclude-pattern>src/Tools/Pagination/PaginatorInterface.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix">

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -11,6 +11,18 @@ parameters:
         - src/Persisters/SqlValueVisitorImplementation.php
 
     ignoreErrors:
+        # Paginator is deprecated in favor of OffsetPaginator, but internal code and the
+        # static-analysis fixture still legitimately reference it until its removal in 4.0.
+        -
+            identifier: classConstant.deprecatedClass
+            path: src/Tools/Pagination/LimitSubqueryWalker.php
+        -
+            identifier: return.deprecatedClass
+            path: tests/StaticAnalysis/Tools/Pagination/paginator-covariant.php
+        -
+            identifier: parameter.deprecatedClass
+            path: tests/StaticAnalysis/Tools/Pagination/paginator-covariant.php
+
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,18 @@ parameters:
         - src/Persisters/SqlValueVisitorImplementation.php
 
     ignoreErrors:
+        # Paginator is deprecated in favor of OffsetPaginator, but internal code and the
+        # static-analysis fixture still legitimately reference it until its removal in 4.0.
+        -
+            identifier: classConstant.deprecatedClass
+            path: src/Tools/Pagination/LimitSubqueryWalker.php
+        -
+            identifier: return.deprecatedClass
+            path: tests/StaticAnalysis/Tools/Pagination/paginator-covariant.php
+        -
+            identifier: parameter.deprecatedClass
+            path: tests/StaticAnalysis/Tools/Pagination/paginator-covariant.php
+
         # Symfony cache supports passing a key prefix to the clear method.
         - '/^Method Psr\\Cache\\CacheItemPoolInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$/'
 

--- a/src/Tools/Pagination/CursorItem.php
+++ b/src/Tools/Pagination/CursorItem.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Tools\Pagination;
 /**
  * Represents a paginated item with its associated cursor.
  *
- * @template T
+ * @template-covariant T
  */
 final class CursorItem
 {

--- a/src/Tools/Pagination/CursorPage.php
+++ b/src/Tools/Pagination/CursorPage.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use ArrayIterator;
+use Closure;
+use LogicException;
+use Traversable;
+
+use function array_map;
+use function count;
+
+/**
+ * Immutable result of a single cursor pagination — the cursor-side counterpart
+ * to {@see WindowPage}.
+ *
+ * It is returned by {@see CursorPaginator::paginate()} instead of the paginator
+ * itself, so the result is not stateful and there is no temporal coupling
+ * between method calls: every accessor is safe to call in any order.
+ *
+ * @template-covariant T
+ * @implements Page<T>
+ */
+final class CursorPage implements Page
+{
+    /** Memoizes the COUNT query, which is only run when asked for. */
+    private int|null $totalCount = null;
+
+    /**
+     * @param list<T>                      $items
+     * @param Closure(): int               $totalCountProvider Runs the COUNT query on demand.
+     * @param Closure(mixed, bool): Cursor $cursorForItem      Builds a Cursor pointing at a given row.
+     */
+    public function __construct(
+        private readonly array $items,
+        private readonly bool $hasMore,
+        private readonly Cursor|null $cursor,
+        private readonly Closure $totalCountProvider,
+        private readonly Closure $cursorForItem,
+    ) {
+    }
+
+    /**
+     * Returns the raw entities on this page.
+     *
+     * @return list<T>
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int, T>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    /**
+     * Returns the number of items on this page.
+     */
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Executes an extra COUNT query and returns the total number of matching
+     * root entities, ignoring the cursor and limit. The result is memoized.
+     */
+    public function getTotalCount(): int
+    {
+        return $this->totalCount ??= ($this->totalCountProvider)();
+    }
+
+    /**
+     * Returns whether there is a previous page.
+     */
+    public function hasPreviousPage(): bool
+    {
+        return $this->cursor !== null && ($this->cursor->isNext() || $this->hasMore);
+    }
+
+    /**
+     * Returns whether there is a next page.
+     */
+    public function hasNextPage(): bool
+    {
+        return $this->hasMore || ($this->cursor !== null && $this->cursor->isPrevious());
+    }
+
+    /**
+     * Returns whether the result set spans more than one page.
+     */
+    public function hasToPaginate(): bool
+    {
+        return $this->hasPreviousPage() || $this->hasNextPage();
+    }
+
+    /** @throws LogicException If there is no next page. Check {@see hasNextPage()} first. */
+    public function getNextCursor(): Cursor
+    {
+        if ($this->items === [] || ! $this->hasNextPage()) {
+            throw new LogicException('There is no next page. Call hasNextPage() before getNextCursor().');
+        }
+
+        return $this->getCursorForItem($this->items[count($this->items) - 1]);
+    }
+
+    /** @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first. */
+    public function getPreviousCursor(): Cursor
+    {
+        if ($this->items === [] || ! $this->hasPreviousPage()) {
+            throw new LogicException('There is no previous page. Call hasPreviousPage() before getPreviousCursor().');
+        }
+
+        return $this->getCursorForItem($this->items[0], false);
+    }
+
+    /**
+     * Returns the encoded cursor string for the next page.
+     *
+     * @throws LogicException If there is no next page. Check {@see hasNextPage()} first.
+     */
+    public function getNextCursorAsString(): string
+    {
+        return $this->getNextCursor()->encodeToString();
+    }
+
+    /**
+     * Returns the encoded cursor string for the previous page.
+     *
+     * @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first.
+     */
+    public function getPreviousCursorAsString(): string
+    {
+        return $this->getPreviousCursor()->encodeToString();
+    }
+
+    /**
+     * Builds a Cursor pointing at a specific entity.
+     *
+     * @param mixed $item   The item to create a cursor for.
+     * @param bool  $isNext Whether the cursor is for the next page.
+     */
+    public function getCursorForItem(mixed $item, bool $isNext = true): Cursor
+    {
+        return ($this->cursorForItem)($item, $isNext);
+    }
+
+    /**
+     * Returns the items wrapped with their associated cursors.
+     *
+     * @return array<int, CursorItem<T>>
+     */
+    public function getItemsWithCursors(): array
+    {
+        return array_map(
+            fn (mixed $item) => new CursorItem($item, $this->getCursorForItem($item)),
+            $this->items,
+        );
+    }
+}

--- a/src/Tools/Pagination/CursorPaginator.php
+++ b/src/Tools/Pagination/CursorPaginator.php
@@ -4,66 +4,63 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Pagination;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\PathExpression;
-use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Exception\InvalidCursor;
 use Doctrine\ORM\Utility\PersisterHelper;
-use IteratorAggregate;
-use LogicException;
-use Traversable;
 
 use function array_map;
 use function array_reverse;
 use function array_slice;
 use function array_sum;
+use function array_values;
 use function count;
 use function is_string;
 
 /**
  * The cursor paginator handles cursor-based pagination for DQL queries.
  *
- * @template T
- * @implements IteratorAggregate<mixed, T>
+ * The query and the cursor are both passed to {@see paginate()}, which returns
+ * an immutable {@see CursorPage} rather than the paginator itself. The paginator
+ * therefore holds no state beyond its configuration: a single instance can be
+ * shared as a service and reused for any query and any page. This keeps the
+ * result free of temporal coupling and symmetric with {@see OffsetPaginator}.
+ *
+ * Unlike the offset-based {@see Window}, which carries its own page size, a
+ * {@see Cursor} is a pure position: the page size is therefore paginator
+ * configuration and never comes from user input.
+ *
+ * @template-covariant T
+ * @implements PaginatorInterface<T, Cursor|string|null>
  */
-final class CursorPaginator implements IteratorAggregate
+final class CursorPaginator implements PaginatorInterface
 {
     use SQLResultCasing;
     use PaginatorQuery;
 
-    private readonly Query $query;
-    /** @var Collection<int, T>|null */
-    private Collection|null $items = null;
-
-    /** @var list<CursorOrderByItem>|null */
-    private array|null $orderByItems = null;
-
-    private bool $hasMore       = false;
-    private Cursor|null $cursor = null;
-
-    /** @param bool $queryProducesDuplicates Whether the query joins a collection (true by default). */
+    /**
+     * @param int       $limit                   The maximum number of results per page.
+     * @param bool      $queryProducesDuplicates Whether the query joins a collection (true by default).
+     * @param bool|null $useOutputWalkers        Whether to force the use of an output walker. Null (default)
+     *                                           lets the paginator decide.
+     */
     public function __construct(
-        Query|QueryBuilder $query,
+        private readonly int $limit,
         private readonly bool $queryProducesDuplicates = true,
+        bool|null $useOutputWalkers = null,
     ) {
-        if ($query instanceof QueryBuilder) {
-            $query = $query->getQuery();
-        }
-
-        $this->query = $query;
+        $this->useOutputWalkers = $useOutputWalkers;
     }
 
     /**
-     * Returns the query.
+     * Returns the maximum number of results per page.
      */
-    public function getQuery(): Query
+    public function getLimit(): int
     {
-        return $this->query;
+        return $this->limit;
     }
 
     /**
@@ -77,31 +74,27 @@ final class CursorPaginator implements IteratorAggregate
     }
 
     /**
-     * Paginates the query with the given limit and optional cursor.
+     * Executes the query for the given cursor and returns an immutable page.
      *
-     * @param mixed $cursor The cursor instance, encoded cursor string, null or empty string for the first page.
-     *                      Any other type (e.g. array) throws InvalidCursor.
-     * @param int   $limit  The maximum number of results to return.
+     * Fetches $limit + 1 rows to detect whether a further page exists, then
+     * trims the extra row.
      *
-     * @return $this
+     * @param Cursor|string|null $position A cursor instance, an encoded cursor string, or
+     *                                     null/empty string for the first page. Any other
+     *                                     type (e.g. an array) throws InvalidCursor.
      *
-     * @throws InvalidCursor If $cursor is not a Cursor instance, a string, or null.
+     * @return CursorPage<T>
+     *
+     * @throws InvalidCursor If $position is not a Cursor instance, a string, or null.
      */
-    public function paginate(mixed $cursor, int $limit): self
+    public function paginate(Query|QueryBuilder $query, mixed $position = null): CursorPage
     {
-        if ($cursor instanceof Cursor) {
-            $this->cursor = $cursor;
-        } elseif ($cursor === null || (is_string($cursor) && $cursor === '')) {
-            $this->cursor = null;
-        } elseif (is_string($cursor)) {
-            $this->cursor = Cursor::fromEncodedString($cursor);
-        } else {
-            throw new InvalidCursor('(non-string value)');
-        }
+        $query  = $this->resolveQuery($query);
+        $cursor = $this->resolveCursor($position);
 
-        $shouldReverse = $this->cursor?->isPrevious() ?? false;
+        $shouldReverse = $cursor?->isPrevious() ?? false;
 
-        $subQuery = $this->cloneQuery($this->query);
+        $subQuery = $this->cloneQuery($query);
         $subQuery->expireQueryCache();
 
         $this->appendTreeWalker($subQuery, CursorWalker::class);
@@ -116,200 +109,82 @@ final class CursorPaginator implements IteratorAggregate
         }
 
         $subQuery->setHint(CursorWalker::HINT_CURSOR_REVERSE, $shouldReverse);
-        $subQuery->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, $this->cursor?->getParameters() ?? []);
-        $subQuery->setFirstResult(0)->setMaxResults($limit + 1);
+        $subQuery->setHint(CursorWalker::HINT_CURSOR_PARAMETERS, $cursor?->getParameters() ?? []);
+        $subQuery->setFirstResult(0)->setMaxResults($this->limit + 1);
 
         if ($this->queryProducesDuplicates) {
-            $foundIdRows        = $subQuery->getScalarResult();
-            $this->orderByItems = $subQuery->getHint(CursorWalker::HINT_CURSOR_ORDER_BY_ITEMS) ?: [];
-            $this->hasMore      = count($foundIdRows) > $limit;
-            $foundIdRows        = array_slice($foundIdRows, 0, $limit);
+            $foundIdRows  = $subQuery->getScalarResult();
+            $orderByItems = $subQuery->getHint(CursorWalker::HINT_CURSOR_ORDER_BY_ITEMS) ?: [];
+            $hasMore      = count($foundIdRows) > $this->limit;
+            $foundIdRows  = array_slice($foundIdRows, 0, $this->limit);
 
-            // don't do this for an empty id array
             if ($foundIdRows === []) {
-                $this->items = new ArrayCollection([]);
+                $items = [];
+            } else {
+                $whereInQuery = $this->cloneQuery($query);
+                $ids          = array_map('current', $foundIdRows);
 
-                return $this;
+                $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
+                $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
+                $whereInQuery->setFirstResult(0)->setMaxResults(null);
+                $whereInQuery->setCacheable($query->isCacheable());
+
+                $databaseIds = $this->convertWhereInIdentifiersToDatabaseValues($query, $ids);
+                $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $databaseIds);
+
+                $items = array_values($whereInQuery->getResult());
             }
-
-            $whereInQuery = $this->cloneQuery($this->query);
-            $ids          = array_map('current', $foundIdRows);
-
-            $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
-            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
-            $whereInQuery->setFirstResult(0)->setMaxResults(null);
-            $whereInQuery->setCacheable($this->query->isCacheable());
-
-            $databaseIds = $this->convertWhereInIdentifiersToDatabaseValues($ids);
-            $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $databaseIds);
-
-            $this->items = new ArrayCollection($whereInQuery->getResult());
         } else {
-            $result        = $subQuery->getResult();
-            $this->hasMore = count($result) > $limit;
-            $result        = array_slice($result, 0, $limit);
+            $result       = $subQuery->getResult();
+            $hasMore      = count($result) > $this->limit;
+            $result       = array_slice($result, 0, $this->limit);
+            $orderByItems = $subQuery->getHint(CursorWalker::HINT_CURSOR_ORDER_BY_ITEMS) ?: [];
 
-            $this->orderByItems = $subQuery->getHint(CursorWalker::HINT_CURSOR_ORDER_BY_ITEMS) ?: [];
-
-            if ($this->cursor !== null && $this->cursor->isPrevious()) {
+            if ($cursor !== null && $cursor->isPrevious()) {
                 $result = array_reverse($result);
             }
 
-            $this->items = new ArrayCollection($result);
+            $items = array_values($result);
         }
 
-        return $this;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return Traversable<mixed, T>
-     */
-    public function getIterator(): Traversable
-    {
-        return $this->items->getIterator();
-    }
-
-    public function countPageItems(): int
-    {
-        if ($this->items === null) {
-            throw new LogicException('The paginator has not been initialized. Call paginate() first.');
-        }
-
-        return $this->items->count();
-    }
-
-    public function getTotalCount(): int
-    {
-        if ($this->count === null) {
-            $this->count = (int) array_sum(array_map('current', $this->getCountQuery()->getScalarResult()));
-        }
-
-        return $this->count;
-    }
-
-    /**
-     * Returns whether there is a previous page.
-     */
-    public function hasPreviousPage(): bool
-    {
-        return $this->cursor !== null && ($this->cursor->isNext() || $this->hasMore);
-    }
-
-    /**
-     * Returns whether there is a next page.
-     */
-    public function hasNextPage(): bool
-    {
-        return $this->hasMore || ($this->cursor !== null && $this->cursor->isPrevious());
-    }
-
-    /**
-     * Returns the cursor object for the next page.
-     *
-     * @throws LogicException If there is no next page. Check {@see hasNextPage()} first.
-     */
-    public function getNextCursor(): Cursor
-    {
-        if ($this->items->isEmpty() || ! $this->hasNextPage()) {
-            throw new LogicException('There is no next page. Call hasNextPage() before getNextCursor().');
-        }
-
-        return $this->getCursorForItem($this->items->last());
-    }
-
-    /**
-     * Returns the cursor object for the previous page.
-     *
-     * @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first.
-     */
-    public function getPreviousCursor(): Cursor
-    {
-        if ($this->items->isEmpty() || ! $this->hasPreviousPage()) {
-            throw new LogicException('There is no previous page. Call hasPreviousPage() before getPreviousCursor().');
-        }
-
-        return $this->getCursorForItem($this->items->first(), false);
-    }
-
-    /**
-     * Returns the encoded cursor string for the next page.
-     *
-     * @throws LogicException If there is no next page. Check {@see hasNextPage()} first.
-     */
-    public function getNextCursorAsString(): string
-    {
-        return $this->getNextCursor()->encodeToString();
-    }
-
-    /**
-     * Returns the encoded cursor string for the previous page.
-     *
-     * @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first.
-     */
-    public function getPreviousCursorAsString(): string
-    {
-        return $this->getPreviousCursor()->encodeToString();
-    }
-
-    /**
-     * Returns the cursor for a given item.
-     *
-     * @param mixed $item   The item to create a cursor for.
-     * @param bool  $isNext Whether the cursor is for the next page.
-     *
-     * @throws Exception
-     * @throws QueryException
-     */
-    public function getCursorForItem(mixed $item, bool $isNext = true): Cursor
-    {
-        return new Cursor($this->getParametersForItem($item), $isNext);
-    }
-
-    /**
-     * Returns items wrapped with their associated cursors.
-     *
-     * @return array<int, CursorItem<T>>
-     *
-     * @throws Exception
-     * @throws QueryException
-     */
-    public function getItems(): array
-    {
-        return array_map(
-            fn (mixed $item) => new CursorItem($item, $this->getCursorForItem($item)),
-            $this->items->toArray(),
+        return new CursorPage(
+            $items,
+            $hasMore,
+            $cursor,
+            fn (): int => (int) array_sum(array_map('current', $this->getCountQuery($query)->getScalarResult())),
+            fn (mixed $item, bool $isNext): Cursor => new Cursor($this->getParametersForItem($query, $item, $orderByItems), $isNext),
         );
     }
 
+    /** @throws InvalidCursor If $position is not a Cursor instance, a string, or null. */
+    private function resolveCursor(mixed $position): Cursor|null
+    {
+        if ($position instanceof Cursor) {
+            return $position;
+        }
+
+        if ($position === null || $position === '') {
+            return null;
+        }
+
+        if (! is_string($position)) {
+            throw new InvalidCursor('(non-string value)');
+        }
+
+        return Cursor::fromEncodedString($position);
+    }
+
     /**
-     * Returns the raw entity values.
+     * @param list<CursorOrderByItem> $orderByItems
      *
-     * @return list<T>
-     */
-    public function getValues(): array
-    {
-        return $this->items->getValues();
-    }
-
-    /**
-     * Returns whether pagination is needed.
-     */
-    public function hasToPaginate(): bool
-    {
-        return $this->hasPreviousPage() || $this->hasNextPage();
-    }
-
-    /**
      * @return array<string, mixed>
      *
      * @throws Query\QueryException
      * @throws Exception
      */
-    private function getParametersForItem(mixed $item): array
+    private function getParametersForItem(Query $query, mixed $item, array $orderByItems): array
     {
-        $em         = $this->query->getEntityManager();
+        $em         = $query->getEntityManager();
         $connection = $em->getConnection();
         $metadata   = $em->getMetadataFactory()->hasMetadataFor($item::class)
             ? $em->getClassMetadata($item::class)
@@ -317,7 +192,7 @@ final class CursorPaginator implements IteratorAggregate
 
         $result = [];
 
-        foreach ($this->orderByItems as $orderByItem) {
+        foreach ($orderByItems as $orderByItem) {
             if (! $orderByItem->expression instanceof PathExpression) {
                 continue;
             }

--- a/src/Tools/Pagination/OffsetPaginator.php
+++ b/src/Tools/Pagination/OffsetPaginator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Internal\SQLResultCasing;
+use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
+
+use function array_map;
+use function array_sum;
+use function array_values;
+use function get_debug_type;
+use function sprintf;
+
+/**
+ * Offset-based paginator, designed to be symmetric with {@see CursorPaginator}.
+ *
+ * The query and the pagination position are both passed to {@see paginate()},
+ * which returns an immutable, iterable {@see WindowPage} rather than the
+ * paginator itself. The paginator therefore holds no state beyond its
+ * configuration: a single instance can be shared as a service and reused for
+ * any query and any page. This avoids the implicit offset handling and the
+ * stateful API of the legacy {@see Paginator}, which this class is intended to
+ * replace.
+ *
+ * @template-covariant T
+ * @implements PaginatorInterface<T, Window>
+ */
+final class OffsetPaginator implements PaginatorInterface
+{
+    use SQLResultCasing;
+    use PaginatorQuery;
+
+    /**
+     * @param bool      $fetchJoinCollection Whether the query joins a collection (true by default).
+     * @param bool|null $useOutputWalkers    Whether to force the use of an output walker. Null (default)
+     *                                       lets the paginator decide.
+     */
+    public function __construct(
+        private readonly bool $fetchJoinCollection = true,
+        bool|null $useOutputWalkers = null,
+    ) {
+        $this->useOutputWalkers = $useOutputWalkers;
+    }
+
+    /**
+     * Returns whether the query joins a collection.
+     */
+    public function getFetchJoinCollection(): bool
+    {
+        return $this->fetchJoinCollection;
+    }
+
+    /**
+     * Executes the query for the given window and returns an immutable page.
+     *
+     * @param Window $position The window to fetch. Use {@see Window::fromPageNumberAndSize()}
+     *                         to build it from a 1-based page number and a page size.
+     *
+     * @return WindowPage<T>
+     *
+     * @throws InvalidArgumentException If $position is not a {@see Window}.
+     */
+    public function paginate(Query|QueryBuilder $query, mixed $position = null): WindowPage
+    {
+        if (! $position instanceof Window) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected an instance of %s, got %s.',
+                Window::class,
+                get_debug_type($position),
+            ));
+        }
+
+        $query = $this->resolveQuery($query);
+
+        /** @var list<T> $items */
+        $items = array_values($this->getResultForOffset(
+            $query,
+            $position->getFirstResult(),
+            $position->getMaxResults(),
+            $this->fetchJoinCollection,
+        ));
+
+        try {
+            $totalCount = (int) array_sum(array_map('current', $this->getCountQuery($query)->getScalarResult()));
+        } catch (NoResultException) {
+            $totalCount = 0;
+        }
+
+        return new WindowPage($items, $totalCount, $position);
+    }
+}

--- a/src/Tools/Pagination/Page.php
+++ b/src/Tools/Pagination/Page.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Immutable result of a single pagination.
+ *
+ * A page is the return value of {@see PaginatorInterface::paginate()}. It is
+ * iterable and countable, and carries no temporal coupling: every accessor is
+ * safe to call in any order, and paginating again never affects a page you
+ * already hold.
+ *
+ * Navigating to another page is deliberately left out of this interface: the
+ * position types are strategy specific ({@see WindowPage::getNextWindow()}
+ * returns a {@see Window}, {@see CursorPage::getNextCursor()} a {@see Cursor}).
+ *
+ * @template-covariant T
+ * @extends IteratorAggregate<int, T>
+ */
+interface Page extends Countable, IteratorAggregate
+{
+    /**
+     * Returns the raw entities on this page.
+     *
+     * @return list<T>
+     */
+    public function getItems(): array;
+
+    /**
+     * Returns the number of items on this page.
+     */
+    public function count(): int;
+
+    /**
+     * Returns the total number of matching root entities, ignoring the
+     * pagination position.
+     */
+    public function getTotalCount(): int;
+
+    /**
+     * Returns whether there is a previous page.
+     */
+    public function hasPreviousPage(): bool;
+
+    /**
+     * Returns whether there is a next page.
+     */
+    public function hasNextPage(): bool;
+
+    /**
+     * Returns whether the result set spans more than one page.
+     */
+    public function hasToPaginate(): bool;
+}

--- a/src/Tools/Pagination/Paginator.php
+++ b/src/Tools/Pagination/Paginator.php
@@ -19,6 +19,9 @@ use function array_sum;
 /**
  * The paginator can handle various complex scenarios with DQL.
  *
+ * @deprecated This class is no longer needed by the ORM and will be removed in 4.0.
+ *             Use {@see OffsetPaginator} instead.
+ *
  * @template-covariant T
  * @implements IteratorAggregate<array-key, T>
  */
@@ -30,17 +33,14 @@ class Paginator implements Countable, IteratorAggregate
     public const HINT_ENABLE_DISTINCT = 'paginator.distinct.enable';
 
     private readonly Query $query;
+    private int|null $count = null;
 
     /** @param bool $fetchJoinCollection Whether the query joins a collection (true by default). */
     public function __construct(
         Query|QueryBuilder $query,
         private readonly bool $fetchJoinCollection = true,
     ) {
-        if ($query instanceof QueryBuilder) {
-            $query = $query->getQuery();
-        }
-
-        $this->query = $query;
+        $this->query = $this->resolveQuery($query);
     }
 
     /**
@@ -61,11 +61,31 @@ class Paginator implements Countable, IteratorAggregate
         return $this->fetchJoinCollection;
     }
 
+    /**
+     * Returns whether the paginator will use an output walker.
+     */
+    public function getUseOutputWalkers(): bool|null
+    {
+        return $this->useOutputWalkers;
+    }
+
+    /**
+     * Sets whether the paginator will use an output walker.
+     *
+     * @return $this
+     */
+    public function setUseOutputWalkers(bool|null $useOutputWalkers): static
+    {
+        $this->useOutputWalkers = $useOutputWalkers;
+
+        return $this;
+    }
+
     public function count(): int
     {
         if ($this->count === null) {
             try {
-                $this->count = (int) array_sum(array_map('current', $this->getCountQuery()->getScalarResult()));
+                $this->count = (int) array_sum(array_map('current', $this->getCountQuery($this->query)->getScalarResult()));
             } catch (NoResultException) {
                 $this->count = 0;
             }
@@ -81,48 +101,11 @@ class Paginator implements Countable, IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        $offset = $this->query->getFirstResult();
-        $length = $this->query->getMaxResults();
-
-        if ($this->fetchJoinCollection && $length !== null) {
-            $subQuery = $this->cloneQuery($this->query);
-
-            if ($this->useOutputWalker($subQuery)) {
-                $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
-            } else {
-                $this->appendTreeWalker($subQuery, LimitSubqueryWalker::class);
-                $this->unbindUnusedQueryParams($subQuery);
-            }
-
-            $subQuery->setFirstResult($offset)->setMaxResults($length);
-
-            $foundIdRows = $subQuery->getScalarResult();
-
-            // don't do this for an empty id array
-            if ($foundIdRows === []) {
-                return new ArrayIterator([]);
-            }
-
-            $whereInQuery = $this->cloneQuery($this->query);
-            $ids          = array_map('current', $foundIdRows);
-
-            $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
-            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
-            $whereInQuery->setFirstResult(0)->setMaxResults(null);
-            $whereInQuery->setCacheable($this->query->isCacheable());
-
-            $databaseIds = $this->convertWhereInIdentifiersToDatabaseValues($ids);
-            $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $databaseIds);
-
-            $result = $whereInQuery->getResult($this->query->getHydrationMode());
-        } else {
-            $result = $this->cloneQuery($this->query)
-                ->setMaxResults($length)
-                ->setFirstResult($offset)
-                ->setCacheable($this->query->isCacheable())
-                ->getResult($this->query->getHydrationMode());
-        }
-
-        return new ArrayIterator($result);
+        return new ArrayIterator($this->getResultForOffset(
+            $this->query,
+            $this->query->getFirstResult(),
+            $this->query->getMaxResults(),
+            $this->fetchJoinCollection,
+        ));
     }
 }

--- a/src/Tools/Pagination/PaginatorInterface.php
+++ b/src/Tools/Pagination/PaginatorInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Paginates a DQL query for a given pagination position.
+ *
+ * Implementations hold no query and no position: both are passed to
+ * {@see paginate()}, so a paginator is stateless and can be reused — and shared
+ * as a service — across queries and pages.
+ *
+ * The position type depends on the pagination strategy, so it is declared as
+ * `mixed` here and narrowed by the `TPosition` template parameter:
+ * {@see OffsetPaginator} is a `PaginatorInterface<T, Window>`, and
+ * {@see CursorPaginator} a `PaginatorInterface<T, Cursor|string|null>`.
+ *
+ * @template-covariant T
+ * @template TPosition
+ */
+interface PaginatorInterface
+{
+    /**
+     * Executes the query for the given position and returns an immutable page.
+     *
+     * @param TPosition $position
+     *
+     * @return Page<T>
+     */
+    public function paginate(Query|QueryBuilder $query, mixed $position = null): Page;
+}

--- a/src/Tools/Pagination/PaginatorQuery.php
+++ b/src/Tools/Pagination/PaginatorQuery.php
@@ -10,41 +10,31 @@ use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\TreeWalker;
+use Doctrine\ORM\QueryBuilder;
 
 use function array_key_exists;
 use function array_map;
 use function assert;
+use function is_array;
 use function is_string;
 
 /**
- * Provides the implementation shared by {@see Paginator} and {@see CursorPaginator}.
+ * Provides the implementation shared by {@see Paginator}, {@see OffsetPaginator}
+ * and {@see CursorPaginator}.
+ *
+ * Every method takes the query it works on as an argument, so that the
+ * stateless paginators can serve any query.
  *
  * @internal
  */
 trait PaginatorQuery
 {
-    private int|null $count             = null;
+    /**
+     * Whether to force the use of an output walker. Null lets the paginator
+     * decide. The legacy {@see Paginator} exposes a setter for it, the
+     * stateless paginators take it as a constructor argument.
+     */
     private bool|null $useOutputWalkers = null;
-
-    /**
-     * Returns whether the paginator will use an output walker.
-     */
-    public function getUseOutputWalkers(): bool|null
-    {
-        return $this->useOutputWalkers;
-    }
-
-    /**
-     * Sets whether the paginator will use an output walker.
-     *
-     * @return $this
-     */
-    public function setUseOutputWalkers(bool|null $useOutputWalkers): static
-    {
-        $this->useOutputWalkers = $useOutputWalkers;
-
-        return $this;
-    }
 
     /**
      * Determines whether to use an output walker for the query.
@@ -56,6 +46,11 @@ trait PaginatorQuery
         }
 
         return $this->useOutputWalkers;
+    }
+
+    private function resolveQuery(Query|QueryBuilder $query): Query
+    {
+        return $query instanceof QueryBuilder ? $query->getQuery() : $query;
     }
 
     private function cloneQuery(Query $query): Query
@@ -77,19 +72,19 @@ trait PaginatorQuery
      *
      * @return mixed[]
      */
-    private function convertWhereInIdentifiersToDatabaseValues(array $identifiers): array
+    private function convertWhereInIdentifiersToDatabaseValues(Query $query, array $identifiers): array
     {
-        $query = $this->cloneQuery($this->query);
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, RootTypeWalker::class);
+        $typeQuery = $this->cloneQuery($query);
+        $typeQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, RootTypeWalker::class);
 
-        $connection = $this->query->getEntityManager()->getConnection();
-        $type       = $query->getSQL();
+        $connection = $query->getEntityManager()->getConnection();
+        $type       = $typeQuery->getSQL();
         assert(is_string($type));
 
         return array_map(static fn ($id): mixed => $connection->convertToDatabaseValue($id, $type), $identifiers);
     }
 
-    private function getCountQuery(): Query
+    private function getCountQuery(Query $query): Query
     {
         /*
             As opposed to using self::cloneQuery, the following code does not transfer
@@ -100,11 +95,11 @@ trait PaginatorQuery
             In the case of using output walkers, we are even creating a new RSM down below.
             In the case of using a tree walker, we want to have a new RSM created by the parser.
         */
-        $countQuery = new Query($this->query->getEntityManager());
-        $countQuery->setDQL($this->query->getDQL());
-        $countQuery->setParameters(clone $this->query->getParameters());
+        $countQuery = new Query($query->getEntityManager());
+        $countQuery->setDQL($query->getDQL());
+        $countQuery->setParameters(clone $query->getParameters());
         $countQuery->setCacheable(false);
-        foreach ($this->query->getHints() as $name => $value) {
+        foreach ($query->getHints() as $name => $value) {
             $countQuery->setHint($name, $value);
         }
 
@@ -128,6 +123,64 @@ trait PaginatorQuery
         $countQuery->setFirstResult(0)->setMaxResults(null);
 
         return $countQuery;
+    }
+
+    /**
+     * Executes the query for the given offset window and returns the entities.
+     *
+     * Shared by {@see Paginator} and {@see OffsetPaginator}: when a to-many
+     * collection is fetch-joined, it uses the ID subquery + WHERE IN strategy to
+     * return the correct number of root entities despite duplicate rows.
+     *
+     * The result keys are preserved (e.g. for DQL ``INDEX BY``); callers that
+     * need a list should apply {@see array_values()} themselves.
+     *
+     * @return array<mixed>
+     */
+    private function getResultForOffset(Query $query, int $offset, int|null $length, bool $fetchJoinCollection): array
+    {
+        if ($fetchJoinCollection && $length !== null) {
+            $subQuery = $this->cloneQuery($query);
+
+            if ($this->useOutputWalker($subQuery)) {
+                $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
+            } else {
+                $this->appendTreeWalker($subQuery, LimitSubqueryWalker::class);
+                $this->unbindUnusedQueryParams($subQuery);
+            }
+
+            $subQuery->setFirstResult($offset)->setMaxResults($length);
+
+            $foundIdRows = $subQuery->getScalarResult();
+
+            // don't do this for an empty id array
+            if ($foundIdRows === []) {
+                return [];
+            }
+
+            $whereInQuery = $this->cloneQuery($query);
+            $ids          = array_map('current', $foundIdRows);
+
+            $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
+            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
+            $whereInQuery->setFirstResult(0)->setMaxResults(null);
+            $whereInQuery->setCacheable($query->isCacheable());
+
+            $databaseIds = $this->convertWhereInIdentifiersToDatabaseValues($query, $ids);
+            $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $databaseIds);
+
+            $result = $whereInQuery->getResult($query->getHydrationMode());
+        } else {
+            $result = $this->cloneQuery($query)
+                ->setMaxResults($length)
+                ->setFirstResult($offset)
+                ->setCacheable($query->isCacheable())
+                ->getResult($query->getHydrationMode());
+        }
+
+        assert(is_array($result));
+
+        return $result;
     }
 
     /**

--- a/src/Tools/Pagination/Window.php
+++ b/src/Tools/Pagination/Window.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use InvalidArgumentException;
+
+use function intdiv;
+use function max;
+
+/**
+ * Represents an offset-based pagination position: a window over the result set.
+ *
+ * Counterpart to {@see Cursor}, but deliberately not its mirror image. A cursor
+ * is a pure position, so the page size belongs to the paginator; a window is a
+ * position *and* a size, because offset pagination has to know how far to skip,
+ * which is a function of the page size. It carries no opaque state and needs no
+ * encoding: navigation between pages is plain arithmetic.
+ *
+ * The window is passed explicitly to {@see OffsetPaginator::paginate()}, instead
+ * of being derived implicitly from {@see \Doctrine\ORM\Query::setFirstResult()}
+ * and {@see \Doctrine\ORM\Query::setMaxResults()}.
+ */
+final class Window
+{
+    public function __construct(
+        private readonly int $firstResult,
+        private readonly int $maxResults,
+    ) {
+        if ($firstResult < 0) {
+            throw new InvalidArgumentException('firstResult must be greater than or equal to 0.');
+        }
+
+        if ($maxResults < 1) {
+            throw new InvalidArgumentException('maxResults must be greater than or equal to 1.');
+        }
+    }
+
+    /**
+     * Builds a window from a 1-based page number and a page size.
+     */
+    public static function fromPageNumberAndSize(int $pageNumber, int $pageSize): self
+    {
+        if ($pageNumber < 1) {
+            throw new InvalidArgumentException('pageNumber must be greater than or equal to 1.');
+        }
+
+        return new self(($pageNumber - 1) * $pageSize, $pageSize);
+    }
+
+    public function getFirstResult(): int
+    {
+        return $this->firstResult;
+    }
+
+    public function getMaxResults(): int
+    {
+        return $this->maxResults;
+    }
+
+    /**
+     * Returns the 1-based page number this window points at.
+     */
+    public function getPageNumber(): int
+    {
+        return intdiv($this->firstResult, $this->maxResults) + 1;
+    }
+
+    /**
+     * Returns the window for the next page, keeping the same page size.
+     */
+    public function next(): self
+    {
+        return new self($this->firstResult + $this->maxResults, $this->maxResults);
+    }
+
+    /**
+     * Returns the window for the previous page, keeping the same page size and
+     * clamping the first result at 0.
+     */
+    public function previous(): self
+    {
+        return new self(max(0, $this->firstResult - $this->maxResults), $this->maxResults);
+    }
+}

--- a/src/Tools/Pagination/WindowPage.php
+++ b/src/Tools/Pagination/WindowPage.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use ArrayIterator;
+use LogicException;
+use Traversable;
+
+use function count;
+use function intdiv;
+use function max;
+
+/**
+ * Immutable result of a single offset pagination.
+ *
+ * It is returned by {@see OffsetPaginator::paginate()} instead of the paginator
+ * itself, so the result is not stateful and there is no temporal coupling
+ * between method calls: every accessor is safe to call in any order.
+ *
+ * On top of {@see Page}, a window page exposes what only offset pagination can
+ * know: the total number of pages and the position of the last one.
+ *
+ * @template-covariant T
+ * @implements Page<T>
+ */
+final class WindowPage implements Page
+{
+    /** @param list<T> $items */
+    public function __construct(
+        private readonly array $items,
+        private readonly int $totalCount,
+        private readonly Window $window,
+    ) {
+    }
+
+    /** @return list<T> */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return Traversable<int, T>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    /**
+     * Returns the number of items on this page.
+     */
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Returns the total number of matching root entities, ignoring the window.
+     */
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    /**
+     * Returns the window that produced this page.
+     */
+    public function getWindow(): Window
+    {
+        return $this->window;
+    }
+
+    /**
+     * Returns the 1-based number of this page.
+     */
+    public function getPageNumber(): int
+    {
+        return $this->window->getPageNumber();
+    }
+
+    /**
+     * Returns the total number of pages, at least 1 even for an empty result
+     * set.
+     */
+    public function getPageCount(): int
+    {
+        $maxResults = $this->window->getMaxResults();
+
+        return max(1, intdiv($this->totalCount + $maxResults - 1, $maxResults));
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->window->getFirstResult() > 0;
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->window->getFirstResult() + count($this->items) < $this->totalCount;
+    }
+
+    /**
+     * Returns whether the result set spans more than one page.
+     */
+    public function hasToPaginate(): bool
+    {
+        return $this->totalCount > count($this->items);
+    }
+
+    /** @throws LogicException If there is no next page. Check {@see hasNextPage()} first. */
+    public function getNextWindow(): Window
+    {
+        if (! $this->hasNextPage()) {
+            throw new LogicException('There is no next page. Call hasNextPage() before getNextWindow().');
+        }
+
+        return $this->window->next();
+    }
+
+    /** @throws LogicException If there is no previous page. Check {@see hasPreviousPage()} first. */
+    public function getPreviousWindow(): Window
+    {
+        if (! $this->hasPreviousPage()) {
+            throw new LogicException('There is no previous page. Call hasPreviousPage() before getPreviousWindow().');
+        }
+
+        return $this->window->previous();
+    }
+
+    /**
+     * Returns the window of the last page, keeping the same page size.
+     *
+     * Unlike {@see getNextWindow()} and {@see getPreviousWindow()}, this never
+     * throws: an empty result set has a single, empty first page.
+     */
+    public function getLastWindow(): Window
+    {
+        return Window::fromPageNumberAndSize($this->getPageCount(), $this->window->getMaxResults());
+    }
+}

--- a/tests/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Tests/ORM/Functional/PaginationTest.php
@@ -15,7 +15,9 @@ use Doctrine\ORM\Query\AST\WhereClause;
 use Doctrine\ORM\Query\SqlOutputWalker;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
+use Doctrine\ORM\Tools\Pagination\OffsetPaginator;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\ORM\Tools\Pagination\Window;
 use Doctrine\Tests\DbalTypes\CustomIdObject;
 use Doctrine\Tests\DbalTypes\CustomIdObjectType;
 use Doctrine\Tests\Models\CMS\CmsArticle;
@@ -29,6 +31,7 @@ use Doctrine\Tests\Models\Pagination\Department;
 use Doctrine\Tests\Models\Pagination\Logo;
 use Doctrine\Tests\Models\Pagination\User1;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
@@ -79,6 +82,111 @@ class PaginationTest extends OrmFunctionalTestCase
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers($useOutputWalkers);
         self::assertCount(9, $paginator);
+    }
+
+    public function testOffsetPaginatorReturnsFirstPage(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC';
+        $query = $this->_em->createQuery($dql);
+
+        $page = (new OffsetPaginator())->paginate($query, new Window(0, 4));
+
+        self::assertCount(4, $page);
+        self::assertSame(9, $page->getTotalCount());
+        self::assertFalse($page->hasPreviousPage());
+        self::assertTrue($page->hasNextPage());
+        self::assertTrue($page->hasToPaginate());
+        self::assertSame(1, $page->getPageNumber());
+        self::assertSame(3, $page->getPageCount());
+        self::assertSame(4, $page->getNextWindow()->getFirstResult());
+        self::assertSame(8, $page->getLastWindow()->getFirstResult());
+    }
+
+    public function testOffsetPaginatorReturnsLastPage(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC';
+        $query = $this->_em->createQuery($dql);
+
+        $page = (new OffsetPaginator())->paginate($query, new Window(8, 4));
+
+        self::assertCount(1, $page);
+        self::assertSame(9, $page->getTotalCount());
+        self::assertTrue($page->hasPreviousPage());
+        self::assertFalse($page->hasNextPage());
+        self::assertSame(4, $page->getPreviousWindow()->getFirstResult());
+        self::assertSame(8, $page->getLastWindow()->getFirstResult());
+    }
+
+    public function testOffsetPaginatorWithFromPageNumberAndSize(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC';
+        $query = $this->_em->createQuery($dql);
+
+        $page = (new OffsetPaginator())->paginate($query, Window::fromPageNumberAndSize(2, 4));
+
+        self::assertCount(4, $page);
+        self::assertSame(2, $page->getPageNumber());
+        self::assertTrue($page->hasPreviousPage());
+        self::assertTrue($page->hasNextPage());
+    }
+
+    public function testOffsetPaginatorWithFetchJoin(): void
+    {
+        $dql   = 'SELECT u, g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g ORDER BY u.id ASC';
+        $query = $this->_em->createQuery($dql);
+
+        $page = (new OffsetPaginator())->paginate($query, new Window(0, 4));
+
+        self::assertCount(4, $page);
+        self::assertSame(9, $page->getTotalCount());
+    }
+
+    public function testOffsetPaginatorIsReusableAcrossQueriesAndPages(): void
+    {
+        $users  = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC');
+        $groups = $this->_em->createQuery('SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g ORDER BY g.id ASC');
+
+        $paginator = new OffsetPaginator();
+
+        $firstPage = $paginator->paginate($users, new Window(0, 4));
+        self::assertCount(4, $firstPage);
+
+        $secondPage = $paginator->paginate($users, $firstPage->getNextWindow());
+        self::assertCount(4, $secondPage);
+        self::assertSame(2, $secondPage->getPageNumber());
+
+        // the first page is unaffected by the second pagination
+        self::assertSame(1, $firstPage->getPageNumber());
+
+        self::assertSame(9, $paginator->paginate($users, new Window(0, 4))->getTotalCount());
+        self::assertSame(3, $paginator->paginate($groups, new Window(0, 4))->getTotalCount());
+    }
+
+    public function testOffsetPaginatorRejectsANonWindowPosition(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC';
+        $query = $this->_em->createQuery($dql);
+
+        $this->expectException(InvalidArgumentException::class);
+        (new OffsetPaginator())->paginate($query, 42);
+    }
+
+    public function testPaginatorPreservesIndexByKeys(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u INDEX BY u.id';
+        $query = $this->_em->createQuery($dql)
+            ->setFirstResult(0)
+            ->setMaxResults(3);
+
+        $paginator = new Paginator($query, fetchJoinCollection: false);
+
+        $seen = 0;
+        foreach ($paginator as $key => $user) {
+            self::assertSame($user->id, $key);
+            $seen++;
+        }
+
+        self::assertSame(3, $seen);
     }
 
     public function testCountComplexWithOutputWalker(): void
@@ -641,7 +749,7 @@ class PaginationTest extends OrmFunctionalTestCase
 
         $getCountQuery = new ReflectionMethod($paginator, 'getCountQuery');
 
-        self::assertCount(2, $getCountQuery->invoke($paginator)->getParameters());
+        self::assertCount(2, $getCountQuery->invoke($paginator, $query)->getParameters());
         self::assertCount(9, $paginator);
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SqlOutputWalker::class);
@@ -650,7 +758,7 @@ class PaginationTest extends OrmFunctionalTestCase
 
         // if select part of query is replaced with count(...) paginator should remove
         // parameters from query object not used in new query.
-        self::assertCount(1, $getCountQuery->invoke($paginator)->getParameters());
+        self::assertCount(1, $getCountQuery->invoke($paginator, $query)->getParameters());
         self::assertCount(9, $paginator);
     }
 

--- a/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/CursorPaginatorTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Cursor;
 use Doctrine\ORM\Tools\Pagination\CursorItem;
 use Doctrine\ORM\Tools\Pagination\CursorPaginator;
@@ -48,24 +49,58 @@ class CursorPaginatorTest extends OrmTestCase
             ->getMock();
 
         $this->em = $this->getMockBuilder(EntityManagerDecorator::class)
-            ->onlyMethods(['newHydrator'])
+            ->onlyMethods(['newHydrator', 'createQuery'])
             ->setConstructorArgs([$this->createTestEntityManagerWithConnection($this->connection)])
             ->getMock();
 
         $this->hydrator = $this->createMock(AbstractHydrator::class);
         $this->em->method('newHydrator')->willReturn($this->hydrator);
+
+        // keep queries built through this entity manager (e.g. by a QueryBuilder) bound to
+        // it, so that they go through the mocked hydrator
+        $this->em->method('createQuery')->willReturnCallback(function (string $dql = ''): Query {
+            $query = new Query($this->em);
+            $query->setDQL($dql);
+
+            return $query;
+        });
     }
 
     public function testPaginatorAcceptsQueryBuilder(): void
     {
-        $qb = $this->em->createQueryBuilder()
+        $items = [(object) ['id' => 1]];
+        $this->hydrator->method('hydrateAll')->willReturn($items);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        // not $this->em->createQueryBuilder(): the decorator would bind the builder to the
+        // wrapped entity manager, bypassing the mocked hydrator.
+        $qb = (new QueryBuilder($this->em))
             ->select('p')
             ->from(BlogPost::class, 'p')
             ->orderBy('p.id', SortDirection::Ascending);
 
-        $paginator = new CursorPaginator($qb);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($qb, null);
 
-        self::assertInstanceOf(Query::class, $paginator->getQuery());
+        self::assertSame($items, $page->getItems());
+    }
+
+    public function testPaginatorIsReusableAcrossQueriesAndPages(): void
+    {
+        $this->hydrator->method('hydrateAll')->willReturn([(object) ['id' => 1]]);
+        $result = $this->createMock(Result::class);
+        $this->connection->method('executeQuery')->willReturn($result);
+
+        $query = new Query($this->em);
+        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
+
+        $otherQuery = new Query($this->em);
+        $otherQuery->setDQL('SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b ORDER BY b.id ASC');
+
+        $paginator = new CursorPaginator(10, queryProducesDuplicates: false);
+
+        self::assertCount(1, $paginator->paginate($query, null));
+        self::assertCount(1, $paginator->paginate($otherQuery, null));
     }
 
     public function testHasNextPageWhenMoreResultsExist(): void
@@ -83,12 +118,11 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 3);
+        $page = (new CursorPaginator(3, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertTrue($paginator->hasNextPage());
-        self::assertFalse($paginator->hasPreviousPage());
-        self::assertSame(3, $paginator->countPageItems());
+        self::assertTrue($page->hasNextPage());
+        self::assertFalse($page->hasPreviousPage());
+        self::assertSame(3, $page->count());
     }
 
     public function testHasNoPagesOnFirstPageWithoutMoreResults(): void
@@ -101,12 +135,11 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertFalse($paginator->hasPreviousPage());
-        self::assertFalse($paginator->hasNextPage());
-        self::assertFalse($paginator->hasToPaginate());
+        self::assertFalse($page->hasPreviousPage());
+        self::assertFalse($page->hasNextPage());
+        self::assertFalse($page->hasToPaginate());
     }
 
     public function testGetNextCursorAsStringThrowsWhenNoNextPage(): void
@@ -119,11 +152,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
         $this->expectException(LogicException::class);
-        $paginator->getNextCursorAsString();
+        $page->getNextCursorAsString();
     }
 
     public function testGetPreviousCursorAsStringThrowsWhenNoPreviousPage(): void
@@ -136,11 +168,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
         $this->expectException(LogicException::class);
-        $paginator->getPreviousCursorAsString();
+        $page->getPreviousCursorAsString();
     }
 
     public function testGetNextCursorThrowsWhenNoNextPage(): void
@@ -153,11 +184,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
         $this->expectException(LogicException::class);
-        $paginator->getNextCursor();
+        $page->getNextCursor();
     }
 
     public function testGetPreviousCursorThrowsWhenNoPreviousPage(): void
@@ -170,11 +200,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
         $this->expectException(LogicException::class);
-        $paginator->getPreviousCursor();
+        $page->getPreviousCursor();
     }
 
     public function testGetNextCursorWhenMoreResultsExist(): void
@@ -190,10 +219,9 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 1);
+        $page = (new CursorPaginator(1, queryProducesDuplicates: false))->paginate($query, null);
 
-        $nextCursor = $paginator->getNextCursor();
+        $nextCursor = $page->getNextCursor();
 
         self::assertTrue($nextCursor->isNext());
     }
@@ -211,10 +239,9 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 1);
+        $page = (new CursorPaginator(1, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertNotEmpty($paginator->getNextCursorAsString());
+        self::assertNotEmpty($page->getNextCursorAsString());
     }
 
     public function testGetPreviousCursorAsStringReturnsStringWhenPreviousPageExists(): void
@@ -230,11 +257,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $cursor    = (new Cursor(['p__id' => 1], true))->encodeToString();
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate($cursor, 10);
+        $cursor = (new Cursor(['p__id' => 1], true))->encodeToString();
+        $page   = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, $cursor);
 
-        self::assertNotEmpty($paginator->getPreviousCursorAsString());
+        self::assertNotEmpty($page->getPreviousCursorAsString());
     }
 
     public function testEmptyResultSet(): void
@@ -246,12 +272,11 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertSame(0, $paginator->countPageItems());
-        self::assertFalse($paginator->hasNextPage());
-        self::assertFalse($paginator->hasPreviousPage());
+        self::assertSame(0, $page->count());
+        self::assertFalse($page->hasNextPage());
+        self::assertFalse($page->hasPreviousPage());
     }
 
     public function testIteratorReturnsItems(): void
@@ -267,18 +292,17 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
         $iteratedItems = [];
-        foreach ($paginator as $item) {
+        foreach ($page as $item) {
             $iteratedItems[] = $item;
         }
 
         self::assertCount(2, $iteratedItems);
     }
 
-    public function testGetValuesReturnsRawEntities(): void
+    public function testGetItemsReturnsRawEntities(): void
     {
         $items = [
             (object) ['id' => 1],
@@ -291,17 +315,16 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        $values = $paginator->getValues();
+        $values = $page->getItems();
 
         self::assertCount(2, $values);
         self::assertSame($items[0], $values[0]);
         self::assertSame($items[1], $values[1]);
     }
 
-    public function testGetItemsReturnsCursorItems(): void
+    public function testGetItemsWithCursorsReturnsCursorItems(): void
     {
         $items = [
             (object) ['id' => 1],
@@ -314,10 +337,9 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        $cursorItems = $paginator->getItems();
+        $cursorItems = $page->getItemsWithCursors();
 
         self::assertCount(2, $cursorItems);
         self::assertInstanceOf(CursorItem::class, $cursorItems[0]);
@@ -335,11 +357,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertSame([], $paginator->getItems());
-        self::assertSame([], $paginator->getValues());
+        self::assertSame([], $page->getItemsWithCursors());
+        self::assertSame([], $page->getItems());
     }
 
     public function testPaginateWithCursorInstance(): void
@@ -355,11 +376,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $cursor    = new Cursor(['p.id' => 1], true);
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate($cursor, 10);
+        $cursor = new Cursor(['p.id' => 1], true);
+        $page   = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, $cursor);
 
-        self::assertNotEmpty($paginator->getPreviousCursorAsString());
+        self::assertNotEmpty($page->getPreviousCursorAsString());
     }
 
     public function testPaginateWithEmptyCursorTreatedAsFirstPage(): void
@@ -372,11 +392,10 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate('', 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, '');
 
-        self::assertFalse($paginator->hasPreviousPage());
-        self::assertFalse($paginator->hasNextPage());
+        self::assertFalse($page->hasPreviousPage());
+        self::assertFalse($page->hasNextPage());
     }
 
     public function testPaginateWithPreviousCursorReversesItems(): void
@@ -395,25 +414,13 @@ class CursorPaginatorTest extends OrmTestCase
 
         $previousCursor = (new Cursor(['p__id' => 3], false))->encodeToString();
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate($previousCursor, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, $previousCursor);
 
-        $values = $paginator->getValues();
+        $values = $page->getItems();
         self::assertCount(3, $values);
         self::assertSame(1, $values[0]->id);
         self::assertSame(2, $values[1]->id);
         self::assertSame(3, $values[2]->id);
-    }
-
-    public function testCountCurrentPageThrowsWhenPaginateNotCalled(): void
-    {
-        $query = new Query($this->em);
-        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
-
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-
-        $this->expectException(LogicException::class);
-        $paginator->countPageItems();
     }
 
     public function testPaginateThrowsInvalidCursorForNonStringNonCursorNonNull(): void
@@ -421,19 +428,15 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-
         $this->expectException(InvalidCursor::class);
-        $paginator->paginate(['injected' => 'array'], 10);
+        (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, ['injected' => 'array']);
     }
 
     public function testDefaultQueryProducesDuplicatesIsTrue(): void
     {
-        $query = new Query($this->em);
-        $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
+        $paginator = new CursorPaginator(10);
 
-        $paginator = new CursorPaginator($query);
-
+        self::assertSame(10, $paginator->getLimit());
         self::assertTrue($paginator->getQueryProducesDuplicates());
     }
 
@@ -444,26 +447,29 @@ class CursorPaginatorTest extends OrmTestCase
         $this->connection->method('executeQuery')->willReturn($result);
 
         $query = new Query($this->em);
-        $query->setDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u');
+        $query->setDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC');
 
-        $paginator = (new CursorPaginator($query, queryProducesDuplicates: false))->setUseOutputWalkers(false);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false, useOutputWalkers: false))
+            ->paginate($query, null);
 
-        self::assertSame(42, $paginator->getTotalCount());
+        self::assertSame(42, $page->getTotalCount());
     }
 
     public function testGetTotalCountIsCached(): void
     {
         $this->hydrator->method('hydrateAll')->willReturn([[1 => 5]]);
         $result = $this->createMock(Result::class);
-        $this->connection->expects(self::once())->method('executeQuery')->willReturn($result);
+        // one executeQuery for the page query, one for the (cached) count query
+        $this->connection->expects(self::exactly(2))->method('executeQuery')->willReturn($result);
 
         $query = new Query($this->em);
-        $query->setDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u');
+        $query->setDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.id ASC');
 
-        $paginator = (new CursorPaginator($query, queryProducesDuplicates: false))->setUseOutputWalkers(false);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false, useOutputWalkers: false))
+            ->paginate($query, null);
 
-        self::assertSame(5, $paginator->getTotalCount());
-        self::assertSame(5, $paginator->getTotalCount());
+        self::assertSame(5, $page->getTotalCount());
+        self::assertSame(5, $page->getTotalCount());
     }
 
     public function testCloneQueryCopiesExistingHints(): void
@@ -477,10 +483,9 @@ class CursorPaginatorTest extends OrmTestCase
         $query->setDQL('SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id ASC');
         $query->setHint('custom.hint', 'custom_value');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 10);
+        $page = (new CursorPaginator(10, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertSame(1, $paginator->countPageItems());
+        self::assertSame(1, $page->count());
     }
 
     public function testGetNextCursorUnwrapsManyToOneAssociationToIdentifier(): void
@@ -502,12 +507,11 @@ class CursorPaginatorTest extends OrmTestCase
         $query = new Query($this->em);
         $query->setDQL('SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b ORDER BY b.author ASC');
 
-        $paginator = new CursorPaginator($query, queryProducesDuplicates: false);
-        $paginator->paginate(null, 1);
+        $page = (new CursorPaginator(1, queryProducesDuplicates: false))->paginate($query, null);
 
-        self::assertTrue($paginator->hasNextPage());
+        self::assertTrue($page->hasNextPage());
 
-        $cursor = $paginator->getNextCursor();
+        $cursor = $page->getNextCursor();
         self::assertSame(42, $cursor->getParameters()['b.author']);
     }
 }

--- a/tests/Tests/ORM/Tools/Pagination/WindowPageTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/WindowPageTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Tools\Pagination\Window;
+use Doctrine\ORM\Tools\Pagination\WindowPage;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+
+class WindowPageTest extends TestCase
+{
+    public function testGetItemsAndCount(): void
+    {
+        $items = [(object) ['id' => 1], (object) ['id' => 2]];
+        $page  = new WindowPage($items, 10, new Window(0, 2));
+
+        self::assertSame($items, $page->getItems());
+        self::assertCount(2, $page);
+        self::assertSame($items, iterator_to_array($page));
+    }
+
+    public function testGetTotalCount(): void
+    {
+        $page = new WindowPage([], 42, new Window(0, 20));
+
+        self::assertSame(42, $page->getTotalCount());
+    }
+
+    public function testFirstPageHasNextButNoPreviousPage(): void
+    {
+        $page = new WindowPage([(object) ['id' => 1], (object) ['id' => 2]], 10, new Window(0, 2));
+
+        self::assertFalse($page->hasPreviousPage());
+        self::assertTrue($page->hasNextPage());
+        self::assertTrue($page->hasToPaginate());
+    }
+
+    public function testMiddlePageHasBothPages(): void
+    {
+        $page = new WindowPage([(object) ['id' => 3], (object) ['id' => 4]], 10, new Window(2, 2));
+
+        self::assertTrue($page->hasPreviousPage());
+        self::assertTrue($page->hasNextPage());
+    }
+
+    public function testLastPageHasPreviousButNoNextPage(): void
+    {
+        $page = new WindowPage([(object) ['id' => 9], (object) ['id' => 10]], 10, new Window(8, 2));
+
+        self::assertTrue($page->hasPreviousPage());
+        self::assertFalse($page->hasNextPage());
+    }
+
+    public function testSinglePageHasNoNavigation(): void
+    {
+        $page = new WindowPage([(object) ['id' => 1]], 1, new Window(0, 20));
+
+        self::assertFalse($page->hasPreviousPage());
+        self::assertFalse($page->hasNextPage());
+        self::assertFalse($page->hasToPaginate());
+    }
+
+    public function testGetNextWindow(): void
+    {
+        $page = new WindowPage([(object) ['id' => 1], (object) ['id' => 2]], 10, new Window(0, 2));
+
+        self::assertSame(2, $page->getNextWindow()->getFirstResult());
+    }
+
+    public function testGetPreviousWindow(): void
+    {
+        $page = new WindowPage([(object) ['id' => 3], (object) ['id' => 4]], 10, new Window(2, 2));
+
+        self::assertSame(0, $page->getPreviousWindow()->getFirstResult());
+    }
+
+    public function testGetNextWindowThrowsWhenNoNextPage(): void
+    {
+        $page = new WindowPage([(object) ['id' => 1]], 1, new Window(0, 20));
+
+        $this->expectException(LogicException::class);
+        $page->getNextWindow();
+    }
+
+    public function testGetPreviousWindowThrowsWhenNoPreviousPage(): void
+    {
+        $page = new WindowPage([(object) ['id' => 1]], 10, new Window(0, 2));
+
+        $this->expectException(LogicException::class);
+        $page->getPreviousWindow();
+    }
+
+    public function testGetWindow(): void
+    {
+        $window = new Window(4, 2);
+        $page   = new WindowPage([], 10, $window);
+
+        self::assertSame($window, $page->getWindow());
+    }
+
+    public function testGetPageNumber(): void
+    {
+        $page = new WindowPage([], 10, new Window(4, 2));
+
+        self::assertSame(3, $page->getPageNumber());
+    }
+
+    public function testGetPageCount(): void
+    {
+        self::assertSame(5, (new WindowPage([], 10, new Window(0, 2)))->getPageCount());
+        self::assertSame(4, (new WindowPage([], 10, new Window(0, 3)))->getPageCount());
+        self::assertSame(1, (new WindowPage([], 10, new Window(0, 20)))->getPageCount());
+    }
+
+    public function testGetPageCountIsAtLeastOneOnEmptyResultSet(): void
+    {
+        self::assertSame(1, (new WindowPage([], 0, new Window(0, 20)))->getPageCount());
+    }
+
+    public function testGetLastWindow(): void
+    {
+        $lastWindow = (new WindowPage([], 10, new Window(0, 3)))->getLastWindow();
+
+        self::assertSame(9, $lastWindow->getFirstResult());
+        self::assertSame(3, $lastWindow->getMaxResults());
+        self::assertSame(4, $lastWindow->getPageNumber());
+    }
+
+    public function testGetLastWindowOnEmptyResultSetPointsAtTheFirstPage(): void
+    {
+        $lastWindow = (new WindowPage([], 0, new Window(0, 20)))->getLastWindow();
+
+        self::assertSame(0, $lastWindow->getFirstResult());
+        self::assertSame(1, $lastWindow->getPageNumber());
+    }
+}

--- a/tests/Tests/ORM/Tools/Pagination/WindowTest.php
+++ b/tests/Tests/ORM/Tools/Pagination/WindowTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Tools\Pagination\Window;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class WindowTest extends TestCase
+{
+    public function testWindowIsFinal(): void
+    {
+        self::assertTrue((new ReflectionClass(Window::class))->isFinal());
+    }
+
+    public function testGetters(): void
+    {
+        $window = new Window(50, 25);
+
+        self::assertSame(50, $window->getFirstResult());
+        self::assertSame(25, $window->getMaxResults());
+    }
+
+    public function testNext(): void
+    {
+        $next = (new Window(0, 25))->next();
+
+        self::assertSame(25, $next->getFirstResult());
+        self::assertSame(25, $next->getMaxResults());
+    }
+
+    public function testPrevious(): void
+    {
+        $previous = (new Window(50, 25))->previous();
+
+        self::assertSame(25, $previous->getFirstResult());
+        self::assertSame(25, $previous->getMaxResults());
+    }
+
+    public function testPreviousIsClampedAtZero(): void
+    {
+        $previous = (new Window(10, 25))->previous();
+
+        self::assertSame(0, $previous->getFirstResult());
+    }
+
+    public function testFromPageNumberAndSize(): void
+    {
+        $window = Window::fromPageNumberAndSize(3, 25);
+
+        self::assertSame(50, $window->getFirstResult());
+        self::assertSame(25, $window->getMaxResults());
+        self::assertSame(3, $window->getPageNumber());
+    }
+
+    public function testGetPageNumber(): void
+    {
+        self::assertSame(1, (new Window(0, 25))->getPageNumber());
+        self::assertSame(2, (new Window(25, 25))->getPageNumber());
+        self::assertSame(3, (new Window(50, 25))->getPageNumber());
+    }
+
+    public function testNegativeFirstResultThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Window(-1, 20);
+    }
+
+    public function testZeroMaxResultsThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Window(0, 0);
+    }
+
+    public function testFromPageNumberAndSizeWithPageNumberBelowOneThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Window::fromPageNumberAndSize(0, 25);
+    }
+
+    public function testIsImmutable(): void
+    {
+        $window = new Window(0, 25);
+        $window->next();
+
+        self::assertSame(0, $window->getFirstResult());
+    }
+}


### PR DESCRIPTION
Closes #12480.

Adds `OffsetPaginator`, the offset-based counterpart to `CursorPaginator`. The position is passed as an `Offset` value object to the constructor, and `paginate()` returns an immutable, iterable `OffsetPage`.

Following @beberlei's feedback, `CursorPaginator` is aligned on the same shape: `cursor` and `limit` move to the constructor and `paginate()` returns an immutable `CursorPage`.

The legacy `Paginator` is now `@deprecated` in favor of `OffsetPaginator` (removal in `4.0`).