### PR TITLE
Deprecate JoinColumns

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,11 @@ and directly start using native lazy objects.
 
 # Upgrade to 3.7
 
+## Deprecated `Doctrine\ORM\Mapping\JoinColumns` attribute
+
+Using it has no effect, it should have been removed in 3.0.0. Instead, use the
+`Doctrine\ORM\Mapping\JoinColumn` attribute multiple times.
+
 ## Deprecated `Doctrine\ORM\Query\AST\TypedExpression`
 
 Implement `Doctrine\ORM\Query\AST\ExpressionWithReturnType` instead, which exposes

--- a/src/Mapping/JoinColumns.php
+++ b/src/Mapping/JoinColumns.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+/**
+ * @deprecated Using this attribute has no effect, use the `#[JoinColumn]`
+ *              attribute instead, it is repeatable.
+ */
 final class JoinColumns implements MappingAttribute
 {
     /** @param array<JoinColumn> $value */


### PR DESCRIPTION
This is a leftover of annotations. With repeatable attributes, it is no longer needed.