### PR TITLE
Allow configuring foreign key names

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -696,6 +696,10 @@ Optional parameters:
    "columnDefinition" attribute on :ref:`#[Column] <attrref_column>` also sets
    the related ``#[JoinColumn]``'s columnDefinition. This is necessary to
    make foreign keys work.
+-  **foreignKeyName**: Allows you to specify a custom name for the foreign key constraint.
+   If not specified, the name will be generated automatically. For composite foreign
+   keys (multiple ``#[JoinColumn]`` attributes), only one join column should specify
+   ``foreignKeyName``.
 -  **options**:
    See "options" attribute on :ref:`#[Column] <attrref_column>`.
 
@@ -708,7 +712,7 @@ Example:
     use Doctrine\ORM\Mapping\JoinColumn;
 
     #[OneToOne(targetEntity: Customer::class)]
-    #[JoinColumn(name: "customer_id", referencedColumnName: "id")]
+    #[JoinColumn(name: "customer_id", referencedColumnName: "id", foreignKeyName: "fk_customer")]
     private $customer;
 
 .. _attrref_jointable:
@@ -727,6 +731,13 @@ Required attribute:
 
 -  **name**: Database name of the join-table
 
+Optional attributes:
+
+-  **foreignKeyName**: Specifies a custom name for the foreign key constraint from the join table
+   to the owning side entity. If not specified, the name will be generated automatically.
+-  **inverseForeignKeyName**: Specifies a custom name for the foreign key constraint from the join
+   table to the inverse side entity. If not specified, the name will be generated automatically.
+
 Example:
 
 .. code-block:: php
@@ -734,9 +745,16 @@ Example:
     <?php
     use Doctrine\ORM\Mapping\ManyToMany;
     use Doctrine\ORM\Mapping\JoinTable;
+    use Doctrine\ORM\Mapping\JoinColumn;
 
-    #[ManyToMany(targetEntity: "Phonenumber")]
-    #[JoinTable(name: "users_phonenumbers")]
+    #[ManyToMany(targetEntity: Phonenumber::class)]
+    #[JoinTable(
+        name: "users_phonenumbers",
+        joinColumns: [new JoinColumn(name: "user_id", referencedColumnName: "id")],
+        inverseJoinColumns: [new JoinColumn(name: "phonenumber_id", referencedColumnName: "id")],
+        foreignKeyName: "fk_users_phonenumbers_user",
+        inverseForeignKeyName: "fk_users_phonenumbers_phonenumber"
+    )]
     public $phonenumbers;
 
 .. _attrref_manytoone:

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -656,7 +656,7 @@ and "group\_id". The explicit definition of this mapping would be:
 
     <entity class="MyProject\User">
         <many-to-many field="groups" target-entity="Group">
-            <join-table name="cms_users_groups">
+            <join-table name="cms_users_groups" foreign-key-name="fk_user_group_user" inverse-foreign-key-name="fk_user_group_group">
                 <join-columns>
                     <join-column name="user_id" referenced-column-name="id"/>
                 </join-columns>
@@ -671,7 +671,9 @@ Here both the ``<join-columns>`` and ``<inverse-join-columns>``
 tags are necessary to tell Doctrine for which side the specified
 join-columns apply. These are nested inside a ``<join-table />``
 attribute which allows to specify the table name of the
-many-to-many join-table.
+many-to-many join-table. The optional ``foreign-key-name`` and
+``inverse-foreign-key-name`` attributes allow specifying custom names
+for the foreign key constraints.
 
 Cascade Element
 ~~~~~~~~~~~~~~~
@@ -724,6 +726,10 @@ Optional attributes:
 -  on-delete - Foreign Key Cascade action to perform when entity is
    deleted, defaults to NO ACTION/RESTRICT but can be set to
    "CASCADE".
+-  foreign-key-name - Allows you to specify a custom name for the foreign key constraint.
+   If not specified, the name will be generated automatically. For composite foreign
+   keys (multiple ``<join-column>`` elements), exactly one join column must specify
+   ``foreign-key-name``.
 
 Defining Order of To-Many Associations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -420,6 +420,7 @@
     <xs:attribute name="nullable" type="xs:boolean" default="true" />
     <xs:attribute name="on-delete" type="orm:fk-action" />
     <xs:attribute name="column-definition" type="xs:string" />
+    <xs:attribute name="foreign-key-name" type="xs:string" use="optional" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
@@ -439,6 +440,8 @@
     </xs:choice>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="schema" type="xs:NMTOKEN" />
+    <xs:attribute name="foreign-key-name" type="xs:string" use="optional" />
+    <xs:attribute name="inverse-foreign-key-name" type="xs:string" use="optional" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -883,7 +883,7 @@ parameters:
 			path: src/Mapping/AnsiQuoteStrategy.php
 
 		-
-			message: '#^Parameter \#1 \$mappingArray of static method Doctrine\\ORM\\Mapping\\JoinTableMapping\:\:fromMappingArray\(\) expects array\{name\: string, quoted\?\: bool\|null, joinColumns\?\: array\<mixed\>, inverseJoinColumns\?\: array\<mixed\>, schema\?\: string\|null, options\?\: array\<string, mixed\>\}, non\-empty\-array\<mixed\> given\.$#'
+			message: '#^Parameter \#1 \$mappingArray of static method Doctrine\\ORM\\Mapping\\JoinTableMapping\:\:fromMappingArray\(\) expects array\{name\: string, quoted\?\: bool\|null, joinColumns\?\: array\<mixed\>, inverseJoinColumns\?\: array\<mixed\>, schema\?\: string\|null, foreignKeyName\?\: string\|null, inverseForeignKeyName\?\: string\|null, options\?\: array\<string, mixed\>\}, non\-empty\-array\<mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Mapping/AssociationMapping.php

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -429,6 +429,14 @@ class AttributeDriver implements MappingDriver
                         $joinTable['options'] = $joinTableAttribute->options;
                     }
 
+                    if ($joinTableAttribute->foreignKeyName !== null) {
+                        $joinTable['foreignKeyName'] = $joinTableAttribute->foreignKeyName;
+                    }
+
+                    if ($joinTableAttribute->inverseForeignKeyName !== null) {
+                        $joinTable['inverseForeignKeyName'] = $joinTableAttribute->inverseForeignKeyName;
+                    }
+
                     foreach ($joinTableAttribute->joinColumns as $joinColumn) {
                         $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumn);
                     }
@@ -688,6 +696,7 @@ class AttributeDriver implements MappingDriver
      *                   onDelete: mixed,
      *                   columnDefinition: string|null,
      *                   referencedColumnName: string,
+     *                   foreignKeyName: string|null,
      *                   options?: array<string, mixed>
      *               }
      */
@@ -701,6 +710,7 @@ class AttributeDriver implements MappingDriver
             'onDelete' => $joinColumn->onDelete,
             'columnDefinition' => $joinColumn->columnDefinition,
             'referencedColumnName' => $joinColumn->referencedColumnName,
+            'foreignKeyName' => $joinColumn->foreignKeyName,
         ];
 
         if ($joinColumn->options) {

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -518,6 +518,14 @@ class XmlDriver extends FileDriver
                         $joinTable['schema'] = (string) $joinTableElement['schema'];
                     }
 
+                    if (isset($joinTableElement['foreign-key-name'])) {
+                        $joinTable['foreignKeyName'] = (string) $joinTableElement['foreign-key-name'];
+                    }
+
+                    if (isset($joinTableElement['inverse-foreign-key-name'])) {
+                        $joinTable['inverseForeignKeyName'] = (string) $joinTableElement['inverse-foreign-key-name'];
+                    }
+
                     if (isset($joinTableElement->options)) {
                         $joinTable['options'] = $this->parseOptions($joinTableElement->options->children());
                     }
@@ -600,6 +608,14 @@ class XmlDriver extends FileDriver
                         'name'      => (string) $joinTableElement['name'],
                         'schema'    => (string) $joinTableElement['schema'],
                     ];
+
+                    if (isset($joinTableElement['foreign-key-name'])) {
+                        $joinTable['foreignKeyName'] = (string) $joinTableElement['foreign-key-name'];
+                    }
+
+                    if (isset($joinTableElement['inverse-foreign-key-name'])) {
+                        $joinTable['inverseForeignKeyName'] = (string) $joinTableElement['inverse-foreign-key-name'];
+                    }
 
                     if (isset($joinTableElement->options)) {
                         $joinTable['options'] = $this->parseOptions($joinTableElement->options->children());
@@ -750,6 +766,7 @@ class XmlDriver extends FileDriver
      *                   nullable?: bool,
      *                   onDelete?: string,
      *                   columnDefinition?: string,
+     *                   foreignKeyName?: string,
      *                   options?: mixed[]
      *               }
      */
@@ -774,6 +791,10 @@ class XmlDriver extends FileDriver
 
         if (isset($joinColumnElement['column-definition'])) {
             $joinColumn['columnDefinition'] = (string) $joinColumnElement['column-definition'];
+        }
+
+        if (isset($joinColumnElement['foreign-key-name'])) {
+            $joinColumn['foreignKeyName'] = (string) $joinColumnElement['foreign-key-name'];
         }
 
         if (isset($joinColumnElement['options'])) {

--- a/src/Mapping/JoinColumnMapping.php
+++ b/src/Mapping/JoinColumnMapping.php
@@ -20,6 +20,7 @@ final class JoinColumnMapping implements ArrayAccess
     public string|null $onDelete         = null;
     public string|null $columnDefinition = null;
     public bool|null $nullable           = null;
+    public string|null $foreignKeyName   = null;
 
     /** @var array<string, mixed>|null */
     public array|null $options = null;
@@ -41,6 +42,7 @@ final class JoinColumnMapping implements ArrayAccess
      *     onDelete?: string|null,
      *     columnDefinition?: string|null,
      *     nullable?: bool|null,
+     *     foreignKeyName?: string|null,
      *     options?: array<string, mixed>|null,
      * } $mappingArray
      */
@@ -61,7 +63,17 @@ final class JoinColumnMapping implements ArrayAccess
     {
         $serialized = [];
 
-        foreach (['name', 'fieldName', 'onDelete', 'columnDefinition', 'referencedColumnName', 'options'] as $stringOrArrayKey) {
+        foreach (
+            [
+                'columnDefinition',
+                'fieldName',
+                'foreignKeyName',
+                'name',
+                'onDelete',
+                'options',
+                'referencedColumnName',
+            ] as $stringOrArrayKey
+        ) {
             if ($this->$stringOrArrayKey !== null) {
                 $serialized[] = $stringOrArrayKey;
             }

--- a/src/Mapping/JoinColumnProperties.php
+++ b/src/Mapping/JoinColumnProperties.php
@@ -16,6 +16,7 @@ trait JoinColumnProperties
         public readonly mixed $onDelete = null,
         public readonly string|null $columnDefinition = null,
         public readonly string|null $fieldName = null,
+        public readonly string|null $foreignKeyName = null,
         public readonly array $options = [],
     ) {
     }

--- a/src/Mapping/JoinTable.php
+++ b/src/Mapping/JoinTable.php
@@ -25,6 +25,8 @@ final class JoinTable implements MappingAttribute
         public readonly string|null $schema = null,
         array|JoinColumn $joinColumns = [],
         array|JoinColumn $inverseJoinColumns = [],
+        public readonly string|null $foreignKeyName = null,
+        public readonly string|null $inverseForeignKeyName = null,
         public readonly array $options = [],
     ) {
         $this->joinColumns        = $joinColumns instanceof JoinColumn ? [$joinColumns] : $joinColumns;

--- a/src/Mapping/JoinTableMapping.php
+++ b/src/Mapping/JoinTableMapping.php
@@ -14,7 +14,9 @@ final class JoinTableMapping implements ArrayAccess
 {
     use ArrayAccessImplementation;
 
-    public bool|null $quoted = null;
+    public bool|null $quoted                  = null;
+    public string|null $foreignKeyName        = null;
+    public string|null $inverseForeignKeyName = null;
 
     /** @var list<JoinColumnMapping> */
     public array $joinColumns = [];
@@ -39,6 +41,8 @@ final class JoinTableMapping implements ArrayAccess
      *    joinColumns?: mixed[],
      *    inverseJoinColumns?: mixed[],
      *    schema?: string|null,
+     *    foreignKeyName?: string|null,
+     *    inverseForeignKeyName?: string|null,
      *    options?: array<string, mixed>
      * } $mappingArray
      */
@@ -50,6 +54,14 @@ final class JoinTableMapping implements ArrayAccess
             if (isset($mappingArray[$key])) {
                 $mapping->$key = $mappingArray[$key];
             }
+        }
+
+        if (isset($mappingArray['foreignKeyName'])) {
+            $mapping->foreignKeyName = $mappingArray['foreignKeyName'];
+        }
+
+        if (isset($mappingArray['inverseForeignKeyName'])) {
+            $mapping->inverseForeignKeyName = $mappingArray['inverseForeignKeyName'];
         }
 
         if (isset($mappingArray['joinColumns'])) {
@@ -103,7 +115,7 @@ final class JoinTableMapping implements ArrayAccess
     {
         $serialized = [];
 
-        foreach (['joinColumns', 'inverseJoinColumns', 'name', 'schema', 'options'] as $stringOrArrayKey) {
+        foreach (['joinColumns', 'inverseJoinColumns', 'name', 'schema', 'options', 'foreignKeyName', 'inverseForeignKeyName'] as $stringOrArrayKey) {
             if ($this->$stringOrArrayKey !== null) {
                 $serialized[] = $stringOrArrayKey;
             }

--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -40,6 +40,7 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Exception\MissingColumnException;
 use Doctrine\ORM\Tools\Exception\NotSupported;
+use RuntimeException;
 use Throwable;
 
 use function array_diff;
@@ -59,6 +60,7 @@ use function interface_exists;
 use function is_numeric;
 use function method_exists;
 use function preg_match;
+use function sprintf;
 use function strtolower;
 
 /**
@@ -524,6 +526,7 @@ class SchemaTool
                                 foreignTableName: $fkData['foreignTableName'],
                                 foreignColumnNames: $fkData['foreignColumns'],
                                 options: $fkData['fkOptions'],
+                                name: $fkData['name'],
                             ));
                         },
                     )->create();
@@ -535,6 +538,7 @@ class SchemaTool
                     $fkData['localColumns'],
                     $fkData['foreignColumns'],
                     $fkData['fkOptions'],
+                    $fkData['name'],
                 );
             }
         }
@@ -740,6 +744,7 @@ class SchemaTool
      *                  foreignColumns: list<string>,
      *                  localColumns: list<string>,
      *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  name: string|null,
      *                  table: Table
      *              }>                               $addedFks
      * @phpstan-param array<string, bool>              $blacklistedFks
@@ -774,6 +779,7 @@ class SchemaTool
                     $primaryKeyColumns,
                     $addedFks,
                     $blacklistedFks,
+                    null,  // For ToOne, FK name comes from JoinColumn, not a parameter
                 );
             } elseif ($mapping instanceof ManyToManyOwningSideMapping) {
                 // create join table
@@ -811,6 +817,7 @@ class SchemaTool
                     $primaryKeyColumns,
                     $addedFks,
                     $blacklistedFks,
+                    $joinTable->foreignKeyName ?? null,
                 );
 
                 // Build second FK constraint (relation table => target table)
@@ -822,6 +829,7 @@ class SchemaTool
                     $primaryKeyColumns,
                     $addedFks,
                     $blacklistedFks,
+                    $joinTable->inverseForeignKeyName ?? null,
                 );
 
                 self::addPrimaryKeyConstraint($theJoinTable, $primaryKeyColumns);
@@ -881,6 +889,7 @@ class SchemaTool
      *                  foreignColumns: list<string>,
      *                  localColumns: list<string>,
      *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  name: string|null,
      *                  table: Table
      *              }>                               $addedFks
      * @phpstan-param array<string,bool>               $blacklistedFks
@@ -892,6 +901,7 @@ class SchemaTool
      *                  foreignColumns: list<string>,
      *                  localColumns: list<string>,
      *                  fkOptions: array{onDelete?: string, deferrable?: bool, deferred?: bool},
+     *                  name: string|null,
      *                  table: Table
      *              }>                               $addedFks
      */
@@ -903,6 +913,7 @@ class SchemaTool
         array &$primaryKeyColumns,
         array &$addedFks,
         array &$blacklistedFks,
+        string|null $foreignKeyName = null,
     ): void {
         $localColumns   = [];
         $foreignColumns = [];
@@ -990,6 +1001,30 @@ class SchemaTool
             $theJoinTable->addUniqueIndex($unique['columns'], is_numeric($indexName) ? null : $indexName);
         }
 
+        // Extract and validate foreign key name from join columns
+        $foreignKeyNames = [];
+
+        foreach ($joinColumns as $joinColumn) {
+            if ($joinColumn->foreignKeyName !== null) {
+                $foreignKeyNames[] = $joinColumn->foreignKeyName;
+            }
+        }
+
+        $extractedForeignKeyName = match (count($foreignKeyNames)) {
+            0 => null,
+            1 => $foreignKeyNames[0],
+            default => throw new RuntimeException(sprintf(
+                'Only one JoinColumn in a composite foreign key may specify foreignKeyName. ' .
+                '%s::$%s has %d join columns with foreignKeyName specified.',
+                $mapping->sourceEntity,
+                $mapping->fieldName,
+                count($foreignKeyNames),
+            )),
+        };
+
+        // Use parameter FK name (from JoinTable) if provided, otherwise use extracted from JoinColumns
+        $finalForeignKeyName = $foreignKeyName ?? $extractedForeignKeyName;
+
         $compositeName = $this->getAssetName($theJoinTable) . '.' . implode('', $localColumns);
 
         // Check if an FK constraint already exists for this composite key (table + columns)
@@ -1032,6 +1067,7 @@ class SchemaTool
                 'foreignColumns' => $foreignColumns,
                 'localColumns' => $localColumns,
                 'fkOptions' => $fkOptions,
+                'name' => $finalForeignKeyName,
                 'table' => $theJoinTable,
             ];
         }

--- a/tests/Tests/ORM/Functional/CustomForeignKeyNameTest.php
+++ b/tests/Tests/ORM/Functional/CustomForeignKeyNameTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use RuntimeException;
+
+use function array_map;
+use function implode;
+
+class CustomForeignKeyNameTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            CustomFKArticle::class,
+            CustomFKAuthor::class,
+            CustomFKTag::class,
+        ]);
+    }
+
+    public function testManyToOneGeneratesCustomForeignKeyName(): void
+    {
+        $sql       = $this->getSchemaSql();
+        $sqlString = implode("\n", $sql);
+
+        // Verify custom FK name is present
+        self::assertStringContainsString('fk_custom_article_author', $sqlString);
+
+        // Verify it's a FOREIGN KEY constraint
+        self::assertMatchesRegularExpression(
+            '/CONSTRAINT\s+(`|")?fk_custom_article_author(`|")?\s+FOREIGN\s+KEY/i',
+            $sqlString,
+        );
+    }
+
+    public function testManyToManyGeneratesCustomForeignKeyNames(): void
+    {
+        $sql       = $this->getSchemaSql();
+        $sqlString = implode("\n", $sql);
+
+        // Verify both FK names
+        self::assertStringContainsString('fk_article_tag_article', $sqlString);
+        self::assertStringContainsString('fk_article_tag_tag', $sqlString);
+    }
+
+    public function testCompositeForeignKeyWithCustomName(): void
+    {
+        $sql       = $this->getSchemaSql();
+        $sqlString = implode("\n", $sql);
+
+        // Verify composite FK has custom name
+        self::assertStringContainsString('fk_article_composite_author', $sqlString);
+    }
+
+    public function testMultipleCompositeFKNamesThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Only one JoinColumn');
+
+        $this->createSchemaForModels(
+            InvalidCompositeFKArticle::class,
+            CustomFKAuthor::class,
+        );
+    }
+
+    public function testPartialCompositeFKNamesIsValid(): void
+    {
+        // This should now be VALID - only one JoinColumn specifies foreignKeyName
+        $this->createSchemaForModels(
+            PartialCompositeFKArticle::class,
+            CustomFKAuthor::class,
+        );
+
+        $sql       = $this->getSchemaSqlForEntities([
+            PartialCompositeFKArticle::class,
+            CustomFKAuthor::class,
+        ]);
+        $sqlString = implode("\n", $sql);
+
+        // Verify custom FK name is present
+        self::assertStringContainsString('fk_partial', $sqlString);
+    }
+
+    public function testCompositeForeignKeyWithSecondPositionCustomName(): void
+    {
+        $this->createSchemaForModels(
+            SecondPositionCompositeFKArticle::class,
+            CustomFKAuthor::class,
+        );
+
+        $sql       = $this->getSchemaSqlForEntities([
+            SecondPositionCompositeFKArticle::class,
+            CustomFKAuthor::class,
+        ]);
+        $sqlString = implode("\n", $sql);
+
+        // Verify composite FK has custom name
+        self::assertStringContainsString('fk_second_position', $sqlString);
+    }
+
+    /** @return string[] */
+    private function getSchemaSql(): array
+    {
+        $schemaTool = new SchemaTool($this->_em);
+        $metadata   = [
+            $this->_em->getClassMetadata(CustomFKArticle::class),
+            $this->_em->getClassMetadata(CustomFKAuthor::class),
+            $this->_em->getClassMetadata(CustomFKTag::class),
+        ];
+
+        return $schemaTool->getCreateSchemaSql($metadata);
+    }
+
+    /**
+     * @param list<class-string> $entityClasses
+     *
+     * @return string[]
+     */
+    private function getSchemaSqlForEntities(array $entityClasses): array
+    {
+        $schemaTool = new SchemaTool($this->_em);
+        $metadata   = array_map(
+            fn ($class) => $this->_em->getClassMetadata($class),
+            $entityClasses,
+        );
+
+        return $schemaTool->getCreateSchemaSql($metadata);
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'custom_fk_article')]
+class CustomFKArticle
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public string $title;
+
+    // Simple ManyToOne with custom FK name
+    #[ORM\ManyToOne(targetEntity: CustomFKAuthor::class)]
+    #[ORM\JoinColumn(
+        name: 'author_id',
+        referencedColumnName: 'id',
+        foreignKeyName: 'fk_custom_article_author',
+    )]
+    public CustomFKAuthor|null $author = null;
+
+    // Composite FK with custom name (only first JoinColumn specifies foreignKeyName)
+    #[ORM\ManyToOne(targetEntity: CustomFKAuthor::class)]
+    #[ORM\JoinColumn(
+        name: 'composite_author_id',
+        referencedColumnName: 'id',
+        foreignKeyName: 'fk_article_composite_author',
+    )]
+    #[ORM\JoinColumn(
+        name: 'composite_author_country',
+        referencedColumnName: 'country',
+    )]
+    public CustomFKAuthor|null $compositeAuthor = null;
+
+    // ManyToMany with custom FK names
+    /** @var Collection<int, CustomFKTag> */
+    #[ORM\ManyToMany(targetEntity: CustomFKTag::class)]
+    #[ORM\JoinTable(
+        name: 'article_tag',
+        joinColumns: new ORM\JoinColumn(name: 'article_id', referencedColumnName: 'id'),
+        inverseJoinColumns: new ORM\JoinColumn(name: 'tag_id', referencedColumnName: 'id'),
+        foreignKeyName: 'fk_article_tag_article',
+        inverseForeignKeyName: 'fk_article_tag_tag',
+    )]
+    public Collection $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'custom_fk_author')]
+#[ORM\UniqueConstraint(
+    name: 'unique_author_country',
+    columns: ['id', 'country'],
+)]
+class CustomFKAuthor
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column(type: 'string', length: 2)]
+    public string $country;
+
+    #[ORM\Column(type: 'string', length: 100)]
+    public string $name;
+}
+
+#[ORM\Entity]
+#[ORM\Table(name: 'custom_fk_tag')]
+class CustomFKTag
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public string $name;
+}
+
+// Test entity with mismatched FK names (should throw exception)
+#[ORM\Entity]
+class InvalidCompositeFKArticle
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    // This should fail validation: different foreignKeyName on each JoinColumn
+    #[ORM\ManyToOne(targetEntity: CustomFKAuthor::class)]
+    #[ORM\JoinColumn(
+        name: 'author_id',
+        referencedColumnName: 'id',
+        foreignKeyName: 'fk_one',
+    )]
+    #[ORM\JoinColumn(
+        name: 'author_country',
+        referencedColumnName: 'country',
+        foreignKeyName: 'fk_two',
+    )]
+    public CustomFKAuthor|null $author = null;
+}
+
+// Test entity with partial FK names (should throw exception)
+#[ORM\Entity]
+class PartialCompositeFKArticle
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    // This should fail validation: only one JoinColumn has foreignKeyName
+    #[ORM\ManyToOne(targetEntity: CustomFKAuthor::class)]
+    #[ORM\JoinColumn(
+        name: 'author_id',
+        referencedColumnName: 'id',
+        foreignKeyName: 'fk_partial',
+    )]
+    #[ORM\JoinColumn(
+        name: 'author_country',
+        referencedColumnName: 'country',
+    )]
+    public CustomFKAuthor|null $author = null;
+}
+
+#[ORM\Entity]
+class SecondPositionCompositeFKArticle
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    // This should fail validation: only second JoinColumn has foreignKeyName
+    #[ORM\ManyToOne(targetEntity: CustomFKAuthor::class)]
+    #[ORM\JoinColumn(
+        name: 'author_id',
+        referencedColumnName: 'id',
+    )]
+    #[ORM\JoinColumn(
+        name: 'author_country',
+        referencedColumnName: 'country',
+        foreignKeyName: 'fk_second_position',
+    )]
+    public CustomFKAuthor|null $author = null;
+}

--- a/tests/Tests/ORM/Mapping/JoinColumnMappingTest.php
+++ b/tests/Tests/ORM/Mapping/JoinColumnMappingTest.php
@@ -26,6 +26,7 @@ final class JoinColumnMappingTest extends TestCase
         $mapping->nullable             = true;
         $mapping->referencedColumnName = 'baz';
         $mapping->options              = ['foo' => 'bar'];
+        $mapping->foreignKeyName       = 'fk_foo_bar';
 
         $resurrectedMapping = unserialize(serialize($mapping));
         assert($resurrectedMapping instanceof JoinColumnMapping);
@@ -40,5 +41,19 @@ final class JoinColumnMappingTest extends TestCase
         self::assertTrue($resurrectedMapping->nullable);
         self::assertSame('baz', $resurrectedMapping->referencedColumnName);
         self::assertSame(['foo' => 'bar'], $resurrectedMapping->options);
+        self::assertSame('fk_foo_bar', $resurrectedMapping->foreignKeyName);
+    }
+
+    public function testFromMappingArrayIncludesForeignKeyName(): void
+    {
+        $mapping = JoinColumnMapping::fromMappingArray([
+            'name' => 'user_id',
+            'referencedColumnName' => 'id',
+            'foreignKeyName' => 'fk_article_user',
+        ]);
+
+        self::assertSame('user_id', $mapping->name);
+        self::assertSame('id', $mapping->referencedColumnName);
+        self::assertSame('fk_article_user', $mapping->foreignKeyName);
     }
 }

--- a/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Cache\Exception\CacheException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -352,6 +353,43 @@ class XmlMappingDriverTest extends MappingDriverTestCase
 
         self::assertCount(1, $class->fieldMappings);
     }
+
+    public function testXmlCustomForeignKeyNames(): void
+    {
+        $class = $this->createClassMetadata(XmlCustomFKArticle::class);
+
+        // Test ManyToOne with custom FK name
+        $authorMapping = $class->getAssociationMapping('author');
+        self::assertCount(1, $authorMapping->joinColumns);
+        self::assertSame('fk_xml_article_author', $authorMapping->joinColumns[0]->foreignKeyName);
+
+        // Test ManyToMany with custom FK names
+        $tagsMapping = $class->getAssociationMapping('tags');
+        self::assertNotNull($tagsMapping->joinTable);
+        self::assertSame('fk_xml_article_tag_article', $tagsMapping->joinTable->foreignKeyName);
+        self::assertSame('fk_xml_article_tag_tag', $tagsMapping->joinTable->inverseForeignKeyName);
+    }
+}
+
+class XmlCustomFKArticle
+{
+    public int|null $id = null;
+    public string $title;
+    public XmlCustomFKAuthor|null $author = null;
+    /** @var Collection<int, XmlCustomFKTag> */
+    public Collection $tags;
+}
+
+class XmlCustomFKAuthor
+{
+    public int|null $id = null;
+    public string $name;
+}
+
+class XmlCustomFKTag
+{
+    public int|null $id = null;
+    public string $name;
 }
 
 class CTI

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKArticle.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKArticle.dcm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\XmlCustomFKArticle" table="xml_custom_fk_article">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="title" type="string" length="255"/>
+
+        <many-to-one field="author" target-entity="Doctrine\Tests\ORM\Mapping\XmlCustomFKAuthor">
+            <join-column name="author_id" referenced-column-name="id" foreign-key-name="fk_xml_article_author"/>
+        </many-to-one>
+
+        <many-to-many field="tags" target-entity="Doctrine\Tests\ORM\Mapping\XmlCustomFKTag">
+            <join-table name="xml_article_tag" foreign-key-name="fk_xml_article_tag_article" inverse-foreign-key-name="fk_xml_article_tag_tag">
+                <join-columns>
+                    <join-column name="article_id" referenced-column-name="id"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="tag_id" referenced-column-name="id"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKAuthor.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKAuthor.dcm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\XmlCustomFKAuthor" table="xml_custom_fk_author">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="name" type="string" length="255"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKTag.dcm.xml
+++ b/tests/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.XmlCustomFKTag.dcm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\XmlCustomFKTag" table="xml_custom_fk_tag">
+        <id name="id" type="integer" column="id">
+            <generator strategy="AUTO"/>
+        </id>
+
+        <field name="name" type="string" length="255"/>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
This could be helpful in dealing with DBAL 5, where on MySQL, auto-generated foreign key names might end up being too long.

Largely done by Claude Sonnet.