### PR TITLE
Remove Type::getName() in docs

### DIFF
--- a/docs/en/cookbook/custom-mapping-types.rst
+++ b/docs/en/cookbook/custom-mapping-types.rst
@@ -22,8 +22,6 @@ you wish. Here is an example skeleton of such a custom type class:
      */
     class MyType extends Type
     {
-        const MYTYPE = 'mytype'; // modify to match your type name
-
         public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             // return the SQL used to create your column type. To create a portable column type, use the $platform.
@@ -37,11 +35,6 @@ you wish. Here is an example skeleton of such a custom type class:
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
             // This is executed when the value is written to the database. Make your conversions here, optionally using the $platform.
-        }
-
-        public function getName()
-        {
-            return self::MYTYPE; // modify to match your constant name
         }
     }
 


### PR DESCRIPTION
ORM 4 requires DBAL 4, which removed `Type::getName()`.

Not sure about removing the constant though, is it still good practice to leave it as the "canonical format" to pass to `Type::addType()`?