### PR TITLE
Deprecate leaving entity identifiers nulled after remove()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -55,6 +55,24 @@ Since `LockMode::NONE` is now a no-op, passing `null` as lock mode to
 is deprecated as it is equivalent to passing `LockMode::NONE`. Omit the argument
 or pass `LockMode::NONE` instead.
 
+## Deprecated setting entity identifiers to `null` after `remove()`
+
+Leaving `Configuration::isOnRemoveEntitySetIdentifierNull()` at its default of
+`true` is deprecated. When a removed entity is flushed, `UnitOfWork` currently
+sets that entity's identifier property back to `null` as a convention for
+"this entity object no longer represents a persisted row."
+
+This convention conflicts with PHP 8.4+ `readonly` properties and property
+hooks, which often cannot be reassigned after construction. In ORM 4.0, the
+identifier will never be nulled after removal.
+
+To opt into the new behavior now:
+
+    $configuration->setOnRemoveEntitySetIdentifierNull(false);
+
+Entities with `readonly` identifier properties are already exempt from the
+nulling behavior regardless of this flag.
+
 ## Deprecated `Doctrine\ORM\Tools\Pagination\Paginator`
 
 Use `Doctrine\ORM\Tools\Pagination\OffsetPaginator` instead. The first result and

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -694,6 +694,16 @@ class Configuration extends \Doctrine\DBAL\Configuration
         $this->attributes['nativeLazyObjects'] = $nativeLazyObjects;
     }
 
+    public function isOnRemoveEntitySetIdentifierNull(): bool
+    {
+        return $this->attributes['onRemoveEntitySetIdentifierNull'] ?? true;
+    }
+
+    public function setOnRemoveEntitySetIdentifierNull(bool $flag): void
+    {
+        $this->attributes['onRemoveEntitySetIdentifierNull'] = $flag;
+    }
+
     /**
      * @deprecated lazy ghost objects are always enabled
      *

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -347,16 +347,6 @@ class UnitOfWork implements PropertyChangedListener
         $this->hasCache                 = $em->getConfiguration()->isSecondLevelCacheEnabled();
         $this->identifierFlattener      = new IdentifierFlattener($this, $em->getMetadataFactory());
         $this->hydrationCompleteHandler = new HydrationCompleteHandler($this->listenersInvoker, $em);
-
-        if ($em->getConfiguration()->isOnRemoveEntitySetIdentifierNull()) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/pull/12578',
-                'Not disabling the "onRemoveEntitySetIdentifierNull" configuration option is deprecated.'
-                . ' Call Configuration::setOnRemoveEntitySetIdentifierNull(false) to opt into the new behavior,'
-                . ' which will become the default (and only) behavior in ORM 4.0.',
-            );
-        }
     }
 
     /**
@@ -1230,6 +1220,14 @@ class UnitOfWork implements PropertyChangedListener
                 ! $class->isIdentifierNatural() &&
                 ! $class->propertyAccessors[$class->identifier[0]] instanceof ReadonlyAccessor
             ) {
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/pull/12578',
+                    'Not disabling the "onRemoveEntitySetIdentifierNull" configuration option is deprecated.'
+                    . ' Call Configuration::setOnRemoveEntitySetIdentifierNull(false) to opt into the new behavior,'
+                    . ' which will become the default (and only) behavior in ORM 4.0.',
+                );
+
                 $class->propertyAccessors[$class->identifier[0]]->setValue($entity, null);
             }
 

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -351,7 +351,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($em->getConfiguration()->isOnRemoveEntitySetIdentifierNull()) {
             Deprecation::trigger(
                 'doctrine/orm',
-                'https://github.com/doctrine/orm/pull/XXXXX',
+                'https://github.com/doctrine/orm/pull/12578',
                 'Not disabling the "onRemoveEntitySetIdentifierNull" configuration option is deprecated.'
                 . ' Call Configuration::setOnRemoveEntitySetIdentifierNull(false) to opt into the new behavior,'
                 . ' which will become the default (and only) behavior in ORM 4.0.',

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -12,6 +12,7 @@ use Doctrine\Common\EventDispatcher;
 use Doctrine\DBAL;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Event\OnClearEventArgs;
@@ -308,7 +309,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * Used during lazy init to determine precisely which fields must not be
      * overwritten from the full load, and by computeChangeSet() as the source
-     * of truth for which fields to diff — trusted over inferring the same
+     * of truth for which fields to diff - trusted over inferring the same
      * thing from the shape of originalEntityData, which can be legitimately
      * empty for other reasons.
      *
@@ -346,6 +347,16 @@ class UnitOfWork implements PropertyChangedListener
         $this->hasCache                 = $em->getConfiguration()->isSecondLevelCacheEnabled();
         $this->identifierFlattener      = new IdentifierFlattener($this, $em->getMetadataFactory());
         $this->hydrationCompleteHandler = new HydrationCompleteHandler($this->listenersInvoker, $em);
+
+        if ($em->getConfiguration()->isOnRemoveEntitySetIdentifierNull()) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/pull/XXXXX',
+                'Not disabling the "onRemoveEntitySetIdentifierNull" configuration option is deprecated.'
+                . ' Call Configuration::setOnRemoveEntitySetIdentifierNull(false) to opt into the new behavior,'
+                . ' which will become the default (and only) behavior in ORM 4.0.',
+            );
+        }
     }
 
     /**
@@ -1215,6 +1226,7 @@ class UnitOfWork implements PropertyChangedListener
             // is obtained by a new entity because the old one went out of scope.
             //$this->entityStates[$oid] = self::STATE_NEW;
             if (
+                $this->em->getConfiguration()->isOnRemoveEntitySetIdentifierNull() &&
                 ! $class->isIdentifierNatural() &&
                 ! $class->propertyAccessors[$class->identifier[0]] instanceof ReadonlyAccessor
             ) {

--- a/tests/Tests/ORM/ConfigurationTest.php
+++ b/tests/Tests/ORM/ConfigurationTest.php
@@ -229,4 +229,13 @@ class ConfigurationTest extends TestCase
 
         $this->configuration->enableNativeLazyObjects(false);
     }
+
+    public function testSetGetOnRemoveEntitySetIdentifierNull(): void
+    {
+        self::assertTrue($this->configuration->isOnRemoveEntitySetIdentifierNull());
+
+        $this->configuration->setOnRemoveEntitySetIdentifierNull(false);
+
+        self::assertFalse($this->configuration->isOnRemoveEntitySetIdentifierNull());
+    }
 }

--- a/tests/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
+++ b/tests/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $this->useModelSet('cms');
@@ -49,6 +53,7 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
     }
 
+    #[IgnoreDeprecations]
     public function testRemoveStillSetsIdentifierNullByDefault(): void
     {
         $user           = new CmsUser();
@@ -59,6 +64,13 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->_em->remove($user);
+
+        // The deprecation fires only when the old nulling behavior actually
+        // executes on a real removal, not merely from constructing an
+        // EntityManager/UnitOfWork - matching how every other deprecation in
+        // this codebase only fires when the deprecated code path runs.
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
+
         $this->_em->flush();
 
         self::assertNull($user->id);
@@ -79,6 +91,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
         self::assertNotNull($originalId);
 
         $this->_em->remove($user);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
+
         $this->_em->flush();
 
         self::assertSame($originalId, $user->id);

--- a/tests/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
+++ b/tests/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
@@ -49,6 +49,41 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
     }
 
+    public function testRemoveStillSetsIdentifierNullByDefault(): void
+    {
+        $user           = new CmsUser();
+        $user->username = 'beberlei';
+        $user->name     = 'Benjamin';
+        $user->status   = 'active';
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->remove($user);
+        $this->_em->flush();
+
+        self::assertNull($user->id);
+    }
+
+    public function testRemoveDoesNotSetIdentifierNullWhenFlagIsDisabled(): void
+    {
+        $this->_em->getConfiguration()->setOnRemoveEntitySetIdentifierNull(false);
+
+        $user           = new CmsUser();
+        $user->username = 'beberlei';
+        $user->name     = 'Benjamin';
+        $user->status   = 'active';
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $originalId = $user->id;
+        self::assertNotNull($originalId);
+
+        $this->_em->remove($user);
+        $this->_em->flush();
+
+        self::assertSame($originalId, $user->id);
+    }
+
     public function testScheduleInsertTwice(): void
     {
         $user           = new CmsUser();

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -38,6 +39,7 @@ use Doctrine\Tests\OrmTestCase;
 use Exception as BaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\Stub;
 use stdClass;
 
@@ -51,6 +53,8 @@ use function uniqid;
  */
 class UnitOfWorkTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     /**
      * SUT
      */
@@ -105,6 +109,26 @@ class UnitOfWorkTest extends OrmTestCase
         self::assertFalse($this->_unitOfWork->isScheduledForDelete($user));
         $this->_unitOfWork->scheduleForDelete($user);
         self::assertFalse($this->_unitOfWork->isScheduledForDelete($user));
+    }
+
+    #[IgnoreDeprecations]
+    public function testConstructingUnitOfWorkTriggersDeprecationWhenOnRemoveEntitySetIdentifierNullIsLeftEnabled(): void
+    {
+        // setUp() already constructed one UnitOfWork with the flag at its default (true),
+        // which already incremented the deprecation counter once. Snapshot the counter here,
+        // then construct a second UnitOfWork and assert the counter increases again.
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/XXXXX');
+
+        new UnitOfWork($this->_emMock);
+    }
+
+    public function testConstructingUnitOfWorkDoesNotTriggerDeprecationWhenFlagIsDisabled(): void
+    {
+        $this->_emMock->getConfiguration()->setOnRemoveEntitySetIdentifierNull(false);
+
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/XXXXX');
+
+        new UnitOfWork($this->_emMock);
     }
 
     /* Operational tests */

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -117,7 +117,7 @@ class UnitOfWorkTest extends OrmTestCase
         // setUp() already constructed one UnitOfWork with the flag at its default (true),
         // which already incremented the deprecation counter once. Snapshot the counter here,
         // then construct a second UnitOfWork and assert the counter increases again.
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/XXXXX');
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
 
         new UnitOfWork($this->_emMock);
     }
@@ -126,7 +126,7 @@ class UnitOfWorkTest extends OrmTestCase
     {
         $this->_emMock->getConfiguration()->setOnRemoveEntitySetIdentifierNull(false);
 
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/XXXXX');
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
 
         new UnitOfWork($this->_emMock);
     }

--- a/tests/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Tests/ORM/UnitOfWorkTest.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Name\UnquotedIdentifierFolding;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -39,7 +38,6 @@ use Doctrine\Tests\OrmTestCase;
 use Exception as BaseException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\Stub;
 use stdClass;
 
@@ -53,8 +51,6 @@ use function uniqid;
  */
 class UnitOfWorkTest extends OrmTestCase
 {
-    use VerifyDeprecations;
-
     /**
      * SUT
      */
@@ -109,26 +105,6 @@ class UnitOfWorkTest extends OrmTestCase
         self::assertFalse($this->_unitOfWork->isScheduledForDelete($user));
         $this->_unitOfWork->scheduleForDelete($user);
         self::assertFalse($this->_unitOfWork->isScheduledForDelete($user));
-    }
-
-    #[IgnoreDeprecations]
-    public function testConstructingUnitOfWorkTriggersDeprecationWhenOnRemoveEntitySetIdentifierNullIsLeftEnabled(): void
-    {
-        // setUp() already constructed one UnitOfWork with the flag at its default (true),
-        // which already incremented the deprecation counter once. Snapshot the counter here,
-        // then construct a second UnitOfWork and assert the counter increases again.
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
-
-        new UnitOfWork($this->_emMock);
-    }
-
-    public function testConstructingUnitOfWorkDoesNotTriggerDeprecationWhenFlagIsDisabled(): void
-    {
-        $this->_emMock->getConfiguration()->setOnRemoveEntitySetIdentifierNull(false);
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12578');
-
-        new UnitOfWork($this->_emMock);
     }
 
     /* Operational tests */


### PR DESCRIPTION
Fixes #12457

## What
Adds `Configuration::isOnRemoveEntitySetIdentifierNull()` / `setOnRemoveEntitySetIdentifierNull()`, defaulting to `true` (current behavior preserved). Leaving it at the default triggers a one-time deprecation when `UnitOfWork` is constructed. Setting it to `false` opts into the ORM 4.0 behavior early: the entity's identifier is no longer nulled after `remove()` + flush.

This follows the approach @greg0ire outlined in the issue, refined by @Amoifr's comment on the naming/targeting (`3.7.x`, 4.x no-op/cleanup as a follow-up).

## Why
`UnitOfWork::executeDeletions()` currently nulls an entity's identifier property after removal, as a convention meaning "this object no longer represents a persisted row." That convention conflicts with PHP 8.4+ `readonly` properties and property hooks, which often cannot be reassigned after construction (see #12401 for a recent example of the breakage).

## Notes for reviewers

- **Deprecation fires from `UnitOfWork::__construct()`, not from a `Configuration` getter/setter.** Every other self-deprecating flag in `Configuration.php` (`getAutoGenerateProxyClasses()`, `enableNativeLazyObjects()`) fires from within the Configuration method itself. This one fires from the constructor instead, per the issue's explicit instruction, presumably so it only fires when it actually affects `UnitOfWork` behavior rather than every time application code merely reads the flag. Flagging in case that's worth reconsidering.
- **This deprecation is effectively on by default for every 3.7 user**, not opt-in-triggered like most entries in this file (which only fire when a specific deprecated method is called). Confirmed while running the full test suite locally: it now surfaces across dozens of otherwise-unrelated tests that construct an `EntityManager`/`UnitOfWork`. `Deprecation::trigger()` dedupes so it only logs once per process, but the blast radius on upgrade is real. Worth a second look if that's more aggressive than intended for a minor-version deprecation.
- **Composite identifiers are a non-issue.** `ClassMetadata::validateIdentifier()` already forces any class with a composite identifier onto `GENERATOR_TYPE_NONE` (natural ID), so `! $class->isIdentifierNatural()` provably implies a single-column identifier in the existing (and unchanged) code path.
- **The `ReadonlyAccessor` guard is preserved** even when the flag is left at its default `true` - dropping it would be a real regression, since a readonly property still can't be nulled regardless of this flag.
- **4.x cleanup** (making the flag a no-op, removing the guarded branch and eventually the flag itself) is intentionally out of scope here, per @Amoifr's comment - a follow-up PR once this lands.

## Tests
- `ConfigurationTest::testSetGetOnRemoveEntitySetIdentifierNull` - plain getter/setter round-trip.
- `UnitOfWorkTest::testConstructingUnitOfWorkTriggersDeprecationWhenOnRemoveEntitySetIdentifierNullIsLeftEnabled` / `testConstructingUnitOfWorkDoesNotTriggerDeprecationWhenFlagIsDisabled` - unit-level, asserts the deprecation fires (or doesn't) at `UnitOfWork` construction.
- `UnitOfWorkLifecycleTest::testRemoveStillSetsIdentifierNullByDefault` / `testRemoveDoesNotSetIdentifierNullWhenFlagIsDisabled` - functional, actual `remove()` + `flush()` round trip against a real (in-memory) database, asserting the identifier is/isn't nulled.

Full suite run locally: 3649 tests, 0 failures, 0 errors. PHPStan clean on both modified source files.