### PR TITLE
Fix: resolve unique-constraint violation when replacing orphanRemoval entities in a single flush (#6776)

### DIFF
--- a/src/Internal/UnitOfWork/ConstraintEdge.php
+++ b/src/Internal/UnitOfWork/ConstraintEdge.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\UnitOfWork;
+
+/**
+ * A DELETE-before-INSERT ordering constraint between a pending deletion and a
+ * pending insertion that collide on a metadata-declared unique tuple.
+ *
+ * @internal
+ */
+final class ConstraintEdge
+{
+    public function __construct(
+        public readonly object $deletion,
+        public readonly object $insertion,
+    ) {
+    }
+}

--- a/src/Internal/UnitOfWork/ConstraintEdgePlan.php
+++ b/src/Internal/UnitOfWork/ConstraintEdgePlan.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\UnitOfWork;
+
+use function array_values;
+use function spl_object_id;
+
+/**
+ * Result of constraint-edge planning.
+ *
+ * @internal
+ */
+final class ConstraintEdgePlan
+{
+    /**
+     * @param list<ConstraintEdge> $edges            resolvable DELETE-before-INSERT edges
+     * @param list<object>         $blockedDeletions deletion candidates with a collision
+     *                                               but a pending FK reference (fallback to
+     *                                               the baseline commit order)
+     */
+    public function __construct(
+        public readonly array $edges,
+        public readonly array $blockedDeletions,
+    ) {
+    }
+
+    /**
+     * Distinct deletion sides of the resolvable edges, to be executed before
+     * the insertions of this flush.
+     *
+     * @return list<object>
+     */
+    public function earlyDeletions(): array
+    {
+        $deletions = [];
+
+        foreach ($this->edges as $edge) {
+            $deletions[spl_object_id($edge->deletion)] = $edge->deletion;
+        }
+
+        return array_values($deletions);
+    }
+}

--- a/src/Internal/UnitOfWork/ConstraintEdgePlanner.php
+++ b/src/Internal/UnitOfWork/ConstraintEdgePlanner.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\UnitOfWork;
+
+use Closure;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneOwningSideMapping;
+
+use function implode;
+use function is_object;
+use function serialize;
+use function spl_object_id;
+
+/**
+ * Plans DELETE-before-INSERT ordering constraints ("value edges") for pending
+ * deletions that collide with pending insertions on metadata-declared unique
+ * tuples: when both sides of a replacement are flushed in one transaction,
+ * the DELETE of the old row must run before the INSERT of the new row (#6776).
+ *
+ * A collision pair is resolvable only when no pending operation of this flush
+ * holds an owning (FK-carrying) to-one reference to the deletion candidate
+ * (current or original/database value), and when the candidate's class is not
+ * the element class of a pending many-to-many collection operation of this
+ * flush: join-row deletions run after the early-deletion seam, so an early
+ * DELETE would leave a live join-row foreign key behind. The filter is
+ * conservative by design — a false positive falls back to the baseline commit
+ * order, a false negative would produce an FK violation.
+ *
+ * This is a pure module: entities and mapping metadata in, ordering edges and
+ * FK verdicts out. No entity manager, database or global state is involved.
+ * The provenance attribute of the deletion candidates is carried, never read.
+ *
+ * Comparison domain is the PHP domain: unique tuples are compared as PHP field
+ * values (or by referenced-entity identity for association components);
+ * database-level conversion is not performed.
+ *
+ * @internal
+ */
+final class ConstraintEdgePlanner
+{
+    /**
+     * Unique-tuple declarations per class name: declaration id to components,
+     * each a pair of property name and whether the component is a to-one
+     * association (referenced-entity identity) rather than a field (PHP value).
+     *
+     * @var array<string, array<string, list<array{string, bool}>>>
+     */
+    private array $uniqueDeclarations = [];
+
+    /** @var array<string, list<string>> */
+    private array $toOneOwningFields = [];
+
+    /**
+     * @param list<DeletionCandidate>                              $candidates
+     * @param array<int, object>                                   $insertions
+     * @param array<int, object>                                   $updates
+     * @param array<int, object>                                   $deletions
+     * @param array<int, array<string, mixed>>                     $originalEntityData
+     * @param array<int, array<string, array{0: mixed, 1: mixed}>> $entityChangeSets
+     * @param array<string, true>                                  $manyToManyTargetClasses hash-set
+     *                                                            of class names referenced as
+     *                                                            elements by pending many-to-many
+     *                                                            collection operations of this flush
+     * @param Closure(string): ClassMetadata<object>               $classMetadata
+     */
+    public static function planEarlyDeletions(
+        array $candidates,
+        array $insertions,
+        array $updates,
+        array $deletions,
+        array $originalEntityData,
+        array $entityChangeSets,
+        array $manyToManyTargetClasses,
+        Closure $classMetadata,
+    ): ConstraintEdgePlan {
+        $planner = new self();
+
+        if ($candidates === [] || $insertions === []) {
+            return new ConstraintEdgePlan([], []);
+        }
+
+        $insertIndex = [];
+        foreach ($insertions as $insertion) {
+            $class = $classMetadata($insertion::class);
+
+            foreach ($planner->uniqueDeclarations($class) as $declarationId => $declaration) {
+                $key = $planner->tupleKey($class, $insertion, $declaration);
+                if ($key === null) {
+                    continue;
+                }
+
+                $insertIndex[$class->name][$declarationId][$key] ??= $insertion;
+            }
+        }
+
+        $fkTargets = [];
+        foreach ($insertions as $oid => $entity) {
+            $planner->collectFkTargets($classMetadata($entity::class), $entity, $oid, $originalEntityData, $entityChangeSets, $fkTargets);
+        }
+
+        foreach ($updates as $oid => $entity) {
+            $planner->collectFkTargets($classMetadata($entity::class), $entity, $oid, $originalEntityData, $entityChangeSets, $fkTargets);
+        }
+
+        foreach ($deletions as $oid => $entity) {
+            $planner->collectFkTargets($classMetadata($entity::class), $entity, $oid, $originalEntityData, $entityChangeSets, $fkTargets);
+        }
+
+        $edges   = [];
+        $blocked = [];
+
+        foreach ($candidates as $candidate) {
+            $entity = $candidate->entity;
+            $class  = $classMetadata($entity::class);
+
+            $collidingInsertions = null;
+            foreach ($planner->uniqueDeclarations($class) as $declarationId => $declaration) {
+                $key = $planner->tupleKey($class, $entity, $declaration);
+                if ($key === null) {
+                    continue;
+                }
+
+                $collidingInsertion = $insertIndex[$class->name][$declarationId][$key] ?? null;
+                if ($collidingInsertion !== null) {
+                    $collidingInsertions[] = $collidingInsertion;
+                }
+            }
+
+            if ($collidingInsertions === null) {
+                continue;
+            }
+
+            if (isset($fkTargets[spl_object_id($entity)]) || isset($manyToManyTargetClasses[$class->name])) {
+                $blocked[] = $entity;
+
+                continue;
+            }
+
+            foreach ($collidingInsertions as $insertion) {
+                $edges[] = new ConstraintEdge($entity, $insertion);
+            }
+        }
+
+        return new ConstraintEdgePlan($edges, $blocked);
+    }
+
+    /**
+     * Metadata-declared unique tuples of the class: field-level and join-column
+     * level unique flags, plus table-level unique constraints.
+     *
+     * @param ClassMetadata<object> $class
+     *
+     * @return array<string, list<array{string, bool}>>
+     */
+    private function uniqueDeclarations(ClassMetadata $class): array
+    {
+        if (isset($this->uniqueDeclarations[$class->name])) {
+            return $this->uniqueDeclarations[$class->name];
+        }
+
+        $declarations = [];
+
+        foreach ($class->fieldMappings as $fieldMapping) {
+            if ($fieldMapping->unique) {
+                $declarations['field:' . $fieldMapping->fieldName] = [[$fieldMapping->fieldName, false]];
+            }
+        }
+
+        foreach ($class->associationMappings as $assoc) {
+            if (! $assoc instanceof ToOneOwningSideMapping) {
+                continue;
+            }
+
+            foreach ($assoc->joinColumns as $joinColumn) {
+                if ($joinColumn->unique) {
+                    $declarations['join:' . $assoc->fieldName] = [[$assoc->fieldName, true]];
+
+                    break;
+                }
+            }
+        }
+
+        foreach ($class->table['uniqueConstraints'] ?? [] as $constraintName => $constraint) {
+            $components = [];
+
+            foreach ($constraint['columns'] ?? [] as $column) {
+                if (isset($class->fieldNames[$column])) {
+                    $components[] = [$class->fieldNames[$column], false];
+
+                    continue;
+                }
+
+                $associationField = $this->associationFieldForColumn($class, $column);
+                if ($associationField === null) {
+                    // Column is not backed by a field or FK association
+                    // (e.g. a discriminator column): tuple is not computable.
+                    continue 2;
+                }
+
+                $components[] = [$associationField, true];
+            }
+
+            if ($components !== []) {
+                $declarations['constraint:' . $constraintName] = $components;
+            }
+        }
+
+        return $this->uniqueDeclarations[$class->name] = $declarations;
+    }
+
+    /**
+     * String key of the unique tuple for the entity, or null when a component
+     * is NULL: NULL never conflicts in a unique constraint.
+     *
+     * @param ClassMetadata<object>     $class
+     * @param list<array{string, bool}> $declaration
+     */
+    private function tupleKey(ClassMetadata $class, object $entity, array $declaration): string|null
+    {
+        $parts = [];
+
+        foreach ($declaration as [$fieldName, $isAssociation]) {
+            $value = $class->getFieldValue($entity, $fieldName);
+
+            if ($isAssociation) {
+                if (! is_object($value)) {
+                    return null;
+                }
+
+                $parts[] = 'o' . spl_object_id($value);
+
+                continue;
+            }
+
+            if ($value === null) {
+                return null;
+            }
+
+            $parts[] = serialize($value);
+        }
+
+        return implode("\x1f", $parts);
+    }
+
+    /**
+     * Collects the entities referenced by owning (FK-carrying) to-one
+     * associations of the pending operation into the hash of FK targets.
+     *
+     * For non-insertions, the original/database value of each association is
+     * considered as well: the owner's database FK row may still reference the
+     * target until its UPDATE or DELETE has run. The original value of updated
+     * entities lives in the change set pairs, since original entity data is
+     * overwritten with the actual data during change-set computation.
+     *
+     * @param ClassMetadata<object>                                $class
+     * @param array<int, array<string, mixed>>                     $originalEntityData
+     * @param array<int, array<string, array{0: mixed, 1: mixed}>> $entityChangeSets
+     * @param array<int, true>                                     $fkTargets
+     */
+    private function collectFkTargets(
+        ClassMetadata $class,
+        object $entity,
+        int $oid,
+        array $originalEntityData,
+        array $entityChangeSets,
+        array &$fkTargets,
+    ): void {
+        foreach ($this->toOneOwningFields($class) as $fieldName) {
+            $target = $class->getFieldValue($entity, $fieldName);
+            if (is_object($target)) {
+                $fkTargets[spl_object_id($target)] = true;
+            }
+
+            $originalTarget = $entityChangeSets[$oid][$fieldName][0]
+                ?? $originalEntityData[$oid][$fieldName]
+                ?? null;
+
+            if (is_object($originalTarget)) {
+                $fkTargets[spl_object_id($originalTarget)] = true;
+            }
+        }
+    }
+
+    /**
+     * @param ClassMetadata<object> $class
+     *
+     * @return list<string>
+     */
+    private function toOneOwningFields(ClassMetadata $class): array
+    {
+        if (isset($this->toOneOwningFields[$class->name])) {
+            return $this->toOneOwningFields[$class->name];
+        }
+
+        $fields = [];
+
+        foreach ($class->associationMappings as $assoc) {
+            if (! $assoc->isToOneOwningSide()) {
+                continue;
+            }
+
+            $fields[] = $assoc->fieldName;
+        }
+
+        return $this->toOneOwningFields[$class->name] = $fields;
+    }
+
+    /**
+     * Field name of the to-one owning association carrying the given FK
+     * column, or null when the column belongs to no such association.
+     *
+     * @param ClassMetadata<object> $class
+     */
+    private function associationFieldForColumn(ClassMetadata $class, string $column): string|null
+    {
+        foreach ($class->associationMappings as $assoc) {
+            if (! $assoc instanceof ToOneOwningSideMapping) {
+                continue;
+            }
+
+            foreach ($assoc->joinColumns as $joinColumn) {
+                if ($joinColumn->name === $column) {
+                    return $assoc->fieldName;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Internal/UnitOfWork/DeletionCandidate.php
+++ b/src/Internal/UnitOfWork/DeletionCandidate.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\UnitOfWork;
+
+/**
+ * A pending deletion considered for constraint-edge planning, carrying the
+ * provenance of its scheduling.
+ *
+ * The provenance is data carried for the orchestrating {@see \Doctrine\ORM\UnitOfWork}:
+ * the planner is provenance-agnostic and never reads it. Step 1 of the
+ * constraint-edge ladder (#5109) widens the source of candidates without
+ * changing the planner.
+ *
+ * @internal
+ */
+final class DeletionCandidate
+{
+    public const PROVENANCE_ORPHAN   = 'orphan';
+    public const PROVENANCE_EXPLICIT = 'explicit';
+
+    public function __construct(
+        public readonly object $entity,
+        public readonly string $provenance,
+    ) {
+    }
+}

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -31,9 +31,12 @@ use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Internal\StronglyConnectedComponents;
 use Doctrine\ORM\Internal\TopologicalSort;
+use Doctrine\ORM\Internal\UnitOfWork\ConstraintEdgePlanner;
+use Doctrine\ORM\Internal\UnitOfWork\DeletionCandidate;
 use Doctrine\ORM\Internal\UnitOfWork\InsertBatch;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\PropertyAccessors\ReadonlyAccessor;
 use Doctrine\ORM\Mapping\ToManyInverseSideMapping;
@@ -288,6 +291,15 @@ class UnitOfWork implements PropertyChangedListener
     private array $orphanRemovals = [];
 
     /**
+     * Entity deletions whose provenance is orphan removal: keys of entities
+     * materialized into {@link $entityDeletions} by the orphan removal loop of
+     * {@link commit()}.
+     *
+     * @var array<int, true>
+     */
+    private array $orphanDeletions = [];
+
+    /**
      * Read-Only objects are never evaluated
      *
      * @var array<int, true>
@@ -377,7 +389,16 @@ class UnitOfWork implements PropertyChangedListener
 
         if ($this->orphanRemovals) {
             foreach ($this->orphanRemovals as $orphan) {
+                $oid          = spl_object_id($orphan);
+                $wasScheduled = isset($this->entityDeletions[$oid]);
+
                 $this->remove($orphan);
+
+                // Deletions materialized here originate from orphan removal: only
+                // they are candidates for early execution before insertions (#6776).
+                if (! $wasScheduled && isset($this->entityDeletions[$oid])) {
+                    $this->orphanDeletions[$oid] = true;
+                }
             }
         }
 
@@ -397,6 +418,15 @@ class UnitOfWork implements PropertyChangedListener
                 if ($this->em->getClassMetadata($owner::class)->isChangeTrackingDeferredImplicit() || $this->isScheduledForDirtyCheck($owner)) {
                     $this->getCollectionPersister($collectionToDelete->getMapping())->delete($collectionToDelete);
                 }
+            }
+
+            // Orphan deletions that collide with pending insertions on a unique
+            // constraint must run before those insertions (#6776): execute the
+            // foreign-key-safe collision subset early, all remaining deletions at
+            // their usual place after the insertions.
+            $earlyOrphanDeletions = $this->computeEarlyOrphanDeletions();
+            if ($earlyOrphanDeletions) {
+                $this->executeDeletions($earlyOrphanDeletions);
             }
 
             if ($this->entityInsertions) {
@@ -490,6 +520,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->pendingCollectionElementRemovals =
         $this->visitedCollections               =
         $this->orphanRemovals                   =
+        $this->orphanDeletions                  =
         $this->entityChangeSets                 =
         $this->scheduledForSynchronization      = [];
     }
@@ -1158,11 +1189,73 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * Executes all entity deletions
+     * Computes the subset of orphan deletions that collide with pending
+     * insertions on a metadata-declared unique constraint and are safe to
+     * execute before those insertions (#6776).
+     *
+     * A colliding orphan is eligible only when no pending operation of this
+     * flush holds an owning to-one reference to it (foreign key soundness);
+     * otherwise it stays on the baseline commit order.
+     *
+     * @return array<int, object>
      */
-    private function executeDeletions(): void
+    private function computeEarlyOrphanDeletions(): array
     {
-        $entities         = $this->computeDeleteExecutionOrder();
+        if (! $this->orphanDeletions || ! $this->entityInsertions) {
+            return [];
+        }
+
+        $candidates = [];
+        foreach ($this->orphanDeletions as $oid => $ignored) {
+            if (isset($this->entityDeletions[$oid])) {
+                $candidates[] = new DeletionCandidate($this->entityDeletions[$oid], DeletionCandidate::PROVENANCE_ORPHAN);
+            }
+        }
+
+        if (! $candidates) {
+            return [];
+        }
+
+        // Pending many-to-many collection operations delete their join rows only
+        // after the early-deletion seam: candidates of the element class stay on
+        // the baseline commit order (S1 (iv)).
+        $manyToManyTargetClasses = [];
+        foreach ($this->collectionUpdates as $collection) {
+            $mapping = $collection->getMapping();
+            if ($mapping instanceof ManyToManyOwningSideMapping) {
+                $manyToManyTargetClasses[$mapping->targetEntity] = true;
+            }
+        }
+
+        foreach ($this->collectionDeletions as $collection) {
+            $mapping = $collection->getMapping();
+            if ($mapping instanceof ManyToManyOwningSideMapping) {
+                $manyToManyTargetClasses[$mapping->targetEntity] = true;
+            }
+        }
+
+        return ConstraintEdgePlanner::planEarlyDeletions(
+            $candidates,
+            $this->entityInsertions,
+            $this->entityUpdates,
+            $this->entityDeletions,
+            $this->originalEntityData,
+            $this->entityChangeSets,
+            $manyToManyTargetClasses,
+            fn (string $class): ClassMetadata => $this->em->getClassMetadata($class),
+        )->earlyDeletions();
+    }
+
+    /**
+     * Executes all entity deletions
+     *
+     * @param array<int, object>|null $deletions Subset of the scheduled entity
+     *                                           deletions to execute; null for
+     *                                           all of them.
+     */
+    private function executeDeletions(array|null $deletions = null): void
+    {
+        $entities         = $this->computeDeleteExecutionOrder($deletions);
         $eventsToDispatch = [];
 
         foreach ($entities as $entity) {
@@ -1267,13 +1360,21 @@ class UnitOfWork implements PropertyChangedListener
         return $sort->sort();
     }
 
-    /** @return list<object> */
-    private function computeDeleteExecutionOrder(): array
+    /**
+     * @param array<int, object>|null $deletions Subset of the scheduled entity
+     *                                           deletions to order; null for
+     *                                           all of them.
+     *
+     * @return list<object>
+     */
+    private function computeDeleteExecutionOrder(array|null $deletions = null): array
     {
         $stronglyConnectedComponents = new StronglyConnectedComponents();
         $sort                        = new TopologicalSort();
 
-        foreach ($this->entityDeletions as $entity) {
+        $deletions ??= $this->entityDeletions;
+
+        foreach ($deletions as $entity) {
             $stronglyConnectedComponents->addNode($entity);
             $sort->addNode($entity);
         }
@@ -1283,7 +1384,7 @@ class UnitOfWork implements PropertyChangedListener
         // in such a group, _all_ of the other entities will be removed as well. So,
         // we need to treat those groups like a single entity when performing delete
         // order topological sorting.
-        foreach ($this->entityDeletions as $entity) {
+        foreach ($deletions as $entity) {
             $class = $this->em->getClassMetadata($entity::class);
 
             foreach ($class->associationMappings as $assoc) {
@@ -1320,7 +1421,7 @@ class UnitOfWork implements PropertyChangedListener
         $stronglyConnectedComponents->findStronglyConnectedComponents();
 
         // Now do the actual topological sorting to find the delete order.
-        foreach ($this->entityDeletions as $entity) {
+        foreach ($deletions as $entity) {
             $class = $this->em->getClassMetadata($entity::class);
 
             // Get the entities representing the SCC
@@ -2309,7 +2410,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections               =
         $this->eagerLoadingEntities             =
         $this->eagerLoadingCollections          =
-        $this->orphanRemovals                   = [];
+        $this->orphanRemovals                   =
+        $this->orphanDeletions                  = [];
 
         if ($this->evm->hasListeners(Events::onClear)) {
             $this->evm->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));

--- a/tests/Tests/ORM/Functional/Ticket/GH6776Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH6776Test.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * Replacing an element of a collection or a to-one reference that is subject
+ * to orphan removal, where the new element collides with the removed one on a
+ * unique constraint, must be possible in a single flush() (#6776).
+ *
+ * The one-to-many scenario adapts the reproduction from #6838, the one-to-one
+ * scenario the one from #7450.
+ */
+class GH6776Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        GH6776Item::$postRemoveCount    = 0;
+        GH6776Address::$postRemoveCount = 0;
+
+        $this->createSchemaForModels(
+            GH6776Cart::class,
+            GH6776Item::class,
+            GH6776User::class,
+            GH6776Address::class,
+        );
+    }
+
+    public function testReplaceCollectionElementWithSameUniqueValueInSingleFlush(): void
+    {
+        $cart = new GH6776Cart();
+
+        $oldItem       = new GH6776Item('v');
+        $oldItem->cart = $cart;
+        $cart->items->add($oldItem);
+
+        $this->_em->persist($cart);
+        $this->_em->flush();
+
+        $oldItemId = $oldItem->id;
+
+        $newItem       = new GH6776Item('v');
+        $newItem->cart = $cart;
+        $cart->items->removeElement($oldItem);
+        $cart->items->add($newItem);
+
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $remainingItems = $this->_em->getRepository(GH6776Item::class)->findBy(['f' => 'v']);
+
+        self::assertCount(1, $remainingItems);
+        self::assertSame($newItem->id, $remainingItems[0]->id);
+        self::assertNull($this->_em->find(GH6776Item::class, $oldItemId));
+        self::assertSame(1, GH6776Item::$postRemoveCount);
+    }
+
+    public function testReplaceOneToOneReferenceWithSameUniqueValueInSingleFlush(): void
+    {
+        $user = new GH6776User();
+
+        $oldAddress       = new GH6776Address();
+        $oldAddress->user = $user;
+        $user->address    = $oldAddress;
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $oldAddressId = $oldAddress->id;
+
+        $newAddress       = new GH6776Address();
+        $newAddress->user = $user;
+        $user->address    = $newAddress;
+
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $remainingAddresses = $this->_em->getRepository(GH6776Address::class)->findAll();
+
+        self::assertCount(1, $remainingAddresses);
+        self::assertSame($newAddress->id, $remainingAddresses[0]->id);
+        self::assertSame($user->id, $remainingAddresses[0]->user->id);
+        self::assertNull($this->_em->find(GH6776Address::class, $oldAddressId));
+        self::assertSame(1, GH6776Address::$postRemoveCount);
+    }
+}
+
+#[ORM\Entity]
+class GH6776Cart
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public int|null $id = null;
+
+    /** @var Collection<int, GH6776Item> */
+    #[ORM\OneToMany(targetEntity: GH6776Item::class, mappedBy: 'cart', cascade: ['persist'], orphanRemoval: true)]
+    public Collection $items;
+
+    public function __construct()
+    {
+        $this->items = new ArrayCollection();
+    }
+}
+
+#[ORM\Entity]
+#[ORM\HasLifecycleCallbacks]
+class GH6776Item
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public int|null $id = null;
+
+    #[ORM\Column(unique: true)]
+    public string $f;
+
+    #[ORM\ManyToOne(targetEntity: GH6776Cart::class, inversedBy: 'items')]
+    public GH6776Cart|null $cart = null;
+
+    public static int $postRemoveCount = 0;
+
+    public function __construct(string $f)
+    {
+        $this->f = $f;
+    }
+
+    #[ORM\PostRemove]
+    public function countRemoval(): void
+    {
+        self::$postRemoveCount++;
+    }
+}
+
+#[ORM\Entity]
+class GH6776User
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public int|null $id = null;
+
+    #[ORM\OneToOne(targetEntity: GH6776Address::class, mappedBy: 'user', cascade: ['persist'], orphanRemoval: true)]
+    public GH6776Address|null $address = null;
+}
+
+#[ORM\Entity]
+#[ORM\HasLifecycleCallbacks]
+class GH6776Address
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public int|null $id = null;
+
+    #[ORM\OneToOne(targetEntity: GH6776User::class, inversedBy: 'address')]
+    #[ORM\JoinColumn(nullable: false)]
+    public GH6776User|null $user = null;
+
+    public static int $postRemoveCount = 0;
+
+    #[ORM\PostRemove]
+    public function countRemoval(): void
+    {
+        self::$postRemoveCount++;
+    }
+}

--- a/tests/Tests/ORM/Internal/UnitOfWork/ConstraintEdgePlannerTest.php
+++ b/tests/Tests/ORM/Internal/UnitOfWork/ConstraintEdgePlannerTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Internal\UnitOfWork;
+
+use Doctrine\ORM\Internal\UnitOfWork\ConstraintEdgePlan;
+use Doctrine\ORM\Internal\UnitOfWork\ConstraintEdgePlanner;
+use Doctrine\ORM\Internal\UnitOfWork\DeletionCandidate;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+use function spl_object_id;
+
+#[CoversClass(ConstraintEdgePlanner::class)]
+#[CoversClass(ConstraintEdgePlan::class)]
+#[Group('#6776')]
+final class ConstraintEdgePlannerTest extends TestCase
+{
+    public function testUniqueFieldCollisionProducesEdgeForEarlyDeletion(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertCount(1, $plan->edges);
+        self::assertSame($old, $plan->edges[0]->deletion);
+        self::assertSame($new, $plan->edges[0]->insertion);
+        self::assertSame([$old], $plan->earlyDeletions());
+        self::assertSame([], $plan->blockedDeletions);
+    }
+
+    public function testNullTupleComponentNeverCollides(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = null;
+        $new    = new PlannerItem();
+        $new->f = null;
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([], $plan->blockedDeletions);
+        self::assertSame([], $plan->earlyDeletions());
+    }
+
+    public function testTableUniqueConstraintCollisionRequiresFullTuple(): void
+    {
+        $old    = new PlannerItem();
+        $old->a = 'x';
+        $old->b = 'y';
+        $new    = new PlannerItem();
+        $new->a = 'x';
+        $new->b = 'y';
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertCount(1, $plan->edges);
+        self::assertSame($old, $plan->edges[0]->deletion);
+        self::assertSame($new, $plan->edges[0]->insertion);
+        self::assertSame([$old], $plan->earlyDeletions());
+    }
+
+    public function testTableUniqueConstraintWithPartiallyDifferentTupleDoesNotCollide(): void
+    {
+        $old    = new PlannerItem();
+        $old->a = 'x';
+        $old->b = 'y';
+        $new    = new PlannerItem();
+        $new->a = 'x';
+        $new->b = 'z';
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([], $plan->blockedDeletions);
+    }
+
+    public function testUniqueJoinColumnCollisionByReferencedEntityIdentity(): void
+    {
+        $ref = new PlannerRef();
+
+        $old      = new PlannerItem();
+        $old->ref = $ref;
+        $new      = new PlannerItem();
+        $new->ref = $ref;
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertCount(1, $plan->edges);
+        self::assertSame($old, $plan->edges[0]->deletion);
+        self::assertSame($new, $plan->edges[0]->insertion);
+        self::assertSame([$old], $plan->earlyDeletions());
+    }
+
+    public function testUniqueJoinColumnWithNullAssociationDoesNotCollide(): void
+    {
+        $old = new PlannerItem();
+        $new = new PlannerItem();
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertSame([], $plan->edges);
+    }
+
+    public function testCandidateWithoutInsertionsStaysOnBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $plan = $this->plan([$this->orphan($old)], []);
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([], $plan->blockedDeletions);
+        self::assertSame([], $plan->earlyDeletions());
+    }
+
+    public function testFkReferenceFromInsertFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $referencing        = new PlannerItem();
+        $referencing->f     = 'w';
+        $referencing->owner = $old;
+
+        $plan = $this->plan([$this->orphan($old)], [$new, $referencing]);
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+        self::assertSame([], $plan->earlyDeletions());
+    }
+
+    public function testFkReferenceFromUpdateOriginalValueFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $updater    = new PlannerItem();
+        $updater->f = 'w';
+
+        $plan = $this->plan(
+            [$this->orphan($old)],
+            [$new],
+            [spl_object_id($updater) => $updater],
+            [],
+            [],
+            [spl_object_id($updater) => ['owner' => [$old, null]]],
+        );
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+    }
+
+    public function testFkReferenceFromUpdateOriginalEntityDataFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $updater    = new PlannerItem();
+        $updater->f = 'w';
+
+        $plan = $this->plan(
+            [$this->orphan($old)],
+            [$new],
+            [spl_object_id($updater) => $updater],
+            [],
+            [spl_object_id($updater) => ['owner' => $old]],
+        );
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+    }
+
+    public function testFkReferenceFromPendingDeletionCurrentValueFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $deleter        = new PlannerItem();
+        $deleter->f     = 'w';
+        $deleter->owner = $old;
+
+        $plan = $this->plan(
+            [$this->orphan($old)],
+            [$new],
+            [],
+            [spl_object_id($deleter) => $deleter],
+        );
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+    }
+
+    public function testFkReferenceFromPendingDeletionOriginalValueFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $deleter    = new PlannerItem();
+        $deleter->f = 'w';
+
+        $plan = $this->plan(
+            [$this->orphan($old)],
+            [$new],
+            [],
+            [spl_object_id($deleter) => $deleter],
+            [spl_object_id($deleter) => ['owner' => $old]],
+        );
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+    }
+
+    public function testFkReferenceFromPendingManyToManyCollectionOperationFallsBackToBaselineOrder(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+
+        $new    = new PlannerItem();
+        $new->f = 'v';
+
+        $plan = $this->plan(
+            [$this->orphan($old)],
+            [$new],
+            [],
+            [],
+            [],
+            [],
+            [PlannerItem::class => true],
+        );
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([$old], $plan->blockedDeletions);
+        self::assertSame([], $plan->earlyDeletions());
+    }
+
+    public function testOutputIsIndependentOfProvenanceAttribute(): void
+    {
+        $oldOrphan         = new PlannerItem();
+        $oldOrphan->f      = 'v';
+        $oldExplicit       = new PlannerItem();
+        $oldExplicit->f    = 'v';
+        $newForOrphan      = new PlannerItem();
+        $newForOrphan->f   = 'v';
+        $newForExplicit    = new PlannerItem();
+        $newForExplicit->f = 'v';
+
+        $orphanPlan   = $this->plan([new DeletionCandidate($oldOrphan, DeletionCandidate::PROVENANCE_ORPHAN)], [$newForOrphan]);
+        $explicitPlan = $this->plan([new DeletionCandidate($oldExplicit, DeletionCandidate::PROVENANCE_EXPLICIT)], [$newForExplicit]);
+
+        self::assertCount(1, $orphanPlan->edges);
+        self::assertCount(1, $explicitPlan->edges);
+        self::assertSame($oldOrphan, $orphanPlan->earlyDeletions()[0]);
+        self::assertSame($oldExplicit, $explicitPlan->earlyDeletions()[0]);
+        self::assertSame($orphanPlan->blockedDeletions, $explicitPlan->blockedDeletions);
+    }
+
+    public function testCollisionIsOnlyMatchedWithinSameClass(): void
+    {
+        $old    = new PlannerItem();
+        $old->f = 'v';
+        $new    = new PlannerOther();
+        $new->f = 'v';
+
+        $plan = $this->plan([$this->orphan($old)], [$new]);
+
+        self::assertSame([], $plan->edges);
+        self::assertSame([], $plan->blockedDeletions);
+    }
+
+    /**
+     * @param list<DeletionCandidate>                              $candidates
+     * @param array<int, object>                                   $insertions
+     * @param array<int, object>                                   $updates
+     * @param array<int, object>                                   $deletions
+     * @param array<int, array<string, mixed>>                     $originalEntityData
+     * @param array<int, array<string, array{0: mixed, 1: mixed}>> $entityChangeSets
+     * @param array<string, true>                                  $manyToManyTargetClasses
+     * @param array<string, ClassMetadata<object>>                 $metadataOverrides
+     */
+    private function plan(
+        array $candidates,
+        array $insertions,
+        array $updates = [],
+        array $deletions = [],
+        array $originalEntityData = [],
+        array $entityChangeSets = [],
+        array $manyToManyTargetClasses = [],
+        array $metadataOverrides = [],
+    ): ConstraintEdgePlan {
+        $metadata = [
+            PlannerItem::class => $this->itemMetadata(),
+            PlannerRef::class => new ClassMetadata(PlannerRef::class),
+            PlannerOther::class => $this->otherMetadata(),
+            ...$metadataOverrides,
+        ];
+
+        $candidateDeletions = [];
+        foreach ($candidates as $candidate) {
+            $candidateDeletions[spl_object_id($candidate->entity)] = $candidate->entity;
+        }
+
+        return ConstraintEdgePlanner::planEarlyDeletions(
+            $candidates,
+            $insertions,
+            $updates,
+            $candidateDeletions + $deletions,
+            $originalEntityData,
+            $entityChangeSets,
+            $manyToManyTargetClasses,
+            static fn (string $class): ClassMetadata => $metadata[$class],
+        );
+    }
+
+    private function orphan(PlannerItem|PlannerOther $entity): DeletionCandidate
+    {
+        return new DeletionCandidate($entity, DeletionCandidate::PROVENANCE_ORPHAN);
+    }
+
+    private function itemMetadata(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(PlannerItem::class);
+
+        $this->addField($metadata, 'f', true);
+        $this->addField($metadata, 'a');
+        $this->addField($metadata, 'b');
+
+        $this->addManyToOne($metadata, 'owner', PlannerItem::class);
+        $this->addManyToOne($metadata, 'ref', PlannerRef::class, true);
+
+        $metadata->table['uniqueConstraints']['ab_uniq'] = ['columns' => ['a', 'b']];
+
+        return $metadata;
+    }
+
+    private function otherMetadata(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(PlannerOther::class);
+
+        $this->addField($metadata, 'f', true);
+
+        return $metadata;
+    }
+
+    private function addField(ClassMetadata $metadata, string $name, bool $unique = false): void
+    {
+        $class = $metadata->name;
+
+        $metadata->fieldMappings[$name]     = FieldMapping::fromMappingArray([
+            'type' => 'string',
+            'fieldName' => $name,
+            'columnName' => $name,
+            'unique' => $unique ? true : null,
+        ]);
+        $metadata->fieldNames[$name]        = $name;
+        $metadata->propertyAccessors[$name] = PropertyAccessorFactory::createPropertyAccessor($class, $name);
+    }
+
+    private function addManyToOne(ClassMetadata $metadata, string $name, string $targetClass, bool $uniqueJoinColumn = false): void
+    {
+        $metadata->associationMappings[$name] = ManyToOneAssociationMapping::fromMappingArray([
+            'fieldName' => $name,
+            'sourceEntity' => $metadata->name,
+            'targetEntity' => $targetClass,
+            'joinColumns' => [
+                [
+                    'name' => $name . '_id',
+                    'referencedColumnName' => 'id',
+                    'unique' => $uniqueJoinColumn ? true : null,
+                ],
+            ],
+        ]);
+        $metadata->propertyAccessors[$name]   = PropertyAccessorFactory::createPropertyAccessor($metadata->name, $name);
+    }
+}
+
+class PlannerItem
+{
+    public string|null $f          = null;
+    public string|null $a          = null;
+    public string|null $b          = null;
+    public PlannerItem|null $owner = null;
+    public PlannerRef|null $ref    = null;
+}
+
+class PlannerRef
+{
+    public int|null $id = null;
+}
+
+class PlannerOther
+{
+    public string|null $f = null;
+}


### PR DESCRIPTION
| Q | A |
|---|---|
| BC Break | no |
| Version | 3.6.x |

Fixes #6776

> This PR was prepared with AI assistance (analysis, fix, tests); the approach, the code and the tests were reviewed by a human, and this description was fact-checked against the repository sources before submission.

## What is broken

A `OneToMany` association with `orphanRemoval: true`, and a unique constraint on the many side. If, in a **single** flush, you remove an element from the collection and add a new one with the **same unique value**, you get a `UniqueConstraintViolationException`: Doctrine runs the INSERT of the new row before the DELETE of the old one. The same happens when replacing a `oneToOne` target with `orphanRemoval`. The only workaround is two flushes, which breaks atomicity.

The reason is the block order inside `UnitOfWork::commit()`: all INSERTs run before all DELETEs. That order is not wrong — it is what keeps foreign keys valid — but for unique values it is always the losing order, and nothing in the current code even looks at this.

## What the fix does

During `commit()` there is a moment where Doctrine already knows all the planned insertions (with their values) and all the planned deletions — and, for the deletions coming from `orphanRemoval`, it can still tell them apart from explicit `remove()` calls. The fix uses exactly that moment:

- if a to-be-deleted orphan holds the same unique value (declared in the mapping) as a row that is about to be inserted of the same class, the old row is deleted right there — **before** the inserts start — instead of at the end of the flush;
- the deletion goes through the same code path as normal deletions (same identity-map bookkeeping, same events — one `postRemove` per entity, nothing doubled);
- inserts, updates, collection handling and the insert batching are not touched at all.

**Safety.** An early delete is only done when nothing else in this flush still references the old row: no pending insert, update, deletion or m2m collection operation pointing at it. When in doubt, the fix does nothing and the current behavior applies unchanged. This is what keeps the known-tricky cases — the ones documented in `GH5742Test`, where reordering is provably impossible — exactly as they are today. And a flush without such a collision produces the same SQL in the same order as before, byte for byte.

The collision check itself is a small standalone class (`src/Internal/UnitOfWork/ConstraintEdgePlanner`) with no dependencies on the EntityManager or the database, covered by plain unit tests, and it is linear (hash lookups, no pairwise comparisons) — so flushes without collisions pay essentially nothing.

## Alternatives considered

- **Delete everything before inserting** — impossible in general: `GH5742Test` in this repo documents cases where a delete-first order violates foreign keys. Also changes the SQL order of every flush (BC).
- **An opt-in flag** (e.g. #5742) — the same problem: a global reorder breaks the GH5742 cases even when opt-in, and it adds a knob for what is simply correct behavior.
- **Not generating the unique index on orphan associations** (the #2310-era approach) — regressed before, and doesn't help with user-defined constraints.
- **A full EF Core-style command planner** — the "right" long-term answer, but it means restructuring how the whole flush executes; a major-version topic, not a bugfix.

## Tests

- New `tests/Tests/ORM/Functional/Ticket/GH6776Test.php` with both scenarios from the issue thread: the collection case (from #6838 — thanks @julienb-allopneus) and the oneToOne case (from #7450 — thanks @toby-griffiths). Both fail on the current code with `UniqueConstraintViolationException` and pass with this fix.
- Unit tests for the collision detection: single- and multi-column unique constraints, NULL values (no collision — SQL semantics), collisions without inserts, "something still references the old row" cases (insert/update/deletion/m2m) falling back to normal order.
- Full sqlite suite green (with and without the second level cache: 3508 / 3430 tests), `GH5742Test` green, phpstan clean, phpcs clean. Other DBMS profiles are covered by CI.

## Limitations (on purpose, stated plainly)

- The unique constraint must be declared in the mapping (`unique: true` on a field or join column, or a table `uniqueConstraint`). Constraints that exist only in the database are invisible to this check.
- It covers the remove-and-replace scenario of this ticket (delete + insert of the same value). Renaming a value without deleting (`UPDATE` vs `UPDATE`/`INSERT` collisions) is a different, bigger problem and is not attempted here.
- Collisions that are provably impossible to order safely (the GH5742 shape) keep today's behavior, silently.
- The reference check treats entity classes exactly (a subclass standing in for a `targetEntity` in an m2m is not seen — an exotic corner, documented in the code).

The detection logic doesn't care *why* an entity is being deleted — it gets that handed in — so extending this to explicit `remove()` (the old #5109 report) later is a small step, not a rewrite.
