### PR TITLE
Forbid WITH keyword usage for arbitrary DQL joins

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,13 @@ awareness about deprecated code.
 
 # Upgrade to 4.0
 
+## Forbid using the `WITH` keyword for arbitrary DQL joins
+
+Using the `WITH` keyword to specify the condition for an arbitrary DQL join is
+forbidden. Instead, use the `ON` keyword (similar to the SQL syntax for joins).
+The `WITH` keyword is now meant to be used only for filtering conditions in
+association joins.
+
 ## Removed support for string expression for default values of temporal fields in mappings
 
 Using a string expression for default values of temporal fields is no longer supported.

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -519,8 +519,7 @@ when the DQL is switched to an arbitrary join.
     - WHERE is applied to the results of an entire query
     - ON is applied to arbitrary joins as the join condition. For
       arbitrary joins (SELECT f, b FROM Foo f, Bar b ON f.id = b.id)
-      the ON is required, even if it is 1 = 1. WITH is also
-      supported as alternative keyword for that case for BC reasons.
+      the ON is required, even if it is 1 = 1.
     - WITH is applied to an association join as an additional condition.
     - HAVING is applied to the results of a query after
       aggregation (GROUP BY)
@@ -1707,13 +1706,8 @@ From, Join and Index by
     SubselectIdentificationVariableDeclaration ::= IdentificationVariableDeclaration
     RangeVariableDeclaration                   ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
     JoinAssociationDeclaration                 ::= JoinAssociationPathExpression ["AS"] AliasIdentificationVariable [IndexBy]
-    Join                                       ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" (JoinAssociationDeclaration ["WITH" ConditionalExpression] | RangeVariableDeclaration [("ON" | "WITH") ConditionalExpression])
+    Join                                       ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" (JoinAssociationDeclaration ["WITH" ConditionalExpression] | RangeVariableDeclaration ["ON" ConditionalExpression])
     IndexBy                                    ::= "INDEX" "BY" SingleValuedPathExpression
-
-.. note::
-    Using the ``WITH`` keyword for the ``ConditionalExpression`` of a
-    ``RangeVariableDeclaration`` is deprecated and will be removed in
-    ORM 4.0. Use the ``ON`` keyword instead.
 
 Select Expressions
 ~~~~~~~~~~~~~~~~~~

--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Lexer\Token;
-use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\DuplicateFieldException;
 use Doctrine\ORM\Exception\NoMatchingPropertyException;
@@ -1579,7 +1578,7 @@ final class Parser
 
     /**
      * Join ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN"
-     *          (JoinAssociationDeclaration ["WITH" ConditionalExpression] | RangeVariableDeclaration [("ON" | "WITH") ConditionalExpression])
+     *          (JoinAssociationDeclaration ["WITH" ConditionalExpression] | RangeVariableDeclaration ["ON" ConditionalExpression])
      */
     public function Join(): AST\Join
     {
@@ -1636,10 +1635,6 @@ final class Parser
             if ($this->lexer->isNextToken(TokenType::T_ON)) {
                 $this->match(TokenType::T_ON);
                 $conditionalExpression = $this->ConditionalExpression();
-            } elseif ($this->lexer->isNextToken(TokenType::T_WITH)) {
-                $this->match(TokenType::T_WITH);
-                $conditionalExpression = $this->ConditionalExpression();
-                Deprecation::trigger('doctrine/orm', 'https://github.com/doctrine/orm/issues/12192', 'Using WITH for the join condition of arbitrary joins is deprecated. Use ON instead.');
             }
         }
 

--- a/tests/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -21,7 +21,6 @@ use Doctrine\Tests\Mocks\NullSqlWalker;
 use Doctrine\Tests\OrmTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 class LanguageRecognitionTest extends OrmTestCase
 {
@@ -269,13 +268,6 @@ class LanguageRecognitionTest extends OrmTestCase
     public function testJoinClassPathUsingON(): void
     {
         $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a ON a.user = u.id');
-    }
-
-    #[IgnoreDeprecations]
-    public function testJoinClassPathUsingWITH(): void
-    {
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/12192');
-        $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a WITH a.user = u.id');
     }
 
     #[Group('DDC-3701')]


### PR DESCRIPTION
It has been deprecated.

Follow-up to https://github.com/doctrine/orm/pull/12198