### PR TITLE
Update documentation for extra lazy associations

### DIFF
--- a/docs/en/tutorials/extra-lazy-associations.rst
+++ b/docs/en/tutorials/extra-lazy-associations.rst
@@ -15,10 +15,10 @@ the first time its accessed. If you mark an association as extra lazy the follow
 can be called without triggering a full load of the collection:
 
 -  ``Collection#contains($entity)``
--  ``Collection#containsKey($key)``
+-  ``Collection#containsKey($key)`` only if the association includes an ``indexBy`` field.
 -  ``Collection#count()``
 -  ``Collection#first()``
--  ``Collection#get($key)``
+-  ``Collection#get($key)`` only if the association includes an ``indexBy`` field.
 -  ``Collection#isEmpty()``
 -  ``Collection#slice($offset, $length = null)``
 


### PR DESCRIPTION
Clarified conditions for using Collection methods with extra lazy associations that won't initialize the Collection.

I was running some manual tests locally and it seems like `EXTRA_LAZY` collections get initialized when calling `Collection::get()` and `Collection::containsKey()` unless an `indexBy` field is specified. This wasn't clear in the docs.