### PR TITLE
Flatten the identifier written by AbstractHydrator::registerManaged()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -967,12 +967,6 @@ parameters:
 			path: src/Internal/Hydration/AbstractHydrator.php
 
 		-
-			message: '#^Offset ''joinColumns'' might not exist on array\{cache\?\: array, cascade\: array\<string\>, declared\?\: class\-string, fetch\: mixed, fieldName\: string, id\?\: bool, inherited\?\: class\-string, indexBy\?\: string, \.\.\.\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: src/Internal/Hydration/AbstractHydrator.php
-
-		-
 			message: '#^Parameter &\$id by\-ref type of method Doctrine\\ORM\\Internal\\Hydration\\AbstractHydrator\:\:gatherRowData\(\) expects array\<string, string\>, array\<string\> given\.$#'
 			identifier: parameterByRef.type
 			count: 1

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Utility\IdentifierFlattener;
 use Generator;
 use LogicException;
 use ReflectionClass;
@@ -68,6 +69,13 @@ abstract class AbstractHydrator
     protected $_uow;
 
     /**
+     * The IdentifierFlattener of the associated UnitOfWork.
+     *
+     * @var IdentifierFlattener
+     */
+    protected $_identifierFlattener;
+
+    /**
      * Local ClassMetadata cache to avoid going to the EntityManager all the time.
      *
      * @var array<string, ClassMetadata<object>>
@@ -102,9 +110,10 @@ abstract class AbstractHydrator
      */
     public function __construct(EntityManagerInterface $em)
     {
-        $this->_em       = $em;
-        $this->_platform = $em->getConnection()->getDatabasePlatform();
-        $this->_uow      = $em->getUnitOfWork();
+        $this->_em                  = $em;
+        $this->_platform            = $em->getConnection()->getDatabasePlatform();
+        $this->_uow                 = $em->getUnitOfWork();
+        $this->_identifierFlattener = new IdentifierFlattener($this->_uow, $em->getMetadataFactory());
     }
 
     /**
@@ -673,29 +682,14 @@ abstract class AbstractHydrator
      * @param mixed[] $data
      *
      * @return void
-     *
-     * @todo The "$id" generation is the same of UnitOfWork#createEntity. Remove this duplication somehow
      */
     protected function registerManaged(ClassMetadata $class, $entity, array $data)
     {
-        if ($class->isIdentifierComposite) {
-            $id = [];
-
-            foreach ($class->identifier as $fieldName) {
-                $id[$fieldName] = isset($class->associationMappings[$fieldName])
-                    ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
-                    : $data[$fieldName];
-            }
-        } else {
-            $fieldName = $class->identifier[0];
-            $id        = [
-                $fieldName => isset($class->associationMappings[$fieldName])
-                    ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
-                    : $data[$fieldName],
-            ];
-        }
-
-        $this->_em->getUnitOfWork()->registerManaged($entity, $id, $data);
+        $this->_em->getUnitOfWork()->registerManaged(
+            $entity,
+            $this->_identifierFlattener->flattenIdentifier($class, $data),
+            $data
+        );
     }
 
     /**

--- a/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Card.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Card.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10852;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class GH10852Card
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string", enumType=GH10852Suit::class)
+     *
+     * @var GH10852Suit
+     */
+    public $suit;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $label;
+
+    public function __construct(GH10852Suit $suit, string $label)
+    {
+        $this->suit  = $suit;
+        $this->label = $label;
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Hand.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Hand.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10852;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class GH10852Hand
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=GH10852Card::class)
+     * @ORM\JoinColumn(referencedColumnName="suit")
+     *
+     * @var GH10852Card
+     */
+    public $card;
+
+    public function __construct(int $id, GH10852Card $card)
+    {
+        $this->id   = $id;
+        $this->card = $card;
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Suit.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Suit.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10852;
+
+enum GH10852Suit: string
+{
+    case Hearts   = 'H';
+    case Diamonds = 'D';
+    case Clubs    = 'C';
+    case Spades   = 'S';
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH10852/GH10852Test.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH10852;
+
+use Doctrine\ORM\Query;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @requires PHP 8.1
+ */
+class GH10852Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            GH10852Card::class,
+            GH10852Hand::class
+        );
+
+        $card = new GH10852Card(GH10852Suit::Clubs, 'clubs');
+
+        $this->_em->persist($card);
+        $this->_em->persist(new GH10852Hand(1, $card));
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        $conn = $this->_em->getConnection();
+
+        $conn->executeStatement('DELETE FROM GH10852Hand');
+        $conn->executeStatement('DELETE FROM GH10852Card');
+
+        parent::tearDown();
+    }
+
+    public function testRehydratingAManagedEntityKeepsItsEnumIdentifierFlattened(): void
+    {
+        $card = $this->_em->find(GH10852Card::class, GH10852Suit::Clubs);
+
+        self::assertSame(['suit' => 'C'], $this->_em->getUnitOfWork()->getEntityIdentifier($card));
+
+        $this->rehydrate($card);
+
+        self::assertSame(['suit' => 'C'], $this->_em->getUnitOfWork()->getEntityIdentifier($card));
+    }
+
+    public function testRehydratedEntityWithEnumIdentifierCanBeBoundAsQueryParameter(): void
+    {
+        $card = $this->_em->find(GH10852Card::class, GH10852Suit::Clubs);
+
+        $this->rehydrate($card);
+
+        self::assertCount(1, $this->handsHolding($card));
+    }
+
+    public function testInitializingAProxyKeepsItsEnumIdentifierFlattened(): void
+    {
+        $card = $this->_em->find(GH10852Hand::class, 1)->card;
+
+        self::assertSame(['suit' => 'C'], $this->_em->getUnitOfWork()->getEntityIdentifier($card));
+
+        // Reading anything but the identifier initializes the proxy, which re-hydrates
+        // the entity through the very same refresh hints.
+        self::assertSame('clubs', $card->label);
+
+        self::assertSame(['suit' => 'C'], $this->_em->getUnitOfWork()->getEntityIdentifier($card));
+        self::assertCount(1, $this->handsHolding($card));
+    }
+
+    /**
+     * Reloads an instance the UnitOfWork already manages, the way the ORM does it
+     * internally when it initializes a lazy proxy.
+     */
+    private function rehydrate(GH10852Card $card): void
+    {
+        $this->_em->createQuery('SELECT c FROM ' . GH10852Card::class . ' c')
+            ->setHint(Query::HINT_REFRESH, true)
+            ->setHint(Query::HINT_REFRESH_ENTITY, $card)
+            ->getSingleResult();
+    }
+
+    /** @return GH10852Hand[] */
+    private function handsHolding(GH10852Card $card): array
+    {
+        return $this->_em->createQuery('SELECT h FROM ' . GH10852Hand::class . ' h WHERE h.card = :card')
+            ->setParameter('card', $card)
+            ->getResult();
+    }
+}

--- a/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -52,6 +52,14 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
             ->expects(self::any())
             ->method('getConnection')
             ->willReturn($mockConnection);
+        $mockEntityManagerInterface
+            ->expects(self::any())
+            ->method('getUnitOfWork')
+            ->willReturn($this->_em->getUnitOfWork());
+        $mockEntityManagerInterface
+            ->expects(self::any())
+            ->method('getMetadataFactory')
+            ->willReturn($this->_em->getMetadataFactory());
         $this->mockResult
             ->expects(self::any())
             ->method('fetchAssociative')


### PR DESCRIPTION
### Failing Test

|    Q        |   A
|------------ | ------
| BC Break    | no
| Version     | 2.20.x

#### Summary

`AbstractHydrator::registerManaged()` writes the identifier into
`UnitOfWork::$entityIdentifiers` without flattening it. When the identifier is a backed
enum, the enum instance itself is stored, where every other write path stores the
backing value.

The registry is expected to hold scalars: `UnitOfWork::getIdHashByIdentifier()` ends
with `implode(' ', $identifier)`, and had to grow a defensive `BackedEnum` unwrap
(#10508) precisely because of this. That defensive unwrap shields the identity hash, but
not the other consumers of the same array.

The consumer that breaks is DQL parameter binding. Passing a managed entity as a query
parameter ends up handing the enum instance to PDO:

```
Error: Object of class Suit could not be converted to string
```

#### Reproduction

Standalone script, SQLite in memory. The only difference between the two runs is
whether a property other than the identifier is read before the query.

```php
$card = $em->find(Hand::class, 1)->getCard();   // uninitialized proxy / lazy ghost

// $card->getLabel();                           // <- uncomment to trigger

$em->createQuery('SELECT h FROM Hand h WHERE h.card = :card')
    ->setParameter('card', $card)
    ->getResult();
```

```
property not read
  identifier in UoW : string
  binding entity    : OK
property read
  identifier in UoW : Suit
  binding entity    : Error: Object of class Suit could not be converted to string
```

`Card` is an entity whose identifier is a backed enum:

```php
#[ORM\Id]
#[ORM\Column(type: 'string', enumType: Suit::class)]
private Suit $id;
```

No custom Doctrine type is involved.

#### Root cause

Two write paths feed `UnitOfWork::$entityIdentifiers`, and they receive the same
hydrated `$data`. Only one of them flattens.

`UnitOfWork::createEntity()` goes through the flattener:

```php
$id = $this->identifierFlattener->flattenIdentifier($class, $data);
```

`IdentifierFlattener::flattenIdentifier()` unwraps:

```php
if ($id[$field] instanceof BackedEnum) {
    $flatId[$field] = $id[$field]->value;
}
```

`AbstractHydrator::registerManaged()` indexes `$data` directly:

```php
$fieldName = $class->identifier[0];
$id        = [
    $fieldName => isset($class->associationMappings[$fieldName])
        ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
        : $data[$fieldName],
];
```

`$data[$fieldName]` has already been converted to the enum by `buildEnum()` earlier in
`SimpleObjectHydrator::hydrateRowData()` (since #10088), so the enum instance is what
lands in the registry.

The `@todo` sitting on top of `registerManaged()` already states that this `$id`
generation duplicates `UnitOfWork#createEntity`. That is exactly where the two copies
diverged.

#### Why it is intermittent

The faulty write only happens when an already-known entity is re-hydrated, which is
what `Query::HINT_REFRESH_ENTITY` signals. On the proxy path that means proxy
initialization:

```php
$entity = $entityPersister->loadById($identifier, $proxy);   // Proxy/ProxyFactory.php
```

On `2.20.x` that line lives in `ProxyFactory::createInitializer()`, the *common* proxy
implementation. The lazy ghost implementation calls `loadById($identifier)` without the
object, so it never sets the hint and never shows the bug. The SQLite CI matrix runs
`ORM_PROXY_IMPLEMENTATION: common` on every PHP version, with a single explicit
`lazy-ghost` entry, so the proxy-driven test below runs red on that matrix without the
fix.

Consequences:

- Reading only the identifier of an uninitialized proxy does not trigger it, since the
  identifier is pre-set on the proxy.
- An entity loaded directly, or through a fetch join, is never re-hydrated this way and
  is never affected.
- Reading any other property of an uninitialized proxy triggers it, and every
  subsequent bind of that instance fails until the `UnitOfWork` is cleared.

So the failure depends on the state of the instance at bind time, not on the call site,
and unrelated code running earlier in the request decides it.

#### Scope

- `2.20.x` and above: reachable through ordinary proxy initialization with the common
  proxy implementation, since `ProxyFactory::createInitializer()` passes the proxy to
  `loadById()`.
- `3.x` with `enable_native_lazy_objects`: reachable the same way, since
  `ProxyFactory::getProxy()` passes the object to `loadById()`. Note that the 3.x
  *generated proxy* path does not pass it, so the bug is invisible there, which is why
  it surfaces when native lazy objects are enabled.

#### Fix

Rather than teaching the copy to unwrap enums, delete the copy: `registerManaged()` now
calls the same `IdentifierFlattener::flattenIdentifier()` that `createEntity()` uses.
That is what the `@todo` asks for, and it is what keeps the two writes from drifting
apart again.

The hydrator holds a flattener the way `BasicEntityPersister`, `ProxyFactory` and
`Cache\DefaultEntityHydrator` already do, same property, same constructor line:

```php
$this->_identifierFlattener = new IdentifierFlattener($this->_uow, $em->getMetadataFactory());
```

and `registerManaged()` writes through it:

```diff
     protected function registerManaged(ClassMetadata $class, $entity, array $data)
     {
-        if ($class->isIdentifierComposite) {
-            $id = [];
-
-            foreach ($class->identifier as $fieldName) {
-                $id[$fieldName] = isset($class->associationMappings[$fieldName])
-                    ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
-                    : $data[$fieldName];
-            }
-        } else {
-            $fieldName = $class->identifier[0];
-            $id        = [
-                $fieldName => isset($class->associationMappings[$fieldName])
-                    ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
-                    : $data[$fieldName],
-            ];
-        }
-
-        $this->_em->getUnitOfWork()->registerManaged($entity, $id, $data);
+        $this->_em->getUnitOfWork()->registerManaged(
+            $entity,
+            $this->_identifierFlattener->flattenIdentifier($class, $data),
+            $data
+        );
     }
```

That constructor line is the one thing a user can notice: building a hydrator now needs
an `EntityManagerInterface` that answers `getUnitOfWork()` and `getMetadataFactory()`,
the same two calls the three classes above already make. `AbstractHydratorTest` mocks an
`EntityManagerInterface` that stubs neither, so both are stubbed there now.

The delegation is safe here because both call sites, `ObjectHydrator::getEntity()` and
`SimpleObjectHydrator::hydrateRowData()`, hand `registerManaged()` the exact array they
hand `UnitOfWork::createEntity()` on the next line. `flattenIdentifier()` therefore
already runs on that data, and the hand-rolled copy was the only thing that could
disagree with it.

The unwrapped backed enum is the only way it did disagree. The flattener's other
departure from the deleted code, joining every join column of an association identifier
where the copy read `joinColumns[0]` only, is unreachable:
`ClassMetadataInfo::_validateAndCompleteAssociationMapping()` rejects an identifier
association carrying two or more join columns with
`MappingException::cannotMapCompositePrimaryKeyEntitiesAsForeignId`, so
`$class->identifier` never holds one. For every mapping the ORM accepts, the two
computations differ on the enum and on nothing else.

The one PHPStan baseline entry that covered the two `'joinColumns'` offsets in the
deleted block is removed with it.

#### Tests

`tests/Tests/ORM/Functional/Ticket/GH10852/`, an entity whose identifier is a backed
enum plus an entity referencing it:

- `testRehydratingAManagedEntityKeepsItsEnumIdentifierFlattened` and
  `testRehydratedEntityWithEnumIdentifierCanBeBoundAsQueryParameter` drive the refresh
  hints directly, so they are red without the fix under any proxy implementation;
- `testInitializingAProxyKeepsItsEnumIdentifierFlattened` is the scenario from the
  report, red under the common proxy implementation.

#### Deliberately out of scope

Three adjacent changes are left out to keep this reviewable:

- Sharing one `IdentifierFlattener` instead of instantiating one per consumer. The class
  is stateless, so this fixes nothing on its own, and the obvious shape for it, a getter
  on the `UnitOfWork`, has a cost: the getter returns a `final` class, PHPUnit cannot
  generate a return value for one, and `AbstractHydrator::__construct()` runs on every
  query, so any test suite that mocks `UnitOfWork` and then executes a query would start
  failing with `ClassIsFinalException`. Two tests in this repository do exactly that. Not
  something to hand users in a patch release. Worth its own PR, and note that it was
  already done once, in f8061618e (July 2017), hung off `EntityManagerInterface`, on the
  abandoned `old-prototype-3.x` branch; the TODO it removed there read *"we could move
  the Identifier Flattener to EM and consume it here, unifying the hash generation that
  happens everywhere in the codebase"* followed by *"handle UnitOfWork#createEntity hash
  generation"*.
- `ObjectHydrator::getEntityFromIdentityMap()` carries its own
  `// TODO: Abstract this code and UnitOfWork::createEntity() equivalent?` and the same
  hand-rolled extraction. It only probes the identity map, so an enum identifier costs
  a missed lookup rather than a wrong result, and routing it through the flattener would
  also drop the `ltrim()` on the composite id hash. Worth a separate look.
- Re-processing the extracted identifier in `AbstractQuery::processParameterValue()`.
  That would be a one-line safety net covering any other unflattened write path, for
  example `EntityManager::getReference()`, which does not flatten either while
  `EntityManager::find()` does. Happy to open it separately if maintainers prefer that
  angle.

#### Related

- #10088 introduced the enum conversion in `SimpleObjectHydrator`, which is what made
  the hydrated `$data` carry the enum on this path.
- #10471 was the first regression from it, fixed by #10508 by unwrapping in the identity
  hash consumer rather than at the write.
- #10852 reports this symptom without a reproduction, and #10851 carried a test case for
  it. Closes #10852.
