### PR TITLE
Forbid passing `null` as lock mode

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -63,6 +63,18 @@ so hints set as a raw string keep working.
 +$query->setHint(PaginatorInterface::HINT_ENABLE_DISTINCT, false);
 ```
 
+## Forbid passing `null` as lock mode
+
+Passing `null` as lock mode to `EntityManager::find()`,
+`EntityManager::refresh()` or `EntityRepository::find()` is no longer possible.
+Since `LockMode::NONE` is a no-op, omit the argument or pass `LockMode::NONE`
+instead.
+
+```diff
+-$entityManager->find(User::class, $id, null);
++$entityManager->find(User::class, $id);
+```
+
 ## Forbid using the `WITH` keyword for arbitrary DQL joins
 
 Using the `WITH` keyword to specify the condition for an arbitrary DQL join is

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -129,13 +129,13 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     }
 
     #[Override]
-    public function find(string $className, mixed $id, LockMode|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
+    public function find(string $className, mixed $id, LockMode $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
         return $this->wrapped->find($className, $id, $lockMode, $lockVersion);
     }
 
     #[Override]
-    public function refresh(object $object, LockMode|null $lockMode = LockMode::NONE): void
+    public function refresh(object $object, LockMode $lockMode = LockMode::NONE): void
     {
         $this->wrapped->refresh($object, $lockMode);
     }

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -10,7 +10,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\Common\EventManagerInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
-use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Exception\EntityManagerClosed;
 use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;
@@ -273,19 +272,8 @@ class EntityManager implements EntityManagerInterface
      * {@inheritDoc}
      */
     #[Override]
-    public function find($className, mixed $id, LockMode|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
+    public function find($className, mixed $id, LockMode $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
-        if ($lockMode === null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/pull/12548',
-                'Passing null as lock mode to %s() is deprecated and will not be possible in Doctrine ORM 4.0, pass LockMode::NONE instead.',
-                __METHOD__,
-            );
-
-            $lockMode = LockMode::NONE;
-        }
-
         $class = $this->metadataFactory->getMetadataFor(ltrim($className, '\\'));
 
         $this->checkLockRequirements($lockMode, $class);
@@ -475,19 +463,8 @@ class EntityManager implements EntityManagerInterface
     }
 
     #[Override]
-    public function refresh(object $object, LockMode|null $lockMode = LockMode::NONE): void
+    public function refresh(object $object, LockMode $lockMode = LockMode::NONE): void
     {
-        if ($lockMode === null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/pull/12548',
-                'Passing null as lock mode to %s() is deprecated and will not be possible in Doctrine ORM 4.0, pass LockMode::NONE instead.',
-                __METHOD__,
-            );
-
-            $lockMode = LockMode::NONE;
-        }
-
         $this->errorIfClosed();
 
         $this->unitOfWork->refresh($object, $lockMode);

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -114,13 +114,11 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string        $className   The class name of the entity to find.
-     * @param mixed         $id          The identity of the entity to find.
-     * @param LockMode|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants.
-     *                                   Passing NULL is deprecated, use LockMode::NONE
-     *                                   instead.
-     * @param int|null      $lockVersion The version of the entity to find when using
-     *                                       optimistic locking.
+     * @param string   $className   The class name of the entity to find.
+     * @param mixed    $id          The identity of the entity to find.
+     * @param LockMode $lockMode    One of the \Doctrine\DBAL\LockMode::* cases.
+     * @param int|null $lockVersion The version of the entity to find when using
+     *                              optimistic locking.
      * @phpstan-param class-string<T> $className
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
@@ -134,22 +132,20 @@ interface EntityManagerInterface extends ObjectManager
      * @template T of object
      */
     #[Override]
-    public function find(string $className, mixed $id, LockMode|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null;
+    public function find(string $className, mixed $id, LockMode $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null;
 
     /**
      * Refreshes the persistent state of an object from the database,
      * overriding any local changes that have not yet been persisted.
      *
-     * @param LockMode|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
-     *                                Passing NULL is deprecated, use LockMode::NONE
-     *                                instead.
+     * @param LockMode $lockMode One of the \Doctrine\DBAL\LockMode::* cases.
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
      * @throws TransactionRequiredException
      */
     #[Override]
-    public function refresh(object $object, LockMode|null $lockMode = LockMode::NONE): void;
+    public function refresh(object $object, LockMode $lockMode = LockMode::NONE): void;
 
     /**
      * Gets a reference to the entity identified by the given type and identifier

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -75,15 +75,13 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Finds an entity by its primary key / identifier.
      *
-     * @param LockMode|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
-     *                                Passing NULL is deprecated, use LockMode::NONE
-     *                                instead.
+     * @param LockMode $lockMode One of the \Doctrine\DBAL\LockMode::* cases.
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @phpstan-return ?T
      */
     #[Override]
-    public function find(mixed $id, LockMode|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
+    public function find(mixed $id, LockMode $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
     {
         return $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
     }

--- a/tests/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Tests/ORM/Functional/Locking/LockTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
-use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\TransactionRequiredException;
@@ -17,13 +16,10 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 #[Group('locking')]
 class LockTest extends OrmFunctionalTestCase
 {
-    use VerifyDeprecations;
-
     protected function setUp(): void
     {
         $this->useModelSet('cms');
@@ -126,54 +122,6 @@ class LockTest extends OrmFunctionalTestCase
         self::assertSame($article, $found);
         self::assertSame('Changed in memory', $found->topic);
         $this->assertQueryCount(0);
-    }
-
-    #[Group('locking')]
-    #[IgnoreDeprecations]
-    public function testFindWithNullLockModeIsDeprecated(): void
-    {
-        $article        = new CmsArticle();
-        $article->text  = 'my article';
-        $article->topic = 'Hello';
-
-        $this->_em->persist($article);
-        $this->_em->flush();
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
-
-        $this->_em->find(CmsArticle::class, $article->id, null);
-    }
-
-    #[Group('locking')]
-    #[IgnoreDeprecations]
-    public function testRefreshWithNullLockModeIsDeprecated(): void
-    {
-        $article        = new CmsArticle();
-        $article->text  = 'my article';
-        $article->topic = 'Hello';
-
-        $this->_em->persist($article);
-        $this->_em->flush();
-
-        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
-
-        $this->_em->refresh($article, null);
-    }
-
-    #[Group('locking')]
-    public function testFindWithoutLockModeIsNotDeprecated(): void
-    {
-        $article        = new CmsArticle();
-        $article->text  = 'my article';
-        $article->topic = 'Hello';
-
-        $this->_em->persist($article);
-        $this->_em->flush();
-
-        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/orm/pull/12548');
-
-        $this->_em->find(CmsArticle::class, $article->id);
-        $this->_em->refresh($article);
     }
 
     #[Group('DDC-178')]


### PR DESCRIPTION
#12548 deprecated passing `null` as lock mode to `EntityManager::find()`, `EntityManager::refresh()` and `EntityRepository::find()`, because `LockMode::NONE` became a no-op there and `null` no longer meant anything different.

That deprecation prophesized removal in 4.0, so drop the `null` from the parameter types and remove the deprecation trigger along with the tests that covered it.