### PR TITLE
Add strict loading and preloading of associations

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -71,6 +71,8 @@ Advanced Topics
 * :doc:`NamingStrategy <reference/namingstrategy>`
 * :doc:`TypedFieldMapper <reference/typedfieldmapper>`
 * :doc:`Improving Performance <reference/improving-performance>`
+* :doc:`Preloading Associations <reference/preloading>`
+* :doc:`Strict Loading <reference/strict-loading>`
 * :doc:`Caching <reference/caching>`
 * :doc:`Partial Hydration <reference/partial-hydration>`
 * :doc:`Partial Objects <reference/partial-objects>`

--- a/docs/en/reference/preloading.rst
+++ b/docs/en/reference/preloading.rst
@@ -1,0 +1,187 @@
+Preloading Associations
+=======================
+
+.. note::
+
+    ``EntityManager::preload()`` is a proposal for Doctrine ORM 4, discussed
+    together with :doc:`strict loading <strict-loading>` in
+    `discussion #10931 <https://github.com/doctrine/orm/discussions/10931>`_.
+
+A fetch join or an eager fetch mode loads associations while a query is being
+hydrated. That does not help for entities that are already in memory - from a
+repository method, a paginator, the second level cache, or a previous preload.
+Iterating over those and touching a lazy association is the N+1 problem, and
+rewriting the original query is not always an option.
+
+``preload()`` loads an association for many entities at once:
+
+.. code-block:: php
+
+    <?php
+    $users = $entityManager->getRepository(User::class)->findAll();
+
+    $entityManager->preload($users, ['articles']);
+
+    foreach ($users as $user) {
+        foreach ($user->getArticles() as $article) {
+            // no queries here
+        }
+    }
+
+One query is issued for all the collections together, in batches of
+``Configuration::setEagerFetchBatchSize()`` entities (100 by default). This is
+what Rails calls
+`preload <https://guides.rubyonrails.org/active_record_querying.html#preload>`_,
+as opposed to
+`eager_load <https://guides.rubyonrails.org/active_record_querying.html#eager-load>`_,
+which is a fetch join.
+
+Fetching and preloading in one call
+-----------------------------------
+
+The repository finders take the paths directly, so the common case does not
+need a second statement:
+
+.. code-block:: php
+
+    <?php
+    $users = $repository->findAll(['articles']);
+    $users = $repository->findBy(['active' => true], preload: ['articles.comments']);
+    $user  = $repository->find($id, preload: ['articles']);
+    $user  = $repository->findOneBy(['email' => $email], preload: ['articles']);
+
+The same on a query, for the associations that a fetch join cannot cover - a
+second collection next to one that is already joined, for instance:
+
+.. code-block:: php
+
+    <?php
+    $users = $entityManager->createQuery(
+        'SELECT u, a FROM App\Entity\User u LEFT JOIN u.articles a',
+    )->preload(['address', 'articles.comments'])->getResult();
+
+and on the query builder, which hands the paths to the query it creates:
+
+.. code-block:: php
+
+    <?php
+    $users = $repository->createQueryBuilder('u')
+        ->where('u.active = true')
+        ->preload(['articles'])
+        ->getQuery()
+        ->getResult();
+
+The paths are preloaded after hydration, so a query preload costs the same
+queries as calling ``preload()`` on the result would. ``toIterable()`` throws
+when paths are set: it hydrates one row at a time, so there is nothing to load
+the associations for in one query.
+
+``EntityManager::preload()`` and ``EntityRepository::preload()`` stay the way to
+preload entities you already hold - from a paginator, an event listener, or a
+previous preload - where there is no finder call to pass paths to.
+
+Paths
+-----
+
+A path may walk several associations. Every step is batched over everything the
+previous step loaded, so the number of queries depends on the depth of the path,
+not on the number of entities:
+
+.. code-block:: php
+
+    <?php
+    $entityManager->preload($users, ['articles.comments.author']);
+
+Several paths can be preloaded at once:
+
+.. code-block:: php
+
+    <?php
+    $entityManager->preload($users, ['articles.comments', 'address']);
+
+Passing no path at all initializes the given entities themselves, which turns a
+list of references into a single query:
+
+.. code-block:: php
+
+    <?php
+    $references = array_map(
+        static fn (int $id): User => $entityManager->getReference(User::class, $id),
+        $ids,
+    );
+
+    $entityManager->preload($references);
+
+What is loaded
+--------------
+
+============================  ==========================================
+Association                   Queries per batch
+============================  ==========================================
+``ManyToOne``, owning
+``OneToOne``                  1
+``OneToMany``                 1
+``ManyToMany``                2 (the join table, then the targets)
+Inverse ``OneToOne``          0 - the ORM already loads it while
+                              hydrating the owner
+============================  ==========================================
+
+A preload always loads the **whole** association: it marks collections as
+initialized, so a partially filled collection would be indistinguishable from a
+complete one. Use
+:ref:`matching() <filtering-collections>` when a filtered subset is what you need
+- it returns a separate result and leaves the collection alone.
+
+Skipped silently:
+
+-  associations that are already loaded, including collections filled by a fetch
+   join, and collections that were preloaded before;
+-  collections with unflushed changes - loading them would take a snapshot that
+   contradicts those changes, so they initialize on their own later;
+-  entities that are not managed by this ``EntityManager``.
+
+Preloading an association that does not exist throws
+``ORMInvalidArgumentException``, naming the class and the path: a typo must not
+silently bring the N+1 back.
+
+Ordering and indexing behave exactly as they do for a lazy load: the
+association's ``orderBy`` is applied in SQL, and ``indexBy`` keys the collection.
+
+Strict loading
+--------------
+
+``preload()`` is the way out of a
+:doc:`strict loading <strict-loading>` violation for entities you already hold.
+Fetch first, then forbid loading:
+
+.. code-block:: php
+
+    <?php
+    $users = $repository->findAll(['articles.comments']);
+
+    $strictLoading->setMode(StrictLoadingMode::All);
+
+    return $this->render('users.html.twig', ['users' => $users]);
+
+Preloading itself never triggers a violation.
+
+Batching without ``preload()``
+------------------------------
+
+The same batching runs while a query is hydrated, for associations mapped with
+``fetch: 'EAGER'`` or overridden per query:
+
+.. code-block:: php
+
+    <?php
+    $query = $entityManager->createQuery('SELECT u FROM App\Entity\User u')
+        ->setFetchMode(User::class, 'articles', ClassMetadata::FETCH_EAGER);
+
+Batching is skipped, and the association is loaded one owner at a time, when:
+
+-  the query is iterated with ``toIterable()`` - rows are hydrated one by one, so
+   there is nothing to batch them with;
+-  the result comes from the second level cache;
+-  the association has a composite key on the side that has to be filtered;
+-  ``indexBy`` names a column rather than a mapped field, because only the SQL
+   result set can resolve that.

--- a/docs/en/reference/strict-loading.rst
+++ b/docs/en/reference/strict-loading.rst
@@ -1,0 +1,192 @@
+Strict Loading
+==============
+
+.. note::
+
+    Strict loading is a proposal for Doctrine ORM 4 and is being discussed in
+    `discussion #10931 <https://github.com/doctrine/orm/discussions/10931>`_.
+
+Lazy loading is convenient, but it hides database access behind ordinary
+property reads. The result is the N+1 query problem: a loop over 100 entities
+that touches a lazy association issues 101 queries, and nothing in the code
+shows that this happens.
+
+Strict loading turns that implicit database access into a reported violation.
+The idea comes from Ruby on Rails, which has had
+`strict loading <https://guides.rubyonrails.org/active_record_querying.html#strict-loading>`_
+since 6.1 (`ActiveRecord::Base#strict_loading!
+<https://api.rubyonrails.org/classes/ActiveRecord/Core.html#method-i-strict_loading-21>`_).
+The typical setup is to fetch everything a request needs up front - with fetch
+joins, ``Query::setFetchMode()`` or an eager fetch mode - and then forbid
+further loading for the rest of the request, for example while rendering a
+template or serializing a response.
+
+Enabling strict loading
+-----------------------
+
+Strict loading is configured per ``EntityManager`` and is disabled by default:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+
+    $strictLoading = $entityManager->getConfiguration()->getStrictLoading();
+    $strictLoading->setMode(StrictLoadingMode::All);
+
+From now on, loading an uninitialized entity or collection throws
+``Doctrine\ORM\Exception\StrictLoadingViolation``:
+
+.. code-block:: php
+
+    <?php
+    $article = $entityManager->find(Article::class, 1);
+
+    echo $article->getAuthor()->getName();
+    // Strict loading violation: lazily loading entity App\Entity\User(42) is not
+    // allowed here. Fetch the data explicitly (fetch join, Query::setFetchMode()
+    // or an eager fetch mode), or wrap the offending code in
+    // Doctrine\ORM\StrictLoading\StrictLoading::allow().
+
+Fetching the association explicitly makes the code work again:
+
+.. code-block:: php
+
+    <?php
+    $article = $entityManager->createQuery(
+        'SELECT a, u FROM App\Entity\Article a JOIN a.author u WHERE a.id = :id',
+    )->setParameter('id', 1)->getSingleResult();
+
+    echo $article->getAuthor()->getName(); // no lazy load, no violation
+
+Modes
+-----
+
+``StrictLoadingMode::Disabled``
+    Lazy loading is allowed. This is the default and the historical behavior.
+
+``StrictLoadingMode::NPlusOneOnly``
+    Only lazy loads that repeat are reported. The first lazy load of a given
+    association - or of a given entity class, for to-one references - is
+    allowed, every following one is a violation. This is the mode to start with
+    in an existing application, because it only complains about loads that
+    actually degrade into an N+1 query.
+
+``StrictLoadingMode::All``
+    Every lazy load is reported. All data has to be fetched explicitly.
+
+The two active modes are the ones Rails offers as ``:n_plus_one_only`` and
+``:all``.
+
+Limiting strict loading to part of a request
+--------------------------------------------
+
+The mode can be changed at any point, which is how you separate "fetching" from
+"rendering":
+
+.. code-block:: php
+
+    <?php
+    // Controller: fetch everything the view needs.
+    $users = $repository->findAll(['articles']);
+
+    // View: no database access allowed from here on.
+    $strictLoading->setMode(StrictLoadingMode::All);
+
+    return $this->render('users.html.twig', ['users' => $users]);
+
+Reset the mode once per request - in a ``kernel.request`` listener, or wherever
+the application sets up its unit of work - so that a request that switched to
+``All`` does not affect the next one.
+
+``allow()`` is the escape hatch for code that knowingly lazy loads. It takes a
+callback because the previous state has to be restored even when the callback
+throws:
+
+.. code-block:: php
+
+    <?php
+    $author = $strictLoading->allow(static fn (): User => $article->getAuthor());
+
+Reporting instead of throwing
+-----------------------------
+
+By default a violation is thrown. Passing a different
+``StrictLoadingViolationHandler`` lets the load happen and only records it,
+which is useful to introduce strict loading into an existing application, or to
+run in ``NPlusOneOnly`` mode in production while the test suite throws. Rails
+makes the same distinction with
+`config.active_record.action_on_strict_loading_violation
+<https://guides.rubyonrails.org/configuring.html#config-active-record-action-on-strict-loading-violation>`_,
+which is either ``:raise`` or ``:log``:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\StrictLoading\LogViolation;
+    use Doctrine\ORM\StrictLoading\StrictLoading;
+    use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+
+    $entityManager->getConfiguration()->setStrictLoading(new StrictLoading(
+        StrictLoadingMode::NPlusOneOnly,
+        new LogViolation($logger),
+    ));
+
+A custom handler receives a ``LazyLoad`` describing what was about to be
+loaded, and may for instance add the violation to a profiler collector:
+
+.. code-block:: php
+
+    <?php
+    use Doctrine\ORM\StrictLoading\LazyLoad;
+    use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+    use Doctrine\ORM\StrictLoading\StrictLoadingViolationHandler;
+
+    final class CollectViolations implements StrictLoadingViolationHandler
+    {
+        /** @var list<LazyLoad> */
+        public array $violations = [];
+
+        public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+        {
+            $this->violations[] = $lazyLoad;
+        }
+    }
+
+What counts as a violation
+--------------------------
+
+Reported:
+
+-  initializing an entity reference (a proxy), including references created by
+   ``EntityManager::getReference()``;
+-  loading an uninitialized collection;
+-  a query that an uninitialized ``EXTRA_LAZY`` collection runs on its own -
+   ``count()``, ``contains()``, ``containsKey()``, ``get()``, ``first()``,
+   ``slice()`` and ``matching()``.
+
+Never reported, because the ORM loads on purpose there:
+
+-  everything that happens during ``flush()``, including change set
+   computation, orphan removal and cascades;
+-  ``persist()``, ``remove()``, ``refresh()`` and ``lock()``;
+-  explicit initialization through ``EntityManager::initializeObject()``.
+
+Not reported, because no lazy loading is involved: fetch joins, eager fetch
+modes (``fetch: 'EAGER'`` and ``Query::setFetchMode()``, which load in batches),
+``EntityManager::find()`` and DQL queries. Inverse to-one associations are
+loaded while hydrating the owning entity, not lazily, and are therefore not
+reported either - use an eager fetch mode or a fetch join to avoid the query
+per row.
+
+Caveats
+-------
+
+Entity references are shared through the identity map, so a violation names the
+entity that was about to be loaded, not the property that was read. Collection
+violations name the owning class and the field.
+
+In ``NPlusOneOnly`` mode, "repeated" means "seen before in the current scope".
+The scope is reset by ``EntityManager::clear()`` and by
+``StrictLoading::reset()`` - call the latter once per request in a long-running
+worker.

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -42,6 +42,8 @@
    reference/php-mapping
    reference/caching
    reference/improving-performance
+   reference/preloading
+   reference/strict-loading
    reference/tools
    reference/metadata-drivers
    reference/best-practices

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1783,6 +1783,16 @@ parameters:
 			path: src/Persisters/Collection/ManyToManyPersister.php
 
 		-
+			message: '#^Call to method Doctrine\\ORM\\Mapping\\AssociationMapping\:\:isIndexed\(\) will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: src/Internal/AssociationBatchLoader.php
+		-
+			message: '#^Call to method Doctrine\\ORM\\Mapping\\ToManyAssociationMapping\:\:isIndexed\(\) will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 1
+			path: src/Internal/AssociationBatchLoader.php
+		-
 			message: '#^Instanceof between Doctrine\\ORM\\Mapping\\InverseSideMapping&Doctrine\\ORM\\Mapping\\ManyToManyAssociationMapping and Doctrine\\ORM\\Mapping\\InverseSideMapping will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 2
@@ -3295,7 +3305,7 @@ parameters:
 			message: '#^Access to an undefined property Doctrine\\ORM\\Mapping\\AssociationMapping\:\:\$joinColumns\.$#'
 			identifier: property.notFound
 			count: 1
-			path: src/UnitOfWork.php
+			path: src/Internal/AssociationBatchLoader.php
 
 		-
 			message: '#^Access to an undefined property Doctrine\\ORM\\Mapping\\ManyToManyInverseSideMapping\|Doctrine\\ORM\\Mapping\\ManyToManyOwningSideMapping\|Doctrine\\ORM\\Mapping\\ManyToOneAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToManyAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToOneInverseSideMapping\|Doctrine\\ORM\\Mapping\\OneToOneOwningSideMapping\:\:\$inversedBy\.$#'
@@ -3312,7 +3322,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Doctrine\\ORM\\Mapping\\ManyToManyInverseSideMapping\|Doctrine\\ORM\\Mapping\\ManyToManyOwningSideMapping\|Doctrine\\ORM\\Mapping\\ManyToOneAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToManyAssociationMapping\|Doctrine\\ORM\\Mapping\\OneToOneInverseSideMapping\|Doctrine\\ORM\\Mapping\\OneToOneOwningSideMapping\:\:\$mappedBy\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 1
 			path: src/UnitOfWork.php
 
 		-
@@ -3327,11 +3337,6 @@ parameters:
 			count: 1
 			path: src/UnitOfWork.php
 
-		-
-			message: '#^Method Doctrine\\ORM\\UnitOfWork\:\:eagerLoadCollections\(\) has parameter \$collections with generic class Doctrine\\ORM\\PersistentCollection but does not specify its types\: TKey, T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/UnitOfWork.php
 
 		-
 			message: '#^Method Doctrine\\ORM\\UnitOfWork\:\:getEntityChangeSet\(\) return type with generic class Doctrine\\ORM\\PersistentCollection does not specify its types\: TKey, T$#'
@@ -3351,11 +3356,6 @@ parameters:
 			count: 1
 			path: src/UnitOfWork.php
 
-		-
-			message: '#^Method Doctrine\\ORM\\UnitOfWork\:\:loadCollection\(\) has parameter \$collection with generic class Doctrine\\ORM\\PersistentCollection but does not specify its types\: TKey, T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/UnitOfWork.php
 
 		-
 			message: '#^Method Doctrine\\ORM\\UnitOfWork\:\:normalizeIdentifier\(\) has parameter \$targetClass with generic class Doctrine\\ORM\\Mapping\\ClassMetadata but does not specify its types\: T$#'
@@ -3399,11 +3399,6 @@ parameters:
 			count: 1
 			path: src/UnitOfWork.php
 
-		-
-			message: '#^Parameter \#2 \$length of function array_chunk expects int\<1, max\>, int given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/UnitOfWork.php
 
 		-
 			message: '#^Parameter \#5 \$invoke of method Doctrine\\ORM\\Event\\ListenersInvoker\:\:invoke\(\) expects int\<0, 7\>, int\<min, \-1\>\|int\<1, max\> given\.$#'

--- a/src/AbstractQuery.php
+++ b/src/AbstractQuery.php
@@ -105,6 +105,15 @@ abstract class AbstractQuery
      */
     protected string|int $hydrationMode = self::HYDRATE_OBJECT;
 
+    /**
+     * Association paths to preload on the result, see {@see self::preload()}.
+     *
+     * @var list<string>
+     */
+    private array $preload = [];
+
+    private Preloader|null $preloader = null;
+
     protected QueryCacheProfile|null $queryCacheProfile = null;
 
     /**
@@ -859,6 +868,14 @@ abstract class AbstractQuery
             $this->setParameters($parameters);
         }
 
+        if ($this->preload !== []) {
+            throw new LogicException(
+                'Preloading is not possible with toIterable(), which hydrates one row at a time:'
+                . ' there is nothing to load the associations for in one query. Use getResult(),'
+                . ' or a fetch join.',
+            );
+        }
+
         $rsm = $this->getResultSetMapping();
         if ($rsm === null) {
             throw new LogicException('Uninitialized result set mapping.');
@@ -867,6 +884,30 @@ abstract class AbstractQuery
         $stmt = $this->_doExecute();
 
         return $this->em->newHydrator($this->hydrationMode)->toIterable($stmt, $rsm, $this->hints);
+    }
+
+    /**
+     * Preloads the given association paths on the entities this query returns.
+     *
+     * This is {@see EntityManagerInterface::preload()} applied to the result, for
+     * associations that cannot be fetch joined - a second collection next to one
+     * that is already joined, for instance:
+     *
+     *     $query->preload(['comments', 'author.address'])->getResult();
+     *
+     * Each association is loaded for all returned entities at once, after
+     * hydration. {@see self::toIterable()} cannot preload, because it hydrates
+     * one row at a time.
+     *
+     * @param list<string> $paths
+     */
+    public function preload(array $paths): static
+    {
+        foreach ($paths as $path) {
+            $this->preload[] = $path;
+        }
+
+        return $this;
     }
 
     /**
@@ -879,11 +920,57 @@ abstract class AbstractQuery
         ArrayCollection|array|null $parameters = null,
         string|int|null $hydrationMode = null,
     ): mixed {
-        if ($this->cacheable && $this->isCacheEnabled()) {
-            return $this->executeUsingQueryCache($parameters, $hydrationMode);
+        $result = $this->cacheable && $this->isCacheEnabled()
+            ? $this->executeUsingQueryCache($parameters, $hydrationMode)
+            : $this->executeIgnoreQueryCache($parameters, $hydrationMode);
+
+        if ($this->preload !== [] && is_array($result)) {
+            $this->preloader()->preload($this->entitiesIn($result), $this->preload);
         }
 
-        return $this->executeIgnoreQueryCache($parameters, $hydrationMode);
+        return $result;
+    }
+
+    /**
+     * Preloading is not on {@see EntityManagerInterface} yet, so the query keeps
+     * its own {@see Preloader} rather than delegating to the manager.
+     */
+    private function preloader(): Preloader
+    {
+        return $this->preloader ??= new Preloader($this->em);
+    }
+
+    /**
+     * The entities in a query result, so that a mixed result - a root entity
+     * next to scalar values - can be preloaded too.
+     *
+     * @param mixed[] $result
+     *
+     * @return list<object>
+     */
+    private function entitiesIn(array $result): array
+    {
+        $entities = [];
+
+        foreach ($result as $row) {
+            if (is_object($row)) {
+                $entities[] = $row;
+
+                continue;
+            }
+
+            if (! is_array($row)) {
+                continue;
+            }
+
+            foreach ($row as $value) {
+                if (is_object($value)) {
+                    $entities[] = $value;
+                }
+            }
+        }
+
+        return $entities;
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
+use Doctrine\ORM\StrictLoading\StrictLoading;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use LogicException;
 use Psr\Cache\CacheItemPoolInterface;
@@ -48,6 +49,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /** @phpstan-var array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> */
     private $identityGenerationPreferences = [];
+
+    private StrictLoading|null $strictLoading = null;
 
     /** @phpstan-param array<class-string<AbstractPlatform>, ClassMetadata::GENERATOR_TYPE_*> $value */
     public function setIdentityGenerationPreferences(array $value): void
@@ -754,5 +757,21 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function getDefaultStringTypeSchemaLength(): int
     {
         return $this->attributes['defaultStringTypeSchemaLength'] ?? 255;
+    }
+
+    /**
+     * Returns the (mutable) strict loading configuration of this EntityManager.
+     *
+     * Strict loading is disabled by default; switch it on with
+     * {@see StrictLoading::setMode()}.
+     */
+    public function getStrictLoading(): StrictLoading
+    {
+        return $this->strictLoading ??= new StrictLoading();
+    }
+
+    public function setStrictLoading(StrictLoading $strictLoading): void
+    {
+        $this->strictLoading = $strictLoading;
     }
 }

--- a/src/Decorator/EntityManagerDecorator.php
+++ b/src/Decorator/EntityManagerDecorator.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\NativeQuery;
+use Doctrine\ORM\Preloader;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr;
@@ -32,6 +33,8 @@ use Doctrine\Persistence\ObjectManagerDecorator;
  */
 abstract class EntityManagerDecorator extends ObjectManagerDecorator implements EntityManagerInterface
 {
+    private Preloader|null $preloader = null;
+
     public function __construct(EntityManagerInterface $wrapped)
     {
         $this->wrapped = $wrapped;
@@ -100,6 +103,21 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     public function getReference(string $entityName, mixed $id): object|null
     {
         return $this->wrapped->getReference($entityName, $id);
+    }
+
+    /**
+     * See {@see EntityManager::preload()}. This is not part of
+     * {@see EntityManagerInterface} yet, so the wrapped manager is preloaded
+     * directly instead of forwarding the call.
+     *
+     * @param iterable<object> $entities
+     * @param list<string>     $paths
+     */
+    public function preload(iterable $entities, array $paths = []): void
+    {
+        $this->preloader ??= new Preloader($this->wrapped);
+
+        $this->preloader->preload($entities, $paths);
     }
 
     public function close(): void

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -81,6 +81,8 @@ class EntityManager implements EntityManagerInterface
      */
     private ProxyFactory $proxyFactory;
 
+    private Preloader|null $preloader = null;
+
     /**
      * The repository factory used to create dynamic repositories.
      */
@@ -557,6 +559,34 @@ class EntityManager implements EntityManagerInterface
     public function isOpen(): bool
     {
         return ! $this->closed;
+    }
+
+    /**
+     * Loads the given association paths for entities that are already in memory.
+     *
+     * Where a fetch join or an eager fetch mode loads associations while a query
+     * is hydrated, this loads them afterwards - for entities that came from a
+     * repository method, a paginator, or the second level cache:
+     *
+     *     $users = $repository->findAll();
+     *     $entityManager->preload($users, ['articles.comments', 'address']);
+     *
+     * A path may walk several associations. Passing no path initializes the
+     * given entities themselves, which is useful for a list of references. Each
+     * association is loaded for all entities at once, in batches of
+     * {@see Configuration::getEagerFetchBatchSize()}.
+     *
+     * A preload always loads the whole association: it marks collections as
+     * initialized.
+     *
+     * @param iterable<object> $entities
+     * @param list<string>     $paths
+     */
+    public function preload(iterable $entities, array $paths = []): void
+    {
+        $this->preloader ??= new Preloader($this);
+
+        $this->preloader->preload($entities, $paths);
     }
 
     public function getUnitOfWork(): UnitOfWork

--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -39,6 +39,7 @@ class EntityRepository implements ObjectRepository, Selectable
     /** @var class-string<T> */
     private readonly string $entityName;
     private static Inflector|null $inflector = null;
+    private Preloader|null $preloader        = null;
 
     /** @param ClassMetadata<T> $class */
     public function __construct(
@@ -77,24 +78,33 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param LockMode|int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
      *                                    Passing NULL is deprecated, use LockMode::NONE
      *                                    instead.
+     * @param list<string>      $preload  Association paths to preload, see {@see self::preload()}.
      * @phpstan-param LockMode::*|null $lockMode
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      * @phpstan-return ?T
      */
-    public function find(mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null): object|null
+    public function find(mixed $id, LockMode|int|null $lockMode = LockMode::NONE, int|null $lockVersion = null, array $preload = []): object|null
     {
-        return $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
+        $entity = $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
+
+        if ($entity !== null && $preload !== []) {
+            $this->preloader()->preload([$entity], $preload);
+        }
+
+        return $entity;
     }
 
     /**
      * Finds all entities in the repository.
      *
+     * @param list<string> $preload Association paths to preload, see {@see self::preload()}.
+     *
      * @phpstan-return list<T> The entities.
      */
-    public function findAll(): array
+    public function findAll(array $preload = []): array
     {
-        return $this->findBy([]);
+        return $this->findBy([], preload: $preload);
     }
 
     /**
@@ -102,28 +112,43 @@ class EntityRepository implements ObjectRepository, Selectable
      *
      * {@inheritDoc}
      *
+     * @param list<string> $preload Association paths to preload, see {@see self::preload()}.
+     *
      * @phpstan-return list<T>
      */
-    public function findBy(array $criteria, array|null $orderBy = null, int|null $limit = null, int|null $offset = null): array
+    public function findBy(array $criteria, array|null $orderBy = null, int|null $limit = null, int|null $offset = null, array $preload = []): array
     {
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->entityName);
 
-        return $persister->loadAll($criteria, $orderBy, $limit, $offset);
+        $entities = $persister->loadAll($criteria, $orderBy, $limit, $offset);
+
+        if ($preload !== []) {
+            $this->preloader()->preload($entities, $preload);
+        }
+
+        return $entities;
     }
 
     /**
      * Finds a single entity by a set of criteria.
      *
+     * @param list<string> $preload Association paths to preload, see {@see self::preload()}.
      * @phpstan-param array<string, mixed> $criteria
      * @phpstan-param array<string, string>|null $orderBy
      *
      * @phpstan-return T|null
      */
-    public function findOneBy(array $criteria, array|null $orderBy = null): object|null
+    public function findOneBy(array $criteria, array|null $orderBy = null, array $preload = []): object|null
     {
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->entityName);
 
-        return $persister->load($criteria, null, null, [], null, 1, $orderBy);
+        $entity = $persister->load($criteria, null, null, [], null, 1, $orderBy);
+
+        if ($entity !== null && $preload !== []) {
+            $this->preloader()->preload([$entity], $preload);
+        }
+
+        return $entity;
     }
 
     /**
@@ -139,6 +164,33 @@ class EntityRepository implements ObjectRepository, Selectable
     public function count(array $criteria = []): int
     {
         return $this->em->getUnitOfWork()->getEntityPersister($this->entityName)->count($criteria);
+    }
+
+    /**
+     * Loads the given association paths for all given entities at once.
+     *
+     *     $users = $repository->findBy(['active' => true]);
+     *     $repository->preload($users, ['articles.comments', 'address']);
+     *
+     * This is {@see EntityManagerInterface::preload()}, scoped to the entities
+     * of this repository. A path may walk several associations; passing no path
+     * initializes the given entities themselves.
+     *
+     * @param iterable<T>  $entities
+     * @param list<string> $paths
+     */
+    public function preload(iterable $entities, array $paths = []): void
+    {
+        $this->preloader()->preload($entities, $paths);
+    }
+
+    /**
+     * Preloading is not on {@see EntityManagerInterface} yet, so the repository
+     * keeps its own {@see Preloader} rather than delegating to the manager.
+     */
+    private function preloader(): Preloader
+    {
+        return $this->preloader ??= new Preloader($this->em);
     }
 
     /**

--- a/src/Exception/StrictLoadingViolation.php
+++ b/src/Exception/StrictLoadingViolation.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use Doctrine\ORM\StrictLoading\LazyLoad;
+use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Thrown when strict loading is active and the ORM was about to lazily load
+ * data from the database.
+ */
+final class StrictLoadingViolation extends RuntimeException implements ORMException
+{
+    private function __construct(public readonly LazyLoad $lazyLoad, string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function fromLazyLoad(LazyLoad $lazyLoad, StrictLoadingMode $mode): self
+    {
+        return new self($lazyLoad, sprintf(
+            'Strict loading violation: lazily loading %s is not allowed here.%s Fetch the data'
+            . ' explicitly - with a fetch join, an eager fetch mode, or EntityManager::preload()'
+            . ' for entities you already hold - or wrap the offending code in'
+            . ' Doctrine\ORM\StrictLoading\StrictLoading::allow().',
+            $lazyLoad->describe(),
+            $mode === StrictLoadingMode::NPlusOneOnly
+                ? ' It was already loaded lazily before in this scope, which makes it an N+1 query.'
+                : '',
+        ));
+    }
+}

--- a/src/Internal/AssociationBatchLoader.php
+++ b/src/Internal/AssociationBatchLoader.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\JoinColumnMapping;
+use Doctrine\ORM\Mapping\ManyToManyAssociationMapping;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
+use Doctrine\ORM\Mapping\ToManyInverseSideMapping;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Utility\IdentifierFlattener;
+use Doctrine\ORM\Utility\PersisterHelper;
+
+use function array_chunk;
+use function array_combine;
+use function array_values;
+use function assert;
+use function count;
+use function implode;
+use function max;
+use function reset;
+
+/**
+ * Loads associations for many entities at once instead of one query per entity.
+ *
+ * This is the machinery behind the eager fetch modes (see
+ * {@see UnitOfWork::triggerEagerLoads()}), which collect associations while
+ * hydrating and load them in batches once hydration completes.
+ *
+ * @internal
+ */
+final class AssociationBatchLoader
+{
+    private readonly IdentifierFlattener $identifierFlattener;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly UnitOfWork $uow,
+    ) {
+        $this->identifierFlattener = new IdentifierFlattener($uow, $em->getMetadataFactory());
+    }
+
+    /**
+     * Whether this loader can load the given to-many association in batches.
+     *
+     * Composite keys are the limitation: neither the identifier list of a batch
+     * nor the join table lookup of a many-to-many can be expressed as a single
+     * IN () condition when more than one column is involved.
+     */
+    public function canBatchLoad(AssociationMapping&ToManyAssociationMapping $mapping): bool
+    {
+        if ($mapping->isIndexed()) {
+            // A batch distributes rows to collections in PHP, so it can only
+            // index by something readable from the target entity. indexBy is
+            // also allowed to name a column - a join column of a to-one
+            // association, say - which only the SQL result set can resolve.
+            $indexBy = $mapping->indexBy();
+
+            if (! isset($this->em->getClassMetadata($mapping->targetEntity)->fieldMappings[$indexBy])) {
+                return false;
+            }
+        }
+
+        if ($mapping->isManyToMany()) {
+            $joinColumns = $this->manyToManyJoinColumns($mapping);
+
+            return $joinColumns !== null
+                && ! $this->em->getClassMetadata($mapping->targetEntity)->isIdentifierComposite;
+        }
+
+        assert($mapping instanceof ToManyInverseSideMapping);
+        $targetClass = $this->em->getClassMetadata($mapping->targetEntity);
+
+        // A composite foreign key on the owning side cannot be filtered with IN ().
+        return ! $targetClass->hasAssociation($mapping->mappedBy)
+            || count($targetClass->getAssociationMapping($mapping->mappedBy)->joinColumns) === 1;
+    }
+
+    /**
+     * Loads uninitialized entities of one class by their identifiers.
+     *
+     * Hydration fills the entities that are already in the identity map, so the
+     * references handed out earlier are initialized by this.
+     *
+     * @param class-string $entityName
+     * @param array<mixed> $ids        Single-column identifier values.
+     */
+    public function initializeEntities(string $entityName, array $ids): void
+    {
+        if ($ids === []) {
+            return;
+        }
+
+        $class     = $this->em->getClassMetadata($entityName);
+        $persister = $this->uow->getEntityPersister($entityName);
+
+        foreach (array_chunk(array_values($ids), $this->batchSize()) as $batch) {
+            $persister->loadAll(array_combine($class->identifier, [$batch]));
+        }
+    }
+
+    /**
+     * Loads the given collections, which all belong to the same association.
+     *
+     * @param array<string, PersistentCollection<array-key, object>> $collections Keyed by owner identifier hash.
+     */
+    public function loadCollections(array $collections, AssociationMapping&ToManyAssociationMapping $mapping): void
+    {
+        if ($collections === []) {
+            return;
+        }
+
+        if ($mapping->isManyToMany()) {
+            $this->loadManyToManyCollections($collections, $mapping);
+        } else {
+            assert($mapping instanceof ToManyInverseSideMapping);
+            $this->loadOneToManyCollections($collections, $mapping);
+        }
+
+        foreach ($collections as $collection) {
+            $collection->setInitialized(true);
+            $collection->takeSnapshot();
+        }
+    }
+
+    /** @param array<string, PersistentCollection<array-key, object>> $collections */
+    private function loadOneToManyCollections(array $collections, AssociationMapping&ToManyInverseSideMapping $mapping): void
+    {
+        $targetEntity = $mapping->targetEntity;
+        $class        = $this->em->getClassMetadata($mapping->sourceEntity);
+        $mappedBy     = $mapping->mappedBy;
+
+        $batches = array_chunk($collections, $this->batchSize(), true);
+
+        foreach ($batches as $collectionBatch) {
+            $entities = [];
+
+            foreach ($collectionBatch as $collection) {
+                $entities[] = $collection->getOwner();
+            }
+
+            $found = $this->uow->getEntityPersister($targetEntity)->loadAll([$mappedBy => $entities], $mapping->orderBy);
+
+            $targetClass    = $this->em->getClassMetadata($targetEntity);
+            $targetProperty = $targetClass->getPropertyAccessor($mappedBy);
+            assert($targetProperty !== null);
+
+            foreach ($found as $targetValue) {
+                $sourceEntity = $targetProperty->getValue($targetValue);
+
+                if ($sourceEntity === null && isset($targetClass->associationMappings[$mappedBy]->joinColumns)) {
+                    // case where the hydration $targetValue itself has not yet fully completed, for example
+                    // in case a bi-directional association is being hydrated and deferring eager loading is
+                    // not possible due to subclassing.
+                    $data = $this->uow->getOriginalEntityData($targetValue);
+                    $id   = [];
+                    foreach ($targetClass->associationMappings[$mappedBy]->joinColumns as $joinColumn) {
+                        $id[] = $data[$joinColumn->name];
+                    }
+                } else {
+                    $id = $this->identifierFlattener->flattenIdentifier($class, $class->getIdentifierValues($sourceEntity));
+                }
+
+                $idHash = implode(' ', $id);
+
+                if (! isset($collectionBatch[$idHash])) {
+                    continue;
+                }
+
+                $this->addToCollection($collectionBatch[$idHash], $targetValue, $mapping, $targetClass);
+            }
+        }
+    }
+
+    /**
+     * Loads many-to-many collections in two steps: the rows of the join table
+     * for all owners at once, then the targets those rows point to.
+     *
+     * @param array<string, PersistentCollection<array-key, object>> $collections
+     */
+    private function loadManyToManyCollections(array $collections, AssociationMapping&ManyToManyAssociationMapping $mapping): void
+    {
+        $joinColumns = $this->manyToManyJoinColumns($mapping);
+        assert($joinColumns !== null);
+
+        [$sourceJoinColumn, $targetJoinColumn] = $joinColumns;
+
+        $sourceClass    = $this->em->getClassMetadata($mapping->sourceEntity);
+        $targetClass    = $this->em->getClassMetadata($mapping->targetEntity);
+        $owningMapping  = $this->em->getMetadataFactory()->getOwningSide($mapping);
+        $joinTableOwner = $this->em->getClassMetadata($owningMapping->sourceEntity);
+
+        $platform      = $this->em->getConnection()->getDatabasePlatform();
+        $quoteStrategy = $this->em->getConfiguration()->getQuoteStrategy();
+
+        $joinTable       = $quoteStrategy->getJoinTableName($owningMapping, $joinTableOwner, $platform);
+        $sourceColumn    = $quoteStrategy->getJoinColumnName($sourceJoinColumn, $joinTableOwner, $platform);
+        $targetColumn    = $quoteStrategy->getJoinColumnName($targetJoinColumn, $joinTableOwner, $platform);
+        $sourceIdField   = $sourceClass->fieldNames[$sourceJoinColumn->referencedColumnName];
+        $targetIdField   = $targetClass->fieldNames[$targetJoinColumn->referencedColumnName];
+        $targetFieldType = Type::getType($targetClass->fieldMappings[$targetIdField]->type);
+
+        foreach (array_chunk($collections, $this->batchSize(), true) as $collectionBatch) {
+            $ownerKeys = [];
+
+            foreach ($collectionBatch as $idHash => $collection) {
+                $owner = $collection->getOwner();
+                assert($owner !== null);
+                $ownerKeys[$this->databaseKey($sourceClass, $sourceIdField, $owner)] = $idHash;
+            }
+
+            $rows = $this->fetchJoinTableRows(
+                $joinTable,
+                $sourceColumn,
+                $targetColumn,
+                $sourceIdField,
+                $sourceClass,
+                $collectionBatch,
+            );
+
+            if ($rows === []) {
+                continue;
+            }
+
+            // Which owners reference which target.
+            $ownersByTargetKey = [];
+            $targetIds         = [];
+
+            foreach ($rows as $row) {
+                $targetKey = (string) $row['doctrine_target'];
+
+                if (! isset($targetIds[$targetKey])) {
+                    $targetIds[$targetKey] = $targetFieldType->convertToPHPValue($row['doctrine_target'], $platform);
+                }
+
+                $ownerKey = (string) $row['doctrine_source'];
+
+                if (! isset($ownerKeys[$ownerKey])) {
+                    continue;
+                }
+
+                $ownersByTargetKey[$targetKey][] = $ownerKeys[$ownerKey];
+            }
+
+            // Loading the targets ordered means the collections end up ordered,
+            // because the relative order of the targets is preserved below.
+            $targets = $this->uow->getEntityPersister($mapping->targetEntity)->loadAll(
+                [$targetIdField => array_values($targetIds)],
+                $mapping->orderBy(),
+            );
+
+            foreach ($targets as $target) {
+                $targetKey = $this->databaseKey($targetClass, $targetIdField, $target);
+
+                foreach ($ownersByTargetKey[$targetKey] ?? [] as $idHash) {
+                    $this->addToCollection($collectionBatch[$idHash], $target, $mapping, $targetClass);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param ClassMetadata<object>                                  $sourceClass
+     * @param array<string, PersistentCollection<array-key, object>> $collections
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fetchJoinTableRows(
+        string $joinTable,
+        string $sourceColumn,
+        string $targetColumn,
+        string $sourceIdField,
+        ClassMetadata $sourceClass,
+        array $collections,
+    ): array {
+        $identifiers = [];
+
+        foreach ($collections as $collection) {
+            $owner = $collection->getOwner();
+            assert($owner !== null);
+            $identifiers[] = $sourceClass->getPropertyAccessor($sourceIdField)?->getValue($owner);
+        }
+
+        $sql = 'SELECT ' . $sourceColumn . ' AS doctrine_source, ' . $targetColumn . ' AS doctrine_target'
+            . ' FROM ' . $joinTable
+            . ' WHERE ' . $sourceColumn . ' IN (?)';
+
+        return $this->em->getConnection()->executeQuery(
+            $sql,
+            PersisterHelper::convertToParameterValue($identifiers, $this->em),
+            PersisterHelper::inferParameterTypes($sourceIdField, $identifiers, $sourceClass, $this->em),
+        )->fetchAllAssociative();
+    }
+
+    /**
+     * The pair of single join columns of a many-to-many association, pointing at
+     * the source and at the target, or null when either side is composite.
+     *
+     * @return array{JoinColumnMapping, JoinColumnMapping}|null
+     */
+    private function manyToManyJoinColumns(AssociationMapping&ToManyAssociationMapping $mapping): array|null
+    {
+        assert($mapping instanceof ManyToManyAssociationMapping);
+        $owningMapping = $this->em->getMetadataFactory()->getOwningSide($mapping);
+
+        $sourceColumns = $mapping->isOwningSide()
+            ? $owningMapping->joinTable->joinColumns
+            : $owningMapping->joinTable->inverseJoinColumns;
+        $targetColumns = $mapping->isOwningSide()
+            ? $owningMapping->joinTable->inverseJoinColumns
+            : $owningMapping->joinTable->joinColumns;
+
+        if (count($sourceColumns) !== 1 || count($targetColumns) !== 1) {
+            return null;
+        }
+
+        return [reset($sourceColumns), reset($targetColumns)];
+    }
+
+    /**
+     * @param PersistentCollection<array-key, object> $collection
+     * @param ClassMetadata<object>                   $targetClass
+     */
+    private function addToCollection(
+        PersistentCollection $collection,
+        object $target,
+        ToManyAssociationMapping $mapping,
+        ClassMetadata $targetClass,
+    ): void {
+        if (! $mapping->isIndexed()) {
+            $collection->add($target);
+
+            return;
+        }
+
+        $indexByProperty = $targetClass->getPropertyAccessor($mapping->indexBy());
+        assert($indexByProperty !== null);
+
+        $collection->hydrateSet($indexByProperty->getValue($target), $target);
+    }
+
+    /**
+     * The identifier hash of an entity, the key collections are grouped by.
+     *
+     * @param ClassMetadata<object> $class
+     */
+    public function identifierHash(ClassMetadata $class, object $entity): string
+    {
+        return implode(' ', $this->identifierFlattener->flattenIdentifier(
+            $class,
+            $class->getIdentifierValues($entity),
+        ));
+    }
+
+    /**
+     * The identifier of an entity as the database sees it, so that it can be
+     * compared with a raw value read from a join table.
+     *
+     * @param ClassMetadata<object> $class
+     */
+    private function databaseKey(ClassMetadata $class, string $idField, object $entity): string
+    {
+        $value = $class->getPropertyAccessor($idField)?->getValue($entity);
+        $type  = Type::getType($class->fieldMappings[$idField]->type);
+
+        return (string) $type->convertToDatabaseValue($value, $this->em->getConnection()->getDatabasePlatform());
+    }
+
+    /** @return positive-int */
+    private function batchSize(): int
+    {
+        return max(1, $this->em->getConfiguration()->getEagerFetchBatchSize());
+    }
+}

--- a/src/Internal/Hydration/AbstractHydrator.php
+++ b/src/Internal/Hydration/AbstractHydrator.php
@@ -172,10 +172,18 @@ abstract class AbstractHydrator
         $this->em->getEventManager()->addEventListener([Events::onClear], $this);
         $this->prepare();
 
+        // Hydrating a row can hydrate more rows: an inverse to-one association, a
+        // to-one association to a class with subclasses, and the eager to-one
+        // fallback all load through a persister while this hydration is running.
+        // The UnitOfWork needs to know about that so a nested hydration does not
+        // flush the batch this one is still collecting.
+        $this->uow->enterHydration();
+
         try {
             $result = $this->hydrateAllData();
         } finally {
             $this->cleanup();
+            $this->uow->leaveHydration();
         }
 
         return $result;

--- a/src/ORMInvalidArgumentException.php
+++ b/src/ORMInvalidArgumentException.php
@@ -170,6 +170,16 @@ EXCEPTION
         return new self('You must configure a proxy namespace');
     }
 
+    public static function preloadOfUnknownAssociation(string $className, string $fieldName, string $path): self
+    {
+        return new self(sprintf(
+            'Cannot preload "%s" of %s: there is no such association. It was reached through the path "%s".',
+            $fieldName,
+            $className,
+            $path,
+        ));
+    }
+
     public static function proxyDirectoryNotWritable(string $proxyDirectory): self
     {
         return new self(sprintf('Your proxy directory "%s" must be writable', $proxyDirectory));

--- a/src/PersistentCollection.php
+++ b/src/PersistentCollection.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Cache\Persister\CompatOrderings;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMapping;
+use Doctrine\ORM\StrictLoading\LazyLoad;
 use RuntimeException;
 use UnexpectedValueException;
 
@@ -129,6 +130,29 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     }
 
     /**
+     * Reports to strict loading that this collection is about to hit the database.
+     *
+     * Loading the whole collection is reported as a collection lazy load; a
+     * query that an uninitialized EXTRA_LAZY collection runs on its own -
+     * count(), contains(), slice(), … - is reported as a collection query,
+     * together with the operation name.
+     */
+    private function checkStrictLoading(string|null $extraLazyOperation = null): void
+    {
+        $strictLoading = $this->em?->getConfiguration()->getStrictLoading();
+
+        if ($strictLoading === null || ! $strictLoading->isActive()) {
+            return;
+        }
+
+        $mapping = $this->getMapping();
+
+        $strictLoading->check($extraLazyOperation === null
+            ? LazyLoad::collection($mapping->sourceEntity, $mapping->fieldName)
+            : LazyLoad::collectionQuery($mapping->sourceEntity, $mapping->fieldName, $extraLazyOperation));
+    }
+
+    /**
      * INTERNAL:
      * Adds an element to a collection during hydration. This will automatically
      * complete bidirectional associations in the case of a one-to-many association.
@@ -184,6 +208,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         if ($this->initialized || ! $this->association) {
             return;
         }
+
+        $this->checkStrictLoading();
 
         $this->doInitialize();
 
@@ -344,6 +370,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             ! $this->initialized && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY
             && isset($this->getMapping()->indexBy)
         ) {
+            $this->checkStrictLoading('containsKey');
+
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $this->unwrap()->containsKey($key) || $persister->containsKey($this, $key);
@@ -355,6 +383,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function contains(mixed $element): bool
     {
         if (! $this->initialized && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $this->checkStrictLoading('contains');
+
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $this->unwrap()->contains($element) || $persister->contains($this, $element);
@@ -372,7 +402,12 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         ) {
             assert($this->em !== null);
             assert($this->typeClass !== null);
-            if (! $this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->getMapping()->indexBy)) {
+
+            $indexBy = $this->getMapping()->indexBy;
+
+            $this->checkStrictLoading('get');
+
+            if (! $this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($indexBy)) {
                 return $this->em->find($this->typeClass->name, $key);
             }
 
@@ -385,6 +420,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function count(): int
     {
         if (! $this->initialized && $this->association !== null && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $this->checkStrictLoading('count');
+
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->association);
 
             return $persister->count($this) + ($this->isDirty ? $this->unwrap()->count() : 0);
@@ -508,6 +545,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function first(): mixed
     {
         if (! $this->initialized && ! $this->isDirty && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $this->checkStrictLoading('first');
+
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return array_values($persister->slice($this, 0, 1))[0] ?? false;
@@ -529,6 +568,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function slice(int $offset, int|null $length = null): array
     {
         if (! $this->initialized && ! $this->isDirty && $this->getMapping()->fetch === ClassMetadata::FETCH_EXTRA_LAZY) {
+            $this->checkStrictLoading('slice');
+
             $persister = $this->getUnitOfWork()->getCollectionPersister($this->getMapping());
 
             return $persister->slice($this, $offset, $length);
@@ -579,6 +620,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         if ($this->initialized) {
             return $this->unwrap()->matching($criteria);
         }
+
+        // Filtering an uninitialized association queries the database, just like
+        // loading it would.
+        $this->checkStrictLoading('matching');
 
         $association = $this->getMapping();
         if ($association->isManyToMany()) {

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM;
+
+use Doctrine\ORM\Internal\AssociationBatchLoader;
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
+
+use function array_values;
+use function assert;
+use function explode;
+use function spl_object_id;
+
+/**
+ * Loads associations of entities that are already in memory, in as few queries
+ * as possible.
+ *
+ * Fetch joins and the eager fetch modes only help while a query is being
+ * hydrated. This is for everything else: entities that came from a repository
+ * method, a paginator, the second level cache, or a previous preload.
+ *
+ *     $users = $repository->findAll();
+ *     $entityManager->preload($users, ['articles.comments', 'address']);
+ *
+ * A preload always loads the whole association, because it marks collections as
+ * initialized. Use {@see PersistentCollection::matching()} when a filtered
+ * subset is what you need.
+ */
+final class Preloader
+{
+    private readonly AssociationBatchLoader $batchLoader;
+    private readonly UnitOfWork $uow;
+
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+        $this->uow         = $em->getUnitOfWork();
+        $this->batchLoader = new AssociationBatchLoader($em, $this->uow);
+    }
+
+    /**
+     * Loads the given association paths for all given entities.
+     *
+     * A path may walk several associations: 'articles.comments' loads the
+     * articles of every entity, then the comments of every article that was
+     * loaded. Passing no path at all initializes the entities themselves, which
+     * is useful for a list of references.
+     *
+     * @param iterable<object> $entities
+     * @param list<string>     $paths
+     */
+    public function preload(iterable $entities, array $paths = []): void
+    {
+        $entities = $this->managedEntities($entities);
+
+        if ($entities === []) {
+            return;
+        }
+
+        // Preloading is an explicit fetch, so it is never a strict loading violation.
+        $this->em->getConfiguration()->getStrictLoading()->allow(function () use ($entities, $paths): void {
+            $this->initializeEntities($entities);
+
+            foreach ($paths as $path) {
+                $current = $entities;
+
+                foreach (explode('.', $path) as $fieldName) {
+                    if ($current === []) {
+                        break;
+                    }
+
+                    $current = $this->loadAssociation($current, $fieldName, $path);
+                }
+            }
+        });
+    }
+
+    /**
+     * Loads one association for the given entities and returns the entities on
+     * the other side of it.
+     *
+     * @param iterable<object> $entities
+     *
+     * @return list<object>
+     */
+    public function preloadAssociation(iterable $entities, string $fieldName): array
+    {
+        $entities = $this->managedEntities($entities);
+
+        if ($entities === []) {
+            return [];
+        }
+
+        return $this->em->getConfiguration()->getStrictLoading()->allow(function () use ($entities, $fieldName): array {
+            $this->initializeEntities($entities);
+
+            return $this->loadAssociation($entities, $fieldName, $fieldName);
+        });
+    }
+
+    /**
+     * @param list<object> $entities
+     *
+     * @return list<object>
+     */
+    private function loadAssociation(array $entities, string $fieldName, string $path): array
+    {
+        $targets = [];
+
+        foreach ($this->groupByAssociation($entities, $fieldName, $path) as [$mapping, $group]) {
+            foreach ($this->loadGroup($group, $mapping) as $target) {
+                $targets[spl_object_id($target)] = $target;
+            }
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * Entities of different classes - and entities of one class hierarchy - can
+     * share an association, but they have to be loaded per mapping.
+     *
+     * @param list<object> $entities
+     *
+     * @return list<array{AssociationMapping, list<object>}>
+     */
+    private function groupByAssociation(array $entities, string $fieldName, string $path): array
+    {
+        $groups   = [];
+        $mappings = [];
+
+        foreach ($entities as $entity) {
+            $class = $this->em->getClassMetadata($entity::class);
+
+            if (! isset($class->associationMappings[$fieldName])) {
+                throw ORMInvalidArgumentException::preloadOfUnknownAssociation($class->name, $fieldName, $path);
+            }
+
+            $mapping = $class->associationMappings[$fieldName];
+            $key     = $mapping->sourceEntity . '#' . $fieldName;
+
+            $mappings[$key] = $mapping;
+            $groups[$key][] = $entity;
+        }
+
+        $result = [];
+
+        foreach ($groups as $key => $group) {
+            $result[] = [$mappings[$key], $group];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<object> $entities
+     *
+     * @return list<object>
+     */
+    private function loadGroup(array $entities, AssociationMapping $mapping): array
+    {
+        if ($mapping->isToMany()) {
+            return $this->loadCollections($entities, $mapping);
+        }
+
+        if (! $mapping->isOwningSide()) {
+            return $this->walkInverseToOne($entities, $mapping);
+        }
+
+        return $this->loadToOne($entities, $mapping);
+    }
+
+    /**
+     * @param list<object> $entities
+     *
+     * @return list<object>
+     */
+    private function loadToOne(array $entities, AssociationMapping $mapping): array
+    {
+        $accessor   = $this->em->getClassMetadata($mapping->sourceEntity)->getPropertyAccessor($mapping->fieldName);
+        $targets    = [];
+        $idsByClass = [];
+        $fallbacks  = [];
+
+        foreach ($entities as $entity) {
+            $target = $accessor?->getValue($entity);
+
+            if ($target === null) {
+                continue;
+            }
+
+            $targets[spl_object_id($target)] = $target;
+
+            if (! $this->uow->isUninitializedObject($target)) {
+                continue;
+            }
+
+            $targetClass = $this->em->getClassMetadata($target::class);
+
+            if ($targetClass->isIdentifierComposite) {
+                // A composite identifier cannot be expressed as one IN () condition.
+                $fallbacks[] = $target;
+
+                continue;
+            }
+
+            $identifier = $this->uow->getEntityIdentifier($target);
+
+            $idsByClass[$targetClass->name][] = $identifier[$targetClass->identifier[0]];
+        }
+
+        foreach ($idsByClass as $className => $ids) {
+            $this->batchLoader->initializeEntities($className, $ids);
+        }
+
+        foreach ($fallbacks as $target) {
+            $this->uow->initializeObject($target);
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * The inverse side of a to-one association is never lazy: the ORM loads it
+     * while hydrating the owner, with one query per owner (see
+     * {@see UnitOfWork::createEntity()}). There is consequently nothing to
+     * preload - a null value means there is no row, not that it was not loaded -
+     * so this only walks to the other side, for paths that continue there.
+     *
+     * @param list<object> $entities
+     *
+     * @return list<object>
+     */
+    private function walkInverseToOne(array $entities, AssociationMapping $mapping): array
+    {
+        $accessor = $this->em->getClassMetadata($mapping->sourceEntity)->getPropertyAccessor($mapping->fieldName);
+        $targets  = [];
+
+        foreach ($entities as $entity) {
+            $target = $accessor?->getValue($entity);
+
+            if ($target !== null) {
+                $targets[spl_object_id($target)] = $target;
+            }
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * @param list<object> $entities
+     *
+     * @return list<object>
+     */
+    private function loadCollections(array $entities, AssociationMapping $mapping): array
+    {
+        assert($mapping instanceof ToManyAssociationMapping);
+
+        $class       = $this->em->getClassMetadata($mapping->sourceEntity);
+        $accessor    = $class->getPropertyAccessor($mapping->fieldName);
+        $collections = [];
+        $loaded      = [];
+        $canBatch    = $this->batchLoader->canBatchLoad($mapping);
+
+        foreach ($entities as $entity) {
+            $collection = $accessor?->getValue($entity);
+
+            if (! $collection instanceof PersistentCollection) {
+                continue;
+            }
+
+            $loaded[] = $collection;
+
+            if ($collection->isInitialized()) {
+                continue;
+            }
+
+            if ($collection->isDirty() || ! $canBatch) {
+                // Batch loading a dirty collection would take a snapshot that
+                // contradicts the pending changes, and an association with a
+                // composite key cannot be batched at all.
+                $collection->initialize();
+
+                continue;
+            }
+
+            $collections[$this->batchLoader->identifierHash($class, $entity)] = $collection;
+        }
+
+        $this->batchLoader->loadCollections($collections, $mapping);
+
+        $targets = [];
+
+        foreach ($loaded as $collection) {
+            foreach ($collection as $target) {
+                $targets[spl_object_id($target)] = $target;
+            }
+        }
+
+        return array_values($targets);
+    }
+
+    /**
+     * Uninitialized entities have to be loaded before their associations can be
+     * read - and loading them one by one is the very thing to avoid here.
+     *
+     * @param list<object> $entities
+     */
+    private function initializeEntities(array $entities): void
+    {
+        $idsByClass = [];
+        $fallbacks  = [];
+
+        foreach ($entities as $entity) {
+            if (! $this->uow->isUninitializedObject($entity)) {
+                continue;
+            }
+
+            $class = $this->em->getClassMetadata($entity::class);
+
+            if ($class->isIdentifierComposite) {
+                $fallbacks[] = $entity;
+
+                continue;
+            }
+
+            $identifier                 = $this->uow->getEntityIdentifier($entity);
+            $idsByClass[$class->name][] = $identifier[$class->identifier[0]];
+        }
+
+        foreach ($idsByClass as $className => $ids) {
+            $this->batchLoader->initializeEntities($className, $ids);
+        }
+
+        foreach ($fallbacks as $entity) {
+            $this->uow->initializeObject($entity);
+        }
+    }
+
+    /**
+     * @param iterable<object> $entities
+     *
+     * @return list<object>
+     */
+    private function managedEntities(iterable $entities): array
+    {
+        $managed = [];
+
+        foreach ($entities as $entity) {
+            // New and detached entities have nothing to preload for.
+            if ($this->uow->getEntityState($entity, UnitOfWork::STATE_DETACHED) === UnitOfWork::STATE_MANAGED) {
+                $managed[] = $entity;
+            }
+        }
+
+        return $managed;
+    }
+}

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\StrictLoading\LazyLoad;
+use Doctrine\ORM\StrictLoading\StrictLoading;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\ClassMetadata;
@@ -255,13 +257,17 @@ EOPHP;
             $classMetadata       = $this->em->getClassMetadata($className);
             $entityPersister     = $this->uow->getEntityPersister($className);
             $identifierFlattener = $this->identifierFlattener;
+            $strictLoading       = $this->em->getConfiguration()->getStrictLoading();
 
             $proxy = $classMetadata->reflClass->newLazyGhost(static function (object $object) use (
                 $identifier,
                 $entityPersister,
                 $identifierFlattener,
                 $classMetadata,
+                $strictLoading,
             ): void {
+                $strictLoading->check(LazyLoad::entity($classMetadata->getName(), $identifier));
+
                 $original = $entityPersister->loadById($identifier, $object);
                 if ($original === null) {
                     throw EntityNotFoundException::fromClassNameAndIdentifier(
@@ -333,9 +339,11 @@ EOPHP;
      *
      * @throws EntityNotFoundException
      */
-    private function createLazyInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister, IdentifierFlattener $identifierFlattener): Closure
+    private function createLazyInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister, IdentifierFlattener $identifierFlattener, StrictLoading $strictLoading): Closure
     {
-        return static function (InternalProxy $proxy, array $identifier) use ($entityPersister, $classMetadata, $identifierFlattener): void {
+        return static function (InternalProxy $proxy, array $identifier) use ($entityPersister, $classMetadata, $identifierFlattener, $strictLoading): void {
+            $strictLoading->check(LazyLoad::entity($classMetadata->getName(), $identifier));
+
             $original = $entityPersister->loadById($identifier);
 
             if ($original === null) {
@@ -404,7 +412,7 @@ EOPHP;
 
         $className        = $class->getName(); // aliases and case sensitivity
         $entityPersister  = $this->uow->getEntityPersister($className);
-        $initializer      = $this->createLazyInitializer($class, $entityPersister, $this->identifierFlattener);
+        $initializer      = $this->createLazyInitializer($class, $entityPersister, $this->identifierFlattener, $this->em->getConfiguration()->getStrictLoading());
         $proxyClassName   = $this->loadProxyClass($class);
         $identifierFields = [];
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -131,6 +131,13 @@ class QueryBuilder implements Stringable
     private array $hints = [];
 
     /**
+     * Association paths to preload on the result, see {@see self::preload()}.
+     *
+     * @var list<string>
+     */
+    private array $preload = [];
+
+    /**
      * Initializes a new <tt>QueryBuilder</tt> that uses the given <tt>EntityManager</tt>.
      *
      * @param EntityManagerInterface $em The EntityManager to use.
@@ -300,6 +307,25 @@ class QueryBuilder implements Stringable
     }
 
     /**
+     * Preloads the given association paths on the entities this query returns.
+     *
+     * See {@see AbstractQuery::preload()}; the paths are handed to the Query this
+     * builder creates:
+     *
+     *     $qb->select('u')->from(User::class, 'u')->preload(['articles.comments']);
+     *
+     * @param list<string> $paths
+     */
+    public function preload(array $paths): static
+    {
+        foreach ($paths as $path) {
+            $this->preload[] = $path;
+        }
+
+        return $this;
+    }
+
+    /**
      * Constructs a Query instance from the current specifications of the builder.
      *
      * <code>
@@ -336,6 +362,10 @@ class QueryBuilder implements Stringable
 
         foreach ($this->hints as $name => $value) {
             $query->setHint($name, $value);
+        }
+
+        if ($this->preload !== []) {
+            $query->preload($this->preload);
         }
 
         return $query;

--- a/src/StrictLoading/LazyLoad.php
+++ b/src/StrictLoading/LazyLoad.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+use function array_values;
+use function count;
+use function get_debug_type;
+use function implode;
+use function is_scalar;
+use function sprintf;
+
+/**
+ * Describes a lazy load that the ORM is about to perform.
+ *
+ * Instances are handed to {@see StrictLoadingViolationHandler} when strict
+ * loading rejects the load.
+ */
+final class LazyLoad
+{
+    /**
+     * @param class-string        $className  The entity class that is being loaded, or the class
+     *                                        owning the collection that is being loaded.
+     * @param array<string,mixed> $identifier The identifier of the entity being loaded, if known.
+     */
+    private function __construct(
+        public readonly LazyLoadKind $kind,
+        public readonly string $className,
+        public readonly string|null $fieldName = null,
+        public readonly array $identifier = [],
+        public readonly string|null $operation = null,
+    ) {
+    }
+
+    /**
+     * @param class-string        $className
+     * @param array<string,mixed> $identifier
+     */
+    public static function entity(string $className, array $identifier): self
+    {
+        return new self(LazyLoadKind::Entity, $className, identifier: $identifier);
+    }
+
+    /** @param class-string $ownerClassName */
+    public static function collection(string $ownerClassName, string $fieldName): self
+    {
+        return new self(LazyLoadKind::Collection, $ownerClassName, $fieldName);
+    }
+
+    /** @param class-string $ownerClassName */
+    public static function collectionQuery(string $ownerClassName, string $fieldName, string $operation): self
+    {
+        return new self(LazyLoadKind::CollectionQuery, $ownerClassName, $fieldName, operation: $operation);
+    }
+
+    /**
+     * A key identifying the *shape* of this lazy load, ignoring the concrete
+     * identifier values. Two lazy loads sharing a signature within the same
+     * strict loading scope form an N+1 query.
+     */
+    public function signature(): string
+    {
+        return $this->kind->value . ' ' . $this->className
+            . ($this->fieldName === null ? '' : '#' . $this->fieldName)
+            . ($this->operation === null ? '' : '::' . $this->operation . '()');
+    }
+
+    public function describe(): string
+    {
+        return match ($this->kind) {
+            LazyLoadKind::Entity => sprintf(
+                'entity %s%s',
+                $this->className,
+                $this->identifier === [] ? '' : '(' . $this->identifierAsString() . ')',
+            ),
+            LazyLoadKind::Collection => sprintf('collection %s#%s', $this->className, $this->fieldName),
+            LazyLoadKind::CollectionQuery => sprintf(
+                '%s() on collection %s#%s',
+                (string) $this->operation,
+                $this->className,
+                (string) $this->fieldName,
+            ),
+        };
+    }
+
+    private function identifierAsString(): string
+    {
+        if (count($this->identifier) === 1) {
+            return self::stringify(array_values($this->identifier)[0]);
+        }
+
+        $parts = [];
+
+        foreach ($this->identifier as $field => $value) {
+            $parts[] = $field . ': ' . self::stringify($value);
+        }
+
+        return implode(', ', $parts);
+    }
+
+    private static function stringify(mixed $value): string
+    {
+        return match (true) {
+            $value === null => 'NULL',
+            $value === true => 'true',
+            $value === false => 'false',
+            is_scalar($value) => (string) $value,
+            default => get_debug_type($value),
+        };
+    }
+}

--- a/src/StrictLoading/LazyLoadKind.php
+++ b/src/StrictLoading/LazyLoadKind.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+/** The kind of lazy load that was attempted. */
+enum LazyLoadKind: string
+{
+    /** An uninitialized entity (a reference/proxy) was about to be loaded. */
+    case Entity = 'entity';
+
+    /** An uninitialized collection was about to be loaded entirely. */
+    case Collection = 'collection';
+
+    /**
+     * An operation on an uninitialized EXTRA_LAZY collection was about to
+     * issue its own query (count(), contains(), slice(), …).
+     */
+    case CollectionQuery = 'collection query';
+}

--- a/src/StrictLoading/LogViolation.php
+++ b/src/StrictLoading/LogViolation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Logs strict loading violations and lets the lazy load happen.
+ *
+ * Use this to introduce strict loading into an existing application without
+ * breaking it, e.g. in production while {@see ThrowOnViolation} is used in
+ * development and in the test suite.
+ */
+final class LogViolation implements StrictLoadingViolationHandler
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly string $level = LogLevel::WARNING,
+    ) {
+    }
+
+    public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+    {
+        $this->logger->log($this->level, 'Strict loading violation: lazily loading {load}.', [
+            'load' => $lazyLoad->describe(),
+            'kind' => $lazyLoad->kind->value,
+            'class' => $lazyLoad->className,
+            'field' => $lazyLoad->fieldName,
+            'mode' => $mode->name,
+        ]);
+    }
+}

--- a/src/StrictLoading/StrictLoading.php
+++ b/src/StrictLoading/StrictLoading.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+/**
+ * Runtime configuration and bookkeeping for strict loading.
+ *
+ * Strict loading turns implicit database access - lazily initialized entities
+ * and collections - into a reported violation. It is meant to be switched on
+ * for the part of a request that must not query the database anymore (template
+ * rendering, serialization, …) and for test suites, so that N+1 queries are
+ * caught while writing the code instead of in production.
+ *
+ * The object is intentionally mutable: it is retrieved from
+ * {@see \Doctrine\ORM\Configuration::getStrictLoading()} and can be
+ * reconfigured at any point during a request.
+ */
+final class StrictLoading
+{
+    private StrictLoadingViolationHandler $violationHandler;
+
+    /**
+     * Number of nested scopes that suspend strict loading.
+     *
+     * ORM internals (flushing, cascades, explicit initialization) suspend
+     * strict loading, and so does {@see self::allow()}.
+     */
+    private int $suspended = 0;
+
+    /** @var array<string,int> Lazy load signatures seen in the current scope, see {@see LazyLoad::signature()}. */
+    private array $seen = [];
+
+    public function __construct(
+        private StrictLoadingMode $mode = StrictLoadingMode::Disabled,
+        StrictLoadingViolationHandler|null $violationHandler = null,
+    ) {
+        $this->violationHandler = $violationHandler ?? new ThrowOnViolation();
+    }
+
+    public function getMode(): StrictLoadingMode
+    {
+        return $this->mode;
+    }
+
+    public function setMode(StrictLoadingMode $mode): void
+    {
+        $this->mode = $mode;
+    }
+
+    public function getViolationHandler(): StrictLoadingViolationHandler
+    {
+        return $this->violationHandler;
+    }
+
+    public function setViolationHandler(StrictLoadingViolationHandler $violationHandler): void
+    {
+        $this->violationHandler = $violationHandler;
+    }
+
+    /** Whether lazy loads are currently reported. */
+    public function isActive(): bool
+    {
+        return $this->mode !== StrictLoadingMode::Disabled && $this->suspended === 0;
+    }
+
+    /**
+     * Runs the given callback with strict loading temporarily switched off.
+     *
+     * This is the escape hatch for code that knowingly lazy loads, e.g. a
+     * fallback path or a legacy corner of an application that is not worth
+     * rewriting yet.
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     *
+     * @template T
+     */
+    public function allow(callable $callback): mixed
+    {
+        $this->suspend();
+
+        try {
+            return $callback();
+        } finally {
+            $this->resume();
+        }
+    }
+
+    /**
+     * Forgets which lazy loads have been seen, which starts a new scope for
+     * {@see StrictLoadingMode::NPlusOneOnly}.
+     */
+    public function reset(): void
+    {
+        $this->seen = [];
+    }
+
+    /**
+     * INTERNAL: suspends strict loading until the matching {@see self::resume()}.
+     *
+     * @internal
+     */
+    public function suspend(): void
+    {
+        ++$this->suspended;
+    }
+
+    /**
+     * INTERNAL: ends a scope opened by {@see self::suspend()}.
+     *
+     * @internal
+     */
+    public function resume(): void
+    {
+        if ($this->suspended > 0) {
+            --$this->suspended;
+        }
+    }
+
+    /**
+     * INTERNAL: reports a lazy load the ORM is about to perform.
+     *
+     * Depending on the configured mode and violation handler this either
+     * returns (the load may happen), or the handler throws.
+     *
+     * @internal called by the ORM at every lazy loading entry point
+     */
+    public function check(LazyLoad $lazyLoad): void
+    {
+        if (! $this->isActive()) {
+            return;
+        }
+
+        if ($this->mode === StrictLoadingMode::NPlusOneOnly) {
+            $signature = $lazyLoad->signature();
+
+            if (! isset($this->seen[$signature])) {
+                $this->seen[$signature] = 1;
+
+                return;
+            }
+
+            ++$this->seen[$signature];
+        }
+
+        // Do not report violations that happen while reporting a violation.
+        $this->suspend();
+
+        try {
+            $this->violationHandler->violation($lazyLoad, $this->mode);
+        } finally {
+            $this->resume();
+        }
+    }
+}

--- a/src/StrictLoading/StrictLoadingMode.php
+++ b/src/StrictLoading/StrictLoadingMode.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+/**
+ * How strictly the ORM should react to lazy loading.
+ *
+ * @see StrictLoading
+ */
+enum StrictLoadingMode
+{
+    /**
+     * Lazy loading is allowed. This is the historical (and default) behavior.
+     */
+    case Disabled;
+
+    /**
+     * Only report lazy loads that repeat the same query shape.
+     *
+     * The first lazy load of a given association (or of a given entity class,
+     * for to-one references) is allowed, every following one is reported. This
+     * is the mode to run in an existing application: it only complains about
+     * loads that actually degrade into an N+1 query.
+     */
+    case NPlusOneOnly;
+
+    /**
+     * Report every lazy load. Comparable to Rails' `strict_loading` default
+     * mode: all data has to be fetched explicitly, up front.
+     */
+    case All;
+}

--- a/src/StrictLoading/StrictLoadingViolationHandler.php
+++ b/src/StrictLoading/StrictLoadingViolationHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+/**
+ * Decides what happens when strict loading detects a lazy load.
+ *
+ * Implementations either throw (see {@see ThrowOnViolation}) or record the
+ * violation and let the ORM proceed with the load (see {@see LogViolation}).
+ */
+interface StrictLoadingViolationHandler
+{
+    public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void;
+}

--- a/src/StrictLoading/ThrowOnViolation.php
+++ b/src/StrictLoading/ThrowOnViolation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\StrictLoading;
+
+use Doctrine\ORM\Exception\StrictLoadingViolation;
+
+/** Turns every strict loading violation into an exception. */
+final class ThrowOnViolation implements StrictLoadingViolationHandler
+{
+    public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+    {
+        throw StrictLoadingViolation::fromLazyLoad($lazyLoad, $mode);
+    }
+}

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\Exception\EntityIdentityCollisionException;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\Exception\UnexpectedAssociationValue;
 use Doctrine\ORM\Id\AssignedGenerator;
+use Doctrine\ORM\Internal\AssociationBatchLoader;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Internal\StronglyConnectedComponents;
 use Doctrine\ORM\Internal\TopologicalSort;
@@ -37,7 +38,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use Doctrine\ORM\Mapping\PropertyAccessors\ReadonlyAccessor;
-use Doctrine\ORM\Mapping\ToManyInverseSideMapping;
+use Doctrine\ORM\Mapping\ToManyAssociationMapping;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
 use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
@@ -55,7 +56,6 @@ use Stringable;
 use Symfony\Component\VarExporter\Hydrator;
 use UnexpectedValueException;
 
-use function array_chunk;
 use function array_combine;
 use function array_diff_key;
 use function array_filter;
@@ -67,7 +67,6 @@ use function array_map;
 use function array_sum;
 use function array_values;
 use function assert;
-use function count;
 use function current;
 use function deepclone_hydrate;
 use function extension_loaded;
@@ -323,8 +322,16 @@ class UnitOfWork implements PropertyChangedListener
      */
     private array $eagerLoadingEntities = [];
 
-    /** @var array<string, array<string, mixed>> */
+    /** @var array<string, array{items: array<string, PersistentCollection<array-key, object>>, mapping: AssociationMapping&ToManyAssociationMapping}> */
     private array $eagerLoadingCollections = [];
+
+    /**
+     * How many hydrations are currently running. Hydrating one row can start
+     * another hydration, see {@see enterHydration()}.
+     */
+    private int $hydrationDepth = 0;
+
+    private readonly AssociationBatchLoader $associationBatchLoader;
 
     protected bool $hasCache = false;
 
@@ -345,6 +352,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->listenersInvoker         = new ListenersInvoker($em);
         $this->hasCache                 = $em->getConfiguration()->isSecondLevelCacheEnabled();
         $this->identifierFlattener      = new IdentifierFlattener($this, $em->getMetadataFactory());
+        $this->associationBatchLoader   = new AssociationBatchLoader($em, $this);
         $this->hydrationCompleteHandler = new HydrationCompleteHandler($this->listenersInvoker, $em);
     }
 
@@ -364,6 +372,16 @@ class UnitOfWork implements PropertyChangedListener
      * @throws Exception
      */
     public function commit(): void
+    {
+        $this->withoutStrictLoading($this->doCommit(...));
+    }
+
+    /**
+     * Flushing loads data on purpose: computing change sets, cascading
+     * operations and orphan removal all initialize what they need. Strict
+     * loading is therefore suspended for the whole flush, see {@see commit()}.
+     */
+    private function doCommit(): void
     {
         $connection = $this->em->getConnection();
 
@@ -1837,7 +1855,9 @@ class UnitOfWork implements PropertyChangedListener
     {
         $visited = [];
 
-        $this->doPersist($entity, $visited);
+        $this->withoutStrictLoading(function () use ($entity, &$visited): void {
+            $this->doPersist($entity, $visited);
+        });
     }
 
     /**
@@ -1917,7 +1937,10 @@ class UnitOfWork implements PropertyChangedListener
     {
         $visited = [];
 
-        $this->doRemove($entity, $visited);
+        // Cascading a removal intentionally initializes collections and proxies.
+        $this->withoutStrictLoading(function () use ($entity, &$visited): void {
+            $this->doRemove($entity, $visited);
+        });
     }
 
     /**
@@ -2044,7 +2067,9 @@ class UnitOfWork implements PropertyChangedListener
     {
         $visited = [];
 
-        $this->doRefresh($entity, $visited, $lockMode);
+        $this->withoutStrictLoading(function () use ($entity, &$visited, $lockMode): void {
+            $this->doRefresh($entity, $visited, $lockMode);
+        });
     }
 
     /**
@@ -2292,6 +2317,12 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function lock(object $entity, LockMode|int $lockMode, DateTimeInterface|int|null $lockVersion = null): void
     {
+        $this->withoutStrictLoading(fn () => $this->doLock($entity, $lockMode, $lockVersion));
+    }
+
+    /** @phpstan-param LockMode::*|int $lockMode */
+    private function doLock(object $entity, LockMode|int $lockMode, DateTimeInterface|int|null $lockVersion = null): void
+    {
         if ($this->getEntityState($entity, self::STATE_DETACHED) !== self::STATE_MANAGED) {
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
@@ -2364,6 +2395,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->eagerLoadingEntities             =
         $this->eagerLoadingCollections          =
         $this->orphanRemovals                   = [];
+
+        $this->em->getConfiguration()->getStrictLoading()->reset();
 
         $this->eventDispatcher->dispatchEvent(Events::onClear, new OnClearEventArgs($this->em));
     }
@@ -2741,12 +2774,14 @@ class UnitOfWork implements PropertyChangedListener
 
                     if ($hints['fetchMode'][$class->name][$field] === ClassMetadata::FETCH_EAGER) {
                         if (
-                            $assoc->isOneToMany()
-                            // is iteration
-                            && ! (isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION])
-                            // is foreign key composite
-                            && ! ($targetClass->hasAssociation($assoc->mappedBy) && count($targetClass->getAssociationMapping($assoc->mappedBy)->joinColumns) > 1)
-                            && ! $assoc->isIndexed()
+                            // is iteration: rows are hydrated one by one, so there is
+                            // nothing to batch them with
+                            ! (isset($hints[Query::HINT_INTERNAL_ITERATION]) && $hints[Query::HINT_INTERNAL_ITERATION])
+                            // Loading from the second-level cache does not go through ObjectHydrator,
+                            // so deferred batch eager loads are never flushed there. Load immediately
+                            // instead (also allows hitting the collection cache region).
+                            && ! isset($hints[Query::HINT_CACHE_ENABLED])
+                            && $this->associationBatchLoader->canBatchLoad($pColl->getMapping())
                         ) {
                             $this->scheduleCollectionForBatchLoading($pColl, $class);
                         } else {
@@ -2772,97 +2807,32 @@ class UnitOfWork implements PropertyChangedListener
             return;
         }
 
+        // A nested hydration must not flush what the hydration around it is still
+        // collecting: doing so turns one batched query into one query per row.
+        if ($this->hydrationDepth > 1) {
+            return;
+        }
+
         // avoid infinite recursion
         $eagerLoadingEntities       = $this->eagerLoadingEntities;
         $this->eagerLoadingEntities = [];
 
         foreach ($eagerLoadingEntities as $entityName => $ids) {
-            if (! $ids) {
-                continue;
-            }
-
-            $class   = $this->em->getClassMetadata($entityName);
-            $batches = array_chunk($ids, $this->em->getConfiguration()->getEagerFetchBatchSize());
-
-            foreach ($batches as $batchedIds) {
-                $this->getEntityPersister($entityName)->loadAll(
-                    array_combine($class->identifier, [$batchedIds]),
-                );
-            }
+            $this->associationBatchLoader->initializeEntities($entityName, $ids);
         }
 
         $eagerLoadingCollections       = $this->eagerLoadingCollections; // avoid recursion
         $this->eagerLoadingCollections = [];
 
         foreach ($eagerLoadingCollections as $group) {
-            $this->eagerLoadCollections($group['items'], $group['mapping']);
-        }
-    }
-
-    /**
-     * Load all data into the given collections, according to the specified mapping
-     *
-     * @param PersistentCollection[] $collections
-     */
-    private function eagerLoadCollections(array $collections, ToManyInverseSideMapping $mapping): void
-    {
-        $targetEntity = $mapping->targetEntity;
-        $class        = $this->em->getClassMetadata($mapping->sourceEntity);
-        $mappedBy     = $mapping->mappedBy;
-
-        $batches = array_chunk($collections, $this->em->getConfiguration()->getEagerFetchBatchSize(), true);
-
-        foreach ($batches as $collectionBatch) {
-            $entities = [];
-
-            foreach ($collectionBatch as $collection) {
-                $entities[] = $collection->getOwner();
-            }
-
-            $found = $this->getEntityPersister($targetEntity)->loadAll([$mappedBy => $entities], $mapping->orderBy);
-
-            $targetClass    = $this->em->getClassMetadata($targetEntity);
-            $targetProperty = $targetClass->getPropertyAccessor($mappedBy);
-            assert($targetProperty !== null);
-
-            foreach ($found as $targetValue) {
-                $sourceEntity = $targetProperty->getValue($targetValue);
-
-                if ($sourceEntity === null && isset($targetClass->associationMappings[$mappedBy]->joinColumns)) {
-                    // case where the hydration $targetValue itself has not yet fully completed, for example
-                    // in case a bi-directional association is being hydrated and deferring eager loading is
-                    // not possible due to subclassing.
-                    $data = $this->getOriginalEntityData($targetValue);
-                    $id   = [];
-                    foreach ($targetClass->associationMappings[$mappedBy]->joinColumns as $joinColumn) {
-                        $id[] = $data[$joinColumn->name];
-                    }
-                } else {
-                    $id = $this->identifierFlattener->flattenIdentifier($class, $class->getIdentifierValues($sourceEntity));
-                }
-
-                $idHash = implode(' ', $id);
-
-                if ($mapping->indexBy !== null) {
-                    $indexByProperty = $targetClass->getPropertyAccessor($mapping->indexBy);
-                    assert($indexByProperty !== null);
-                    $collectionBatch[$idHash]->hydrateSet($indexByProperty->getValue($targetValue), $targetValue);
-                } else {
-                    $collectionBatch[$idHash]->add($targetValue);
-                }
-            }
-        }
-
-        foreach ($collections as $association) {
-            $association->setInitialized(true);
-            $association->takeSnapshot();
+            $this->associationBatchLoader->loadCollections($group['items'], $group['mapping']);
         }
     }
 
     /**
      * Initializes (loads) an uninitialized persistent collection of an entity.
      *
-     * @todo Maybe later move to EntityManager#initialize($proxyOrCollection). See DDC-733.
+     * @param PersistentCollection<array-key, object> $collection The collection to initialize.
      */
     public function loadCollection(PersistentCollection $collection): void
     {
@@ -3217,9 +3187,59 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * Runs an ORM-internal operation that is allowed to load data from the
+     * database, no matter how strict loading is configured.
+     *
+     * @param callable():T $operation
+     *
+     * @return T
+     *
+     * @template T
+     */
+    private function withoutStrictLoading(callable $operation): mixed
+    {
+        $strictLoading = $this->em->getConfiguration()->getStrictLoading();
+        $strictLoading->suspend();
+
+        try {
+            return $operation();
+        } finally {
+            $strictLoading->resume();
+        }
+    }
+
+    /**
+     * INTERNAL: tells the UnitOfWork that a hydration has started.
+     *
+     * @internal called by {@see \Doctrine\ORM\Internal\Hydration\AbstractHydrator}
+     */
+    public function enterHydration(): void
+    {
+        ++$this->hydrationDepth;
+    }
+
+    /**
+     * INTERNAL: tells the UnitOfWork that a hydration has finished.
+     *
+     * @internal called by {@see \Doctrine\ORM\Internal\Hydration\AbstractHydrator}
+     */
+    public function leaveHydration(): void
+    {
+        if ($this->hydrationDepth > 0) {
+            --$this->hydrationDepth;
+        }
+    }
+
+    /**
      * Helper method to initialize a lazy loading proxy or persistent collection.
      */
     public function initializeObject(object $obj): void
+    {
+        // Explicitly asking for initialization is never a strict loading violation.
+        $this->withoutStrictLoading(fn () => $this->doInitializeObject($obj));
+    }
+
+    private function doInitializeObject(object $obj): void
     {
         if ($obj instanceof InternalProxy) {
             $obj->__load();

--- a/tests/Tests/Models/BatchLoading/BatchLoadChild.php
+++ b/tests/Tests/Models/BatchLoading/BatchLoadChild.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\BatchLoading;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class BatchLoadChild
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column]
+    public string $code = '';
+
+    #[ORM\ManyToOne(targetEntity: BatchLoadOwner::class, inversedBy: 'children')]
+    public BatchLoadOwner|null $owner = null;
+
+    #[ORM\ManyToOne(targetEntity: BatchLoadOwner::class, inversedBy: 'indexedChildren')]
+    public BatchLoadOwner|null $indexedOwner = null;
+}

--- a/tests/Tests/Models/BatchLoading/BatchLoadOwner.php
+++ b/tests/Tests/Models/BatchLoading/BatchLoadOwner.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\BatchLoading;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use SortDirection;
+
+#[ORM\Entity]
+class BatchLoadOwner
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column]
+    public string $name = '';
+
+    /** @var Collection<int, BatchLoadChild> */
+    #[ORM\OneToMany(targetEntity: BatchLoadChild::class, mappedBy: 'owner')]
+    #[ORM\OrderBy(['code' => SortDirection::Ascending])]
+    public Collection $children;
+
+    /** @var Collection<string, BatchLoadChild> */
+    #[ORM\OneToMany(targetEntity: BatchLoadChild::class, mappedBy: 'indexedOwner', indexBy: 'code')]
+    #[ORM\OrderBy(['code' => SortDirection::Ascending])]
+    public Collection $indexedChildren;
+
+    /** @var Collection<int, BatchLoadTag> */
+    #[ORM\ManyToMany(targetEntity: BatchLoadTag::class, inversedBy: 'owners')]
+    #[ORM\OrderBy(['name' => SortDirection::Ascending])]
+    public Collection $tags;
+
+    #[ORM\OneToOne(targetEntity: BatchLoadProfile::class, mappedBy: 'owner')]
+    public BatchLoadProfile|null $profile = null;
+
+    public function __construct()
+    {
+        $this->children        = new ArrayCollection();
+        $this->indexedChildren = new ArrayCollection();
+        $this->tags            = new ArrayCollection();
+    }
+}

--- a/tests/Tests/Models/BatchLoading/BatchLoadProfile.php
+++ b/tests/Tests/Models/BatchLoading/BatchLoadProfile.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\BatchLoading;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class BatchLoadProfile
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column]
+    public string $bio = '';
+
+    #[ORM\OneToOne(targetEntity: BatchLoadOwner::class, inversedBy: 'profile')]
+    public BatchLoadOwner|null $owner = null;
+}

--- a/tests/Tests/Models/BatchLoading/BatchLoadTag.php
+++ b/tests/Tests/Models/BatchLoading/BatchLoadTag.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\BatchLoading;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use SortDirection;
+
+#[ORM\Entity]
+class BatchLoadTag
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public int|null $id = null;
+
+    #[ORM\Column]
+    public string $name = '';
+
+    /** @var Collection<int, BatchLoadOwner> */
+    #[ORM\ManyToMany(targetEntity: BatchLoadOwner::class, mappedBy: 'tags')]
+    #[ORM\OrderBy(['id' => SortDirection::Ascending])]
+    public Collection $owners;
+
+    public function __construct()
+    {
+        $this->owners = new ArrayCollection();
+    }
+}

--- a/tests/Tests/ORM/Functional/AssociationBatchLoadingTest.php
+++ b/tests/Tests/ORM/Functional/AssociationBatchLoadingTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadChild;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadOwner;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadTag;
+
+use function array_keys;
+use function array_map;
+
+/**
+ * Batched loading of associations, as used by the eager fetch modes.
+ */
+class AssociationBatchLoadingTest extends BatchLoadingTestCase
+{
+    /** @return list<BatchLoadOwner> */
+    private function loadOwnersWithEager(string $field): array
+    {
+        $this->_em->clear();
+
+        return $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o ORDER BY o.id')
+            ->setFetchMode(BatchLoadOwner::class, $field, ClassMetadata::FETCH_EAGER)
+            ->getResult();
+    }
+
+    public function testOneToManyIsBatchedEvenWhenTheOwnerHasAnInverseToOne(): void
+    {
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->loadOwnersWithEager('children');
+
+        // 1 root query + 4 inverse one-to-one loads + 1 batched collection load.
+        $this->assertQueryCount(6);
+
+        foreach ($owners as $owner) {
+            $index = $this->indexOf($owner);
+
+            self::assertTrue($owner->children->isInitialized());
+            self::assertSame(
+                [$index . 'a', $index . 'b'],
+                array_map(static fn (BatchLoadChild $c): string => $c->code, $owner->children->toArray()),
+            );
+        }
+
+        // Reading the collections adds no queries.
+        $this->assertQueryCount(6);
+    }
+
+    public function testIndexedOneToManyIsBatched(): void
+    {
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->loadOwnersWithEager('indexedChildren');
+
+        $this->assertQueryCount(6);
+
+        foreach ($owners as $owner) {
+            $index = $this->indexOf($owner);
+
+            self::assertSame(['i' . $index . 'a', 'i' . $index . 'b'], array_keys($owner->indexedChildren->toArray()));
+            self::assertSame('i' . $index . 'a', $owner->indexedChildren->get('i' . $index . 'a')->code);
+        }
+    }
+
+    public function testManyToManyIsBatched(): void
+    {
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->loadOwnersWithEager('tags');
+
+        // 1 root query + 4 inverse one-to-one loads + 1 join table query + 1 target query.
+        $this->assertQueryCount(7);
+
+        foreach ($owners as $owner) {
+            self::assertTrue($owner->tags->isInitialized());
+            self::assertSame(
+                ['alpha', 'beta', 'own ' . $this->indexOf($owner)],
+                array_map(static fn (BatchLoadTag $t): string => $t->name, $owner->tags->toArray()),
+            );
+        }
+
+        $this->assertQueryCount(7);
+    }
+
+    public function testManyToManySharesTargetInstancesBetweenCollections(): void
+    {
+        $owners = $this->loadOwnersWithEager('tags');
+
+        self::assertSame($owners[0]->tags->get(0), $owners[1]->tags->get(0), 'The shared tag is one instance.');
+    }
+
+    public function testManyToManyRespectsTheAssociationOrdering(): void
+    {
+        // tags is ordered by name; "own N" sorts after "alpha" and "beta".
+        foreach ($this->loadOwnersWithEager('tags') as $owner) {
+            self::assertSame(
+                ['alpha', 'beta', 'own ' . $this->indexOf($owner)],
+                array_map(static fn (BatchLoadTag $t): string => $t->name, $owner->tags->toArray()),
+            );
+        }
+    }
+
+    public function testManyToManyIsBatchedFromTheInverseSide(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $tags = $this->_em->createQuery('SELECT t FROM ' . BatchLoadTag::class . ' t WHERE t.name IN (:names) ORDER BY t.name')
+            ->setParameter('names', ['alpha', 'beta'])
+            ->setFetchMode(BatchLoadTag::class, 'owners', ClassMetadata::FETCH_EAGER)
+            ->getResult();
+
+        // 1 root query + 1 join table query + 1 target query. Tags have no
+        // inverse one-to-one, so nothing interrupts the batch.
+        $this->assertQueryCount(3);
+
+        self::assertCount(2, $tags);
+
+        foreach ($tags as $tag) {
+            self::assertCount(4, $tag->owners, 'Both shared tags belong to all four owners.');
+        }
+    }
+
+    public function testBatchLoadingSchedulesNoWrites(): void
+    {
+        $owners = $this->loadOwnersWithEager('tags');
+
+        foreach ($owners as $owner) {
+            self::assertFalse($owner->tags->isDirty(), 'A batch loaded collection is not dirty.');
+        }
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->flush();
+
+        $this->assertQueryCount(0, 'Batch loading must leave a correct snapshot behind.');
+    }
+
+    public function testEmptyCollectionsAreStillMarkedInitialized(): void
+    {
+        $lonely       = new BatchLoadOwner();
+        $lonely->name = 'lonely';
+        $this->_em->persist($lonely);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $owners = $this->loadOwnersWithEager('tags');
+
+        self::assertCount(5, $owners);
+        self::assertCount(0, $owners[4]->tags);
+        self::assertTrue($owners[4]->tags->isInitialized());
+    }
+
+    public function testIterationStillLoadsCollectionsOneByOne(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $query = $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o')
+            ->setFetchMode(BatchLoadOwner::class, 'children', ClassMetadata::FETCH_EAGER);
+
+        $seen = 0;
+
+        foreach ($query->toIterable() as $owner) {
+            self::assertCount(2, $owner->children);
+            ++$seen;
+        }
+
+        self::assertSame(4, $seen);
+
+        // Row-by-row iteration cannot batch across rows: 1 root + 4 profiles + 4 collections.
+        $this->assertQueryCount(9);
+    }
+
+    public function testLazyLoadingIsUnchanged(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o ORDER BY o.id')->getResult();
+
+        foreach ($owners as $owner) {
+            self::assertSame(
+                ['alpha', 'beta', 'own ' . $this->indexOf($owner)],
+                array_map(static fn (BatchLoadTag $t): string => $t->name, $owner->tags->toArray()),
+            );
+        }
+
+        // 1 root + 4 profiles + one lazy load per collection.
+        $this->assertQueryCount(9);
+    }
+}

--- a/tests/Tests/ORM/Functional/BatchLoadingTestCase.php
+++ b/tests/Tests/ORM/Functional/BatchLoadingTestCase.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\BatchLoading\BatchLoadChild;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadOwner;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadProfile;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadTag;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function strlen;
+use function substr;
+
+/**
+ * Fixture for batched and explicit association loading.
+ *
+ * Four owners, each with two children, two indexed children, an inverse
+ * one-to-one profile and three tags - two of which are shared by every owner,
+ * so that fanning join table rows out to several collections is covered.
+ *
+ * The inverse one-to-one is deliberate: loading it starts a nested hydration in
+ * the middle of the outer one, which used to flush a deferred batch after a
+ * single owner.
+ */
+abstract class BatchLoadingTestCase extends OrmFunctionalTestCase
+{
+    protected const OWNER_COUNT = 4;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(
+            BatchLoadOwner::class,
+            BatchLoadChild::class,
+            BatchLoadTag::class,
+            BatchLoadProfile::class,
+        );
+
+        $this->emptyDatabase();
+        $this->createFixture();
+    }
+
+    private function emptyDatabase(): void
+    {
+        $connection = $this->_em->getConnection();
+        $joinTable  = $this->_em->getClassMetadata(BatchLoadOwner::class)->associationMappings['tags']->joinTable->name;
+
+        $connection->executeStatement('DELETE FROM ' . $joinTable);
+
+        foreach ([BatchLoadChild::class, BatchLoadProfile::class, BatchLoadOwner::class, BatchLoadTag::class] as $entity) {
+            $connection->executeStatement('DELETE FROM ' . $this->_em->getClassMetadata($entity)->getTableName());
+        }
+    }
+
+    private function createFixture(): void
+    {
+        $shared = [];
+
+        foreach (['alpha', 'beta'] as $name) {
+            $tag       = new BatchLoadTag();
+            $tag->name = $name;
+            $shared[]  = $tag;
+            $this->_em->persist($tag);
+        }
+
+        for ($i = 0; $i < self::OWNER_COUNT; $i++) {
+            $owner       = new BatchLoadOwner();
+            $owner->name = 'owner ' . $i;
+
+            $profile        = new BatchLoadProfile();
+            $profile->bio   = 'bio ' . $i;
+            $profile->owner = $owner;
+            $owner->profile = $profile;
+
+            foreach (['a', 'b'] as $suffix) {
+                $child        = new BatchLoadChild();
+                $child->code  = $i . $suffix;
+                $child->owner = $owner;
+                $owner->children->add($child);
+
+                $indexed               = new BatchLoadChild();
+                $indexed->code         = 'i' . $i . $suffix;
+                $indexed->indexedOwner = $owner;
+                $owner->indexedChildren->set($indexed->code, $indexed);
+
+                $this->_em->persist($child);
+                $this->_em->persist($indexed);
+            }
+
+            $own       = new BatchLoadTag();
+            $own->name = 'own ' . $i;
+            $this->_em->persist($own);
+
+            foreach ([...$shared, $own] as $tag) {
+                $owner->tags->add($tag);
+            }
+
+            $this->_em->persist($owner);
+            $this->_em->persist($profile);
+
+            $this->_em->flush();
+        }
+
+        $this->_em->clear();
+    }
+
+    /** @return list<BatchLoadOwner> */
+    protected function owners(): array
+    {
+        return $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o ORDER BY o.id')->getResult();
+    }
+
+    /** The number an owner was created with, so assertions do not depend on result order. */
+    protected function indexOf(BatchLoadOwner $owner): string
+    {
+        return substr($owner->name, strlen('owner '));
+    }
+}

--- a/tests/Tests/ORM/Functional/PreloadTest.php
+++ b/tests/Tests/ORM/Functional/PreloadTest.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use ArrayIterator;
+use Doctrine\ORM\Exception\StrictLoadingViolation;
+use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadChild;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadOwner;
+use Doctrine\Tests\Models\BatchLoading\BatchLoadTag;
+use LogicException;
+
+use function array_map;
+use function count;
+
+/** Explicitly loading associations of entities that are already in memory. */
+class PreloadTest extends BatchLoadingTestCase
+{
+    public function testPreloadACollectionInOneQuery(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['children']);
+
+        $this->assertQueryCount(1, 'One query for all four collections.');
+
+        foreach ($owners as $owner) {
+            self::assertTrue($owner->children->isInitialized());
+            self::assertCount(2, $owner->children);
+        }
+
+        $this->assertQueryCount(1);
+    }
+
+    public function testPreloadThroughAFinder(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->_em->getRepository(BatchLoadOwner::class)->findAll(preload: ['children']);
+
+        // One query for the owners, one for all four collections.
+        $this->assertQueryCount(2);
+
+        foreach ($owners as $owner) {
+            self::assertTrue($owner->children->isInitialized());
+            self::assertCount(2, $owner->children);
+        }
+
+        $this->assertQueryCount(2);
+    }
+
+    public function testPreloadThroughFindOneBy(): void
+    {
+        $this->_em->clear();
+
+        $owner = $this->_em->getRepository(BatchLoadOwner::class)
+            ->findOneBy(['name' => 'owner 1'], preload: ['children']);
+
+        self::assertNotNull($owner);
+
+        $this->getQueryLog()->reset()->enable();
+
+        self::assertCount(2, $owner->children);
+
+        $this->assertQueryCount(0, 'The collection was already preloaded.');
+    }
+
+    public function testPreloadThroughAQuery(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o')
+            ->preload(['children', 'tags'])
+            ->getResult();
+
+        // Five for the owners themselves - the inverse one-to-one profile is still
+        // loaded per row - then one for the children and two for the tags.
+        $this->assertQueryCount(8);
+
+        foreach ($owners as $owner) {
+            self::assertCount(2, $owner->children);
+            self::assertCount(3, $owner->tags);
+        }
+
+        $this->assertQueryCount(8);
+    }
+
+    public function testPreloadThroughTheQueryBuilder(): void
+    {
+        $this->_em->clear();
+        $this->getQueryLog()->reset()->enable();
+
+        $owners = $this->_em->getRepository(BatchLoadOwner::class)
+            ->createQueryBuilder('o')
+            ->preload(['children'])
+            ->getQuery()
+            ->getResult();
+
+        // Five for the owners, one for all four collections.
+        $this->assertQueryCount(6);
+
+        foreach ($owners as $owner) {
+            self::assertTrue($owner->children->isInitialized());
+        }
+
+        $this->assertQueryCount(6);
+    }
+
+    public function testPreloadIsAppliedToASingleResult(): void
+    {
+        $this->_em->clear();
+
+        $owner = $this->_em->createQuery(
+            'SELECT o FROM ' . BatchLoadOwner::class . ' o WHERE o.name = :name',
+        )->setParameter('name', 'owner 1')->preload(['children'])->getSingleResult();
+
+        $this->getQueryLog()->reset()->enable();
+
+        self::assertCount(2, $owner->children);
+
+        $this->assertQueryCount(0);
+    }
+
+    public function testPreloadRejectsIteration(): void
+    {
+        $query = $this->_em->createQuery('SELECT o FROM ' . BatchLoadOwner::class . ' o')
+            ->preload(['children']);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Preloading is not possible with toIterable()');
+
+        $query->toIterable();
+    }
+
+    public function testPreloadThroughTheRepository(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->getRepository(BatchLoadOwner::class)->preload($owners, ['children']);
+
+        $this->assertQueryCount(1, 'One query for all four collections.');
+
+        foreach ($owners as $owner) {
+            self::assertTrue($owner->children->isInitialized());
+            self::assertCount(2, $owner->children);
+        }
+
+        $this->assertQueryCount(1);
+    }
+
+    public function testPreloadAManyToManyCollection(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['tags']);
+
+        // One query for the join table, one for the tags themselves.
+        $this->assertQueryCount(2);
+
+        foreach ($owners as $owner) {
+            self::assertSame(
+                ['alpha', 'beta', 'own ' . $this->indexOf($owner)],
+                array_map(static fn (BatchLoadTag $t): string => $t->name, $owner->tags->toArray()),
+            );
+        }
+    }
+
+    public function testPreloadAToOneAssociation(): void
+    {
+        $children = $this->_em->createQuery(
+            'SELECT c FROM ' . BatchLoadChild::class . ' c WHERE c.owner IS NOT NULL',
+        )->getResult();
+
+        self::assertCount(8, $children);
+
+        foreach ($children as $child) {
+            self::assertTrue($this->_em->isUninitializedObject($child->owner));
+        }
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($children, ['owner']);
+
+        // Eight children, four distinct owners, one query.
+        $this->assertQueryCount(1);
+
+        foreach ($children as $child) {
+            self::assertFalse($this->_em->isUninitializedObject($child->owner));
+            self::assertStringStartsWith('owner ', $child->owner->name);
+        }
+    }
+
+    public function testPreloadingAnInverseToOneIsANoOp(): void
+    {
+        // The inverse side of a to-one association is not lazy: the ORM loads it
+        // while hydrating the owner. Preloading it has nothing left to do.
+        $owners = $this->owners();
+
+        foreach ($owners as $owner) {
+            self::assertNotNull($owner->profile);
+        }
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['profile']);
+
+        $this->assertQueryCount(0);
+    }
+
+    public function testPreloadWalksThroughAnInverseToOne(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        // profile is already there; owner is a reference on the other side of it.
+        $this->_em->preload($owners, ['profile.owner']);
+
+        $this->assertQueryCount(0, 'Both sides are in the identity map already.');
+
+        foreach ($owners as $owner) {
+            self::assertSame($owner, $owner->profile->owner);
+        }
+    }
+
+    public function testPreloadANestedPath(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['children.owner']);
+
+        // One query for the children of all owners, and the children's owner is
+        // already in the identity map, so nothing more.
+        $this->assertQueryCount(1);
+
+        foreach ($owners as $owner) {
+            foreach ($owner->children as $child) {
+                self::assertSame($owner, $child->owner);
+            }
+        }
+    }
+
+    public function testPreloadSeveralPaths(): void
+    {
+        $owners = $this->owners();
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['children', 'tags', 'profile']);
+
+        // children (1) + tags (2); the inverse one-to-one is already loaded.
+        $this->assertQueryCount(3);
+
+        foreach ($owners as $owner) {
+            self::assertCount(2, $owner->children);
+            self::assertCount(3, $owner->tags);
+            self::assertNotNull($owner->profile);
+        }
+    }
+
+    public function testPreloadWithoutAPathInitializesReferences(): void
+    {
+        $references = [];
+
+        foreach ($this->_em->createQuery('SELECT o.id FROM ' . BatchLoadOwner::class . ' o')->getScalarResult() as $row) {
+            $references[] = $this->_em->getReference(BatchLoadOwner::class, $row['id']);
+        }
+
+        self::assertCount(4, $references);
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($references);
+
+        $this->assertQueryCount(1, 'All four references are initialized by one query.');
+
+        foreach ($references as $reference) {
+            self::assertFalse($this->_em->isUninitializedObject($reference));
+        }
+    }
+
+    public function testPreloadInitializesReferencesBeforeReadingTheirAssociations(): void
+    {
+        $references = [];
+
+        foreach ($this->_em->createQuery('SELECT o.id FROM ' . BatchLoadOwner::class . ' o')->getScalarResult() as $row) {
+            $references[] = $this->_em->getReference(BatchLoadOwner::class, $row['id']);
+        }
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($references, ['children']);
+
+        // One query to initialize the references, one for their collections -
+        // instead of one query per reference.
+        $this->assertQueryCount(2);
+
+        foreach ($references as $reference) {
+            self::assertCount(2, $reference->children);
+        }
+    }
+
+    public function testPreloadingTwiceQueriesOnce(): void
+    {
+        $owners = $this->owners();
+
+        $this->_em->preload($owners, ['children']);
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload($owners, ['children']);
+
+        $this->assertQueryCount(0, 'Initialized collections are skipped.');
+    }
+
+    public function testPreloadSchedulesNoWrites(): void
+    {
+        $owners = $this->owners();
+
+        $this->_em->preload($owners, ['children', 'tags']);
+
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->flush();
+
+        $this->assertQueryCount(0, 'Preloading must leave a correct snapshot behind.');
+    }
+
+    public function testPreloadSkipsDirtyCollections(): void
+    {
+        $owners = $this->owners();
+
+        $child        = new BatchLoadChild();
+        $child->code  = 'new';
+        $child->owner = $owners[0];
+        $owners[0]->children->add($child);
+
+        self::assertTrue($owners[0]->children->isDirty());
+
+        $this->_em->preload($owners, ['children']);
+
+        // The dirty collection was loaded on its own and kept the new element.
+        self::assertCount(3, $owners[0]->children);
+        self::assertCount(2, $owners[1]->children);
+    }
+
+    public function testPreloadIsNotAStrictLoadingViolation(): void
+    {
+        $owners        = $this->owners();
+        $strictLoading = $this->_em->getConfiguration()->getStrictLoading();
+        $strictLoading->setMode(StrictLoadingMode::All);
+
+        try {
+            $this->_em->preload($owners, ['children', 'tags', 'profile']);
+
+            foreach ($owners as $owner) {
+                self::assertCount(2, $owner->children);
+                self::assertCount(3, $owner->tags);
+                self::assertNotNull($owner->profile);
+            }
+        } finally {
+            $strictLoading->setMode(StrictLoadingMode::Disabled);
+        }
+    }
+
+    public function testStrictLoadingStillRejectsWhatWasNotPreloaded(): void
+    {
+        $owners        = $this->owners();
+        $strictLoading = $this->_em->getConfiguration()->getStrictLoading();
+
+        $this->_em->preload($owners, ['children']);
+        $strictLoading->setMode(StrictLoadingMode::All);
+
+        try {
+            $this->expectException(StrictLoadingViolation::class);
+
+            $owners[0]->tags->toArray();
+        } finally {
+            $strictLoading->setMode(StrictLoadingMode::Disabled);
+        }
+    }
+
+    public function testPreloadingAnUnknownAssociationFails(): void
+    {
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Cannot preload "editor" of ' . BatchLoadChild::class
+            . ': there is no such association. It was reached through the path "children.editor".',
+        );
+
+        $this->_em->preload($this->owners(), ['children.editor']);
+    }
+
+    public function testPreloadingNothingIsHarmless(): void
+    {
+        $this->getQueryLog()->reset()->enable();
+
+        $this->_em->preload([], ['children']);
+        $this->_em->preload([new BatchLoadOwner()], ['children']);
+
+        $this->assertQueryCount(0, 'New and detached entities have nothing to preload.');
+    }
+
+    public function testPreloadAcceptsAnyIterable(): void
+    {
+        $owners = $this->owners();
+
+        $this->_em->preload(new ArrayIterator($owners), ['children']);
+
+        self::assertTrue($owners[0]->children->isInitialized());
+        self::assertSame(4, count($owners));
+    }
+}

--- a/tests/Tests/ORM/Functional/StrictLoadingTest.php
+++ b/tests/Tests/ORM/Functional/StrictLoadingTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Exception\StrictLoadingViolation;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\StrictLoading\LazyLoad;
+use Doctrine\ORM\StrictLoading\LazyLoadKind;
+use Doctrine\ORM\StrictLoading\StrictLoading;
+use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+use Doctrine\ORM\StrictLoading\StrictLoadingViolationHandler;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * Proof of concept for strict loading, see
+ * https://github.com/doctrine/orm/discussions/10931
+ */
+class StrictLoadingTest extends OrmFunctionalTestCase
+{
+    /** @var list<int> */
+    private array $userIds = [];
+
+    /** @var list<int> */
+    private array $articleIds = [];
+
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+
+        foreach (['alice', 'bob'] as $index => $username) {
+            $user           = new CmsUser();
+            $user->username = $username;
+            $user->name     = $username;
+            $user->status   = 'dev';
+
+            $phonenumber              = new CmsPhonenumber();
+            $phonenumber->phonenumber = '12345' . $index;
+            $user->addPhonenumber($phonenumber);
+
+            $article        = new CmsArticle();
+            $article->topic = 'Topic of ' . $username;
+            $article->text  = 'Text of ' . $username;
+            $article->setAuthor($user);
+
+            $this->_em->persist($user);
+            $this->_em->persist($article);
+
+            $this->_em->flush();
+
+            $this->userIds[]    = $user->id;
+            $this->articleIds[] = $article->id;
+        }
+
+        $this->_em->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->_em->getConfiguration()->getStrictLoading()->setMode(StrictLoadingMode::Disabled);
+
+        parent::tearDown();
+    }
+
+    private function strictLoading(StrictLoadingMode $mode = StrictLoadingMode::All): StrictLoading
+    {
+        $strictLoading = $this->_em->getConfiguration()->getStrictLoading();
+        $strictLoading->setMode($mode);
+        $strictLoading->reset();
+
+        return $strictLoading;
+    }
+
+    public function testLazyLoadingIsAllowedByDefault(): void
+    {
+        self::assertSame(
+            StrictLoadingMode::Disabled,
+            $this->_em->getConfiguration()->getStrictLoading()->getMode(),
+        );
+
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+
+        self::assertTrue($this->_em->isUninitializedObject($article->user));
+        self::assertSame('alice', $article->user->username);
+    }
+
+    public function testLoadingAToOneReferenceIsAViolation(): void
+    {
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+        self::assertTrue($this->_em->isUninitializedObject($article->user));
+
+        $this->strictLoading();
+
+        $this->expectException(StrictLoadingViolation::class);
+        $this->expectExceptionMessage('lazily loading entity ' . CmsUser::class . '(' . $this->userIds[0] . ')');
+
+        // @phpstan-ignore expr.resultUnused
+        $article->user->username;
+    }
+
+    public function testARejectedLazyLoadLeavesTheEntityUsable(): void
+    {
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+
+        $strictLoading = $this->strictLoading();
+
+        try {
+            // @phpstan-ignore expr.resultUnused
+            $article->user->username;
+            self::fail('Expected a strict loading violation.');
+        } catch (StrictLoadingViolation) {
+        }
+
+        // The failed initialization attempt must not have corrupted the entity:
+        // it is still an uninitialized reference and can be loaded afterwards.
+        self::assertTrue($this->_em->isUninitializedObject($article->user));
+        self::assertSame($this->userIds[0], $article->user->id);
+
+        $username = $strictLoading->allow(static fn (): string => $article->user->username);
+
+        self::assertSame('alice', $username);
+        self::assertFalse($this->_em->isUninitializedObject($article->user));
+    }
+
+    public function testLoadingACollectionIsAViolation(): void
+    {
+        $user = $this->_em->find(CmsUser::class, $this->userIds[0]);
+
+        $this->strictLoading();
+
+        $this->expectException(StrictLoadingViolation::class);
+        $this->expectExceptionMessage('lazily loading collection ' . CmsUser::class . '#articles');
+
+        $user->articles->toArray();
+    }
+
+    public function testARejectedCollectionLoadLeavesTheCollectionUsable(): void
+    {
+        $user = $this->_em->find(CmsUser::class, $this->userIds[0]);
+
+        $strictLoading = $this->strictLoading();
+
+        try {
+            $user->articles->toArray();
+            self::fail('Expected a strict loading violation.');
+        } catch (StrictLoadingViolation) {
+        }
+
+        self::assertFalse($user->articles->isInitialized());
+
+        $articles = $strictLoading->allow(static fn (): array => $user->articles->toArray());
+
+        self::assertCount(1, $articles);
+        self::assertTrue($user->articles->isInitialized());
+    }
+
+    public function testFetchJoinedDataIsNotAViolation(): void
+    {
+        $article = $this->_em->createQuery(
+            'SELECT a, u FROM ' . CmsArticle::class . ' a JOIN a.user u WHERE a.id = :id',
+        )->setParameter('id', $this->articleIds[0])->getSingleResult();
+
+        $user = $this->_em->createQuery(
+            'SELECT u, a FROM ' . CmsUser::class . ' u LEFT JOIN u.articles a WHERE u.id = :id',
+        )->setParameter('id', $this->userIds[0])->getSingleResult();
+
+        $this->strictLoading();
+
+        self::assertSame('alice', $article->user->username);
+        self::assertCount(1, $user->articles);
+    }
+
+    public function testEagerFetchModeIsNotAViolation(): void
+    {
+        $query = $this->_em->createQuery('SELECT a FROM ' . CmsArticle::class . ' a')
+            ->setFetchMode(CmsArticle::class, 'user', ClassMetadata::FETCH_EAGER);
+
+        $articles = $query->getResult();
+
+        $this->strictLoading();
+
+        foreach ($articles as $article) {
+            self::assertNotSame('', $article->user->username);
+        }
+    }
+
+    public function testNPlusOneOnlyModeAllowsASingleLazyLoad(): void
+    {
+        $this->strictLoading(StrictLoadingMode::NPlusOneOnly);
+
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+
+        self::assertSame('alice', $article->user->username);
+    }
+
+    public function testNPlusOneOnlyModeRejectsTheSecondLazyLoad(): void
+    {
+        $articles = $this->_em->createQuery('SELECT a FROM ' . CmsArticle::class . ' a ORDER BY a.id')->getResult();
+
+        $this->strictLoading(StrictLoadingMode::NPlusOneOnly);
+
+        self::assertSame('alice', $articles[0]->user->username);
+
+        $this->expectException(StrictLoadingViolation::class);
+        $this->expectExceptionMessage('which makes it an N+1 query');
+
+        // @phpstan-ignore expr.resultUnused
+        $articles[1]->user->username;
+    }
+
+    public function testLoggingHandlerLetsTheLoadHappen(): void
+    {
+        $users = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u ORDER BY u.id')->getResult();
+
+        $handler       = new CollectedViolations();
+        $strictLoading = $this->strictLoading();
+        $strictLoading->setViolationHandler($handler);
+
+        foreach ($users as $user) {
+            self::assertCount(1, $user->articles);
+        }
+
+        self::assertCount(2, $handler->violations);
+        self::assertSame(LazyLoadKind::Collection, $handler->violations[0]->kind);
+        self::assertSame(CmsUser::class, $handler->violations[0]->className);
+        self::assertSame('articles', $handler->violations[0]->fieldName);
+    }
+
+    public function testFlushIsNeverAViolation(): void
+    {
+        $user = $this->_em->find(CmsUser::class, $this->userIds[0]);
+
+        $this->strictLoading();
+
+        $user->name = 'changed';
+        $this->_em->flush();
+
+        self::assertFalse($user->articles->isInitialized());
+    }
+
+    public function testCascadingARemovalIsNeverAViolation(): void
+    {
+        $user    = $this->_em->find(CmsUser::class, $this->userIds[0]);
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+
+        $this->strictLoading();
+
+        // CmsUser::$phonenumbers uses orphanRemoval, so removing the user has to
+        // load the collection - which must not be reported as a violation.
+        self::assertFalse($user->phonenumbers->isInitialized());
+
+        $this->_em->remove($article);
+        $this->_em->remove($user);
+        $this->_em->flush();
+
+        self::assertTrue($user->phonenumbers->isInitialized());
+        self::assertNull($this->_em->find(CmsUser::class, $this->userIds[0]));
+    }
+
+    public function testExplicitInitializationIsNeverAViolation(): void
+    {
+        $article = $this->_em->find(CmsArticle::class, $this->articleIds[0]);
+        $user    = $this->_em->find(CmsUser::class, $this->userIds[1]);
+
+        $this->strictLoading();
+
+        $this->_em->refresh($user);
+        $this->_em->initializeObject($article->user);
+        $this->_em->initializeObject($user->articles);
+
+        self::assertFalse($this->_em->isUninitializedObject($article->user));
+        self::assertTrue($user->articles->isInitialized());
+    }
+
+    public function testExtraLazyCountIsReportedSeparately(): void
+    {
+        $metadata                                         = $this->_em->getClassMetadata(CmsUser::class);
+        $previousFetchMode                                = $metadata->associationMappings['articles']->fetch;
+        $metadata->associationMappings['articles']->fetch = ClassMetadata::FETCH_EXTRA_LAZY;
+
+        try {
+            $user = $this->_em->find(CmsUser::class, $this->userIds[0]);
+
+            $handler       = new CollectedViolations();
+            $strictLoading = $this->strictLoading();
+            $strictLoading->setViolationHandler($handler);
+
+            self::assertSame(1, $user->articles->count());
+
+            self::assertCount(1, $handler->violations);
+            self::assertSame(LazyLoadKind::CollectionQuery, $handler->violations[0]->kind);
+            self::assertSame('count', $handler->violations[0]->operation);
+        } finally {
+            $metadata->associationMappings['articles']->fetch = $previousFetchMode;
+        }
+    }
+
+    public function testStrictLoadingCanBeLimitedToAPartOfTheRequest(): void
+    {
+        $strictLoading = $this->_em->getConfiguration()->getStrictLoading();
+
+        // "Controller": fetch everything that the "view" is going to need.
+        $user = $this->_em->createQuery(
+            'SELECT u, a FROM ' . CmsUser::class . ' u LEFT JOIN u.articles a WHERE u.id = :id',
+        )->setParameter('id', $this->userIds[0])->getSingleResult();
+
+        // "View": no database access allowed from here on.
+        $strictLoading->setMode(StrictLoadingMode::All);
+
+        $rendered = $user->name;
+
+        foreach ($user->articles as $article) {
+            $rendered .= ' ' . $article->topic;
+        }
+
+        self::assertSame('alice Topic of alice', $rendered);
+    }
+}
+
+final class CollectedViolations implements StrictLoadingViolationHandler
+{
+    /** @var list<LazyLoad> */
+    public array $violations = [];
+
+    public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+    {
+        $this->violations[] = $lazyLoad;
+    }
+}

--- a/tests/Tests/ORM/StrictLoading/StrictLoadingTest.php
+++ b/tests/Tests/ORM/StrictLoading/StrictLoadingTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\StrictLoading;
+
+use Doctrine\ORM\Exception\StrictLoadingViolation;
+use Doctrine\ORM\StrictLoading\LazyLoad;
+use Doctrine\ORM\StrictLoading\LazyLoadKind;
+use Doctrine\ORM\StrictLoading\StrictLoading;
+use Doctrine\ORM\StrictLoading\StrictLoadingMode;
+use Doctrine\ORM\StrictLoading\StrictLoadingViolationHandler;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StrictLoadingTest extends TestCase
+{
+    public function testDisabledByDefault(): void
+    {
+        $strictLoading = new StrictLoading();
+
+        self::assertSame(StrictLoadingMode::Disabled, $strictLoading->getMode());
+        self::assertFalse($strictLoading->isActive());
+
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 1]));
+    }
+
+    public function testAllModeReportsEveryLazyLoad(): void
+    {
+        $handler       = new CollectViolations();
+        $strictLoading = new StrictLoading(StrictLoadingMode::All, $handler);
+
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 1]));
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 2]));
+        $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+
+        self::assertCount(3, $handler->violations);
+    }
+
+    public function testNPlusOneOnlyModeAllowsTheFirstLoadOfEachShape(): void
+    {
+        $handler       = new CollectViolations();
+        $strictLoading = new StrictLoading(StrictLoadingMode::NPlusOneOnly, $handler);
+
+        // First load of each shape is fine: it does not repeat.
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 1]));
+        $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+        self::assertCount(0, $handler->violations);
+
+        // Loading the same shape again is an N+1 query.
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 2]));
+        $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+
+        self::assertCount(2, $handler->violations);
+        self::assertSame(LazyLoadKind::Entity, $handler->violations[0]->kind);
+        self::assertSame(LazyLoadKind::Collection, $handler->violations[1]->kind);
+    }
+
+    public function testResetStartsANewNPlusOneScope(): void
+    {
+        $handler       = new CollectViolations();
+        $strictLoading = new StrictLoading(StrictLoadingMode::NPlusOneOnly, $handler);
+
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 1]));
+        $strictLoading->reset();
+        $strictLoading->check(LazyLoad::entity(CmsUser::class, ['id' => 2]));
+
+        self::assertCount(0, $handler->violations);
+    }
+
+    public function testAllowSuspendsStrictLoading(): void
+    {
+        $handler       = new CollectViolations();
+        $strictLoading = new StrictLoading(StrictLoadingMode::All, $handler);
+
+        $returned = $strictLoading->allow(static function () use ($strictLoading, $handler): string {
+            self::assertFalse($strictLoading->isActive());
+            $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+            self::assertCount(0, $handler->violations);
+
+            return 'from callback';
+        });
+
+        self::assertSame('from callback', $returned);
+        self::assertTrue($strictLoading->isActive());
+    }
+
+    public function testAllowIsReentrant(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+
+        $strictLoading->allow(static function () use ($strictLoading): void {
+            $strictLoading->allow(static function () use ($strictLoading): void {
+                self::assertFalse($strictLoading->isActive());
+            });
+
+            self::assertFalse($strictLoading->isActive());
+        });
+
+        self::assertTrue($strictLoading->isActive());
+    }
+
+    public function testStrictLoadingIsRestoredWhenTheCallbackThrows(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+
+        try {
+            $strictLoading->allow(static function (): void {
+                throw new RuntimeExceptionStub();
+            });
+        } catch (RuntimeExceptionStub) {
+        }
+
+        self::assertTrue($strictLoading->isActive());
+    }
+
+    public function testDefaultHandlerThrows(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+
+        $this->expectException(StrictLoadingViolation::class);
+        $this->expectExceptionMessage('lazily loading collection ' . CmsUser::class . '#articles is not allowed here.');
+
+        $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+    }
+
+    public function testViolationExceptionCarriesTheLazyLoad(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+        $lazyLoad      = LazyLoad::entity(CmsUser::class, ['id' => 42]);
+
+        try {
+            $strictLoading->check($lazyLoad);
+            self::fail('Expected a strict loading violation.');
+        } catch (StrictLoadingViolation $exception) {
+            self::assertSame($lazyLoad, $exception->lazyLoad);
+            self::assertStringContainsString('entity ' . CmsUser::class . '(42)', $exception->getMessage());
+        }
+    }
+
+    public function testViolationHandlerMayNotTriggerNestedViolations(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+        $handler       = new class ($strictLoading) implements StrictLoadingViolationHandler {
+            public int $calls = 0;
+
+            public function __construct(private StrictLoading $strictLoading)
+            {
+            }
+
+            public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+            {
+                ++$this->calls;
+
+                // A handler that renders the violation may itself touch lazy data.
+                $this->strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+            }
+        };
+
+        $strictLoading->setViolationHandler($handler);
+        $strictLoading->check(LazyLoad::collection(CmsUser::class, 'articles'));
+
+        self::assertSame(1, $handler->calls);
+    }
+
+    public function testDescriptions(): void
+    {
+        self::assertSame(
+            'entity ' . CmsUser::class . '(1)',
+            LazyLoad::entity(CmsUser::class, ['id' => 1])->describe(),
+        );
+        self::assertSame(
+            'entity ' . CmsUser::class . '(id: 1, name: foo)',
+            LazyLoad::entity(CmsUser::class, ['id' => 1, 'name' => 'foo'])->describe(),
+        );
+        self::assertSame(
+            'collection ' . CmsUser::class . '#articles',
+            LazyLoad::collection(CmsUser::class, 'articles')->describe(),
+        );
+        self::assertSame(
+            'count() on collection ' . CmsUser::class . '#articles',
+            LazyLoad::collectionQuery(CmsUser::class, 'articles', 'count')->describe(),
+        );
+    }
+
+    public function testSignatureIgnoresIdentifierValues(): void
+    {
+        self::assertSame(
+            LazyLoad::entity(CmsUser::class, ['id' => 1])->signature(),
+            LazyLoad::entity(CmsUser::class, ['id' => 2])->signature(),
+        );
+        self::assertNotSame(
+            LazyLoad::collection(CmsUser::class, 'articles')->signature(),
+            LazyLoad::collection(CmsUser::class, 'phonenumbers')->signature(),
+        );
+        self::assertNotSame(
+            LazyLoad::collection(CmsUser::class, 'articles')->signature(),
+            LazyLoad::collectionQuery(CmsUser::class, 'articles', 'count')->signature(),
+        );
+    }
+
+    public function testResumeWithoutSuspendIsHarmless(): void
+    {
+        $strictLoading = new StrictLoading(StrictLoadingMode::All);
+        $strictLoading->resume();
+
+        self::assertTrue($strictLoading->isActive());
+    }
+}
+
+final class CollectViolations implements StrictLoadingViolationHandler
+{
+    /** @var list<LazyLoad> */
+    public array $violations = [];
+
+    /** @var list<StrictLoadingMode> */
+    public array $modes = [];
+
+    public function violation(LazyLoad $lazyLoad, StrictLoadingMode $mode): void
+    {
+        $this->violations[] = $lazyLoad;
+        $this->modes[]      = $mode;
+    }
+}
+
+final class RuntimeExceptionStub extends RuntimeException
+{
+}


### PR DESCRIPTION
Lazy loading hides database access behind a normal property read, so N+1
queries are usually found in production and not while writing the code.
This adds a way to detect them, and a way to fix them.

Strict loading reports a lazy load as a violation. It is off by default.
Modes are Disabled, NPlusOneOnly and All. A handler decides what happens:
throw, or log the violation and let the load happen.

Preloading loads an association for many entities at once. It is for
entities that are already in memory, where a fetch join can not help:

```php
    $em->preload($users, ['articles.comments']);
    $repository->findAll(['articles']);
    $query->preload(['articles'])->getResult();
```

It also fixes the batching that the eager fetch modes already had. A
nested hydration flushed the batch too early, so one query per owner was
issued instead of one query for all of them. Many to many never batched
at all, and indexed collections were excluded.

Both features are inspired by Ruby on Rails, which has [strict loading](https://guides.rubyonrails.org/active_record_querying.html#strict-loading) and [preloading](https://guides.rubyonrails.org/active_record_querying.html#preload).

See discussion #10931.
