### PR TITLE
PHP 8.6+ compatibility

### DIFF
--- a/src/Utility/IdentifierFlattener.php
+++ b/src/Utility/IdentifierFlattener.php
@@ -55,7 +55,7 @@ final class IdentifierFlattener
         $flatId = [];
 
         foreach ($class->identifier as $field) {
-            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_a($id[$field], $class->associationMappings[$field]['targetEntity'])) {
+            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_a($id[$field], $class->associationMappings[$field]['targetEntity'], true)) {
                 $targetClassMetadata = $this->metadataFactory->getMetadataFor(
                     $class->associationMappings[$field]['targetEntity']
                 );


### PR DESCRIPTION
`Calling is_a() with a string when $allow_string is false` error in a few tests with PHP master.

```
There were 5 errors:

1) Doctrine\Tests\ORM\Functional\CompositePrimaryKeyWithAssociationsTest::testFindByAbleToGetCompositeEntitiesWithMixedTypeIdentifiers
Calling is_a() with a string when $allow_string is false

/home/runner/work/php-latest-builds/php-latest-builds/src/Utility/IdentifierFlattener.php:58
/home/runner/work/php-latest-builds/php-latest-builds/src/UnitOfWork.php:2930
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:181
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:66
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/AbstractHydrator.php:276
/home/runner/work/php-latest-builds/php-latest-builds/src/Persisters/Entity/BasicEntityPersister.php:787
/home/runner/work/php-latest-builds/php-latest-builds/src/EntityRepository.php:240
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/CompositePrimaryKeyWithAssociationsTest.php:50

2) Doctrine\Tests\ORM\Functional\OneToOneInverseSideWithAssociativeIdLoadAfterDqlQueryTest::testInverseSideWithAssociativeIdOneToOneLoadedAfterDqlQuery
Calling is_a() with a string when $allow_string is false

/home/runner/work/php-latest-builds/php-latest-builds/src/Utility/IdentifierFlattener.php:58
/home/runner/work/php-latest-builds/php-latest-builds/src/UnitOfWork.php:2930
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:272
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:502
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:149
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/AbstractHydrator.php:276
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:1226
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:1167
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:996
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/OneToOneInverseSideWithAssociativeIdLoadAfterDqlQueryTest.php:51

3) Doctrine\Tests\ORM\Functional\SecondLevelCacheCompositePrimaryKeyWithAssociationsTest::testFindByReturnsCachedEntity
Calling is_a() with a string when $allow_string is false

/home/runner/work/php-latest-builds/php-latest-builds/src/Utility/IdentifierFlattener.php:58
/home/runner/work/php-latest-builds/php-latest-builds/src/UnitOfWork.php:2930
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:181
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:66
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/AbstractHydrator.php:276
/home/runner/work/php-latest-builds/php-latest-builds/src/Persisters/Entity/BasicEntityPersister.php:787
/home/runner/work/php-latest-builds/php-latest-builds/src/Cache/Persister/Entity/AbstractEntityPersister.php:362
/home/runner/work/php-latest-builds/php-latest-builds/src/EntityRepository.php:240
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php:58

4) Doctrine\Tests\ORM\Functional\Ticket\GH5762Test::testIssue
Calling is_a() with a string when $allow_string is false

/home/runner/work/php-latest-builds/php-latest-builds/src/Utility/IdentifierFlattener.php:58
/home/runner/work/php-latest-builds/php-latest-builds/src/UnitOfWork.php:2930
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:272
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:414
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/ObjectHydrator.php:149
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/AbstractHydrator.php:276
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:1226
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:1167
/home/runner/work/php-latest-builds/php-latest-builds/src/AbstractQuery.php:996
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/Ticket/GH5762Test.php:72
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/Ticket/GH5762Test.php:39

5) Doctrine\Tests\ORM\Functional\Ticket\GH7062Test::testEntityWithAssociationKeyIdentityCanBeUpdated
Calling is_a() with a string when $allow_string is false

/home/runner/work/php-latest-builds/php-latest-builds/src/Utility/IdentifierFlattener.php:58
/home/runner/work/php-latest-builds/php-latest-builds/src/UnitOfWork.php:2930
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:181
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/SimpleObjectHydrator.php:66
/home/runner/work/php-latest-builds/php-latest-builds/src/Internal/Hydration/AbstractHydrator.php:276
/home/runner/work/php-latest-builds/php-latest-builds/src/Persisters/Entity/BasicEntityPersister.php:787
/home/runner/work/php-latest-builds/php-latest-builds/src/Persisters/Entity/BasicEntityPersister.php:797
/home/runner/work/php-latest-builds/php-latest-builds/src/EntityManager.php:530
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/Ticket/GH7062Test.php:67
/home/runner/work/php-latest-builds/php-latest-builds/tests/Tests/ORM/Functional/Ticket/GH7062Test.php:44
```