### PR TITLE
Skip an initialized readonly identifier when hydrating

### DIFF
--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -893,8 +893,8 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             }
 
             $this->propertyAccessors[$field] = isset($mapping->declared)
-                ? PropertyAccessorFactory::createPropertyAccessor($mapping->declared, $field)
-                : PropertyAccessorFactory::createPropertyAccessor($this->name, $field);
+                ? PropertyAccessorFactory::createPropertyAccessor($mapping->declared, $field, $mapping->id === true)
+                : PropertyAccessorFactory::createPropertyAccessor($this->name, $field, $mapping->id === true);
 
             if ($mapping->enumType !== null) {
                 $this->propertyAccessors[$field] = new EnumPropertyAccessor(

--- a/src/Mapping/PropertyAccessors/PropertyAccessorFactory.php
+++ b/src/Mapping/PropertyAccessors/PropertyAccessorFactory.php
@@ -11,8 +11,11 @@ use const PHP_VERSION_ID;
 class PropertyAccessorFactory
 {
     /** @phpstan-param class-string $className */
-    public static function createPropertyAccessor(string $className, string $propertyName): PropertyAccessor
-    {
+    public static function createPropertyAccessor(
+        string $className,
+        string $propertyName,
+        bool $identifier = false,
+    ): PropertyAccessor {
         $reflectionProperty = new ReflectionProperty($className, $propertyName);
 
         $accessor = PHP_VERSION_ID >= 80400
@@ -24,7 +27,7 @@ class PropertyAccessorFactory
         }
 
         if ($reflectionProperty->isReadOnly()) {
-            $accessor = new ReadonlyAccessor($accessor, $reflectionProperty);
+            $accessor = new ReadonlyAccessor($accessor, $reflectionProperty, $identifier);
         }
 
         return $accessor;

--- a/src/Mapping/PropertyAccessors/ReadonlyAccessor.php
+++ b/src/Mapping/PropertyAccessors/ReadonlyAccessor.php
@@ -15,8 +15,11 @@ use const PHP_VERSION_ID;
 /** @internal */
 class ReadonlyAccessor implements PropertyAccessor
 {
-    public function __construct(private PropertyAccessor $parent, private ReflectionProperty $reflectionProperty)
-    {
+    public function __construct(
+        private PropertyAccessor $parent,
+        private ReflectionProperty $reflectionProperty,
+        private bool $identifier = false,
+    ) {
         if (! $this->reflectionProperty->isReadOnly()) {
             throw new InvalidArgumentException(sprintf(
                 '%s::$%s must be readonly property',
@@ -36,6 +39,12 @@ class ReadonlyAccessor implements PropertyAccessor
         ) {
             $this->parent->setValue($object, $value);
 
+            return;
+        }
+
+        // The identifier of a managed entity never changes; hydrating it again, as initializing
+        // a lazy object does, would only replace it with an equal but not identical instance.
+        if ($this->identifier) {
             return;
         }
 

--- a/tests/Tests/ORM/Functional/Ticket/GH9863Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9863Test.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+use Doctrine\Tests\DbalTypes\CustomIdObjectType;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('GH-9863')]
+class GH9863Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (Type::hasType(CustomIdObjectType::NAME)) {
+            Type::overrideType(CustomIdObjectType::NAME, CustomIdObjectType::class);
+        } else {
+            Type::addType(CustomIdObjectType::NAME, CustomIdObjectType::class);
+        }
+
+        $this->createSchemaForModels(GH9863Feed::class, GH9863Item::class);
+    }
+
+    public function testLazyLoadingAnEntityWithAReadonlyObjectIdentifier(): void
+    {
+        $feed = new GH9863Feed(new CustomIdObject('feed-1'), 'News');
+        $item = new GH9863Item($feed);
+
+        $this->_em->persist($feed);
+        $this->_em->persist($item);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $item = $this->_em->find(GH9863Item::class, $item->id);
+
+        self::assertTrue($this->isUninitializedObject($item->feed));
+        self::assertSame('News', $item->feed->title);
+        self::assertSame('feed-1', $item->feed->id->id);
+    }
+
+    public function testInitializingAReferenceWithAReadonlyObjectIdentifier(): void
+    {
+        $feed = new GH9863Feed(new CustomIdObject('feed-2'), 'Sports');
+
+        $this->_em->persist($feed);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reference = $this->_em->getReference(GH9863Feed::class, new CustomIdObject('feed-2'));
+
+        self::assertSame('Sports', $reference->title);
+    }
+}
+
+#[Entity]
+class GH9863Feed
+{
+    #[Id]
+    #[Column(type: CustomIdObjectType::NAME, length: 255)]
+    #[GeneratedValue(strategy: 'NONE')]
+    public readonly CustomIdObject $id;
+
+    #[Column(type: 'string', length: 255)]
+    public string $title;
+
+    public function __construct(CustomIdObject $id, string $title)
+    {
+        $this->id    = $id;
+        $this->title = $title;
+    }
+}
+
+#[Entity]
+class GH9863Item
+{
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue]
+    public int|null $id = null;
+
+    #[ManyToOne(targetEntity: GH9863Feed::class)]
+    public GH9863Feed $feed;
+
+    public function __construct(GH9863Feed $feed)
+    {
+        $this->feed = $feed;
+    }
+}


### PR DESCRIPTION
|    Q         |   A
|------------- | ------
| Type         | bug
| BC Break     | no
| Fixed issues | #9863

#### Summary

A lazy object is created with its identifier already assigned. Its initialization loads the row by that identifier and hydrates it with `HINT_REFRESH`, which assigns every field again. For an identifier of object type (a custom id object, a UUID) the new value is an equal but not identical instance, and `ReadonlyAccessor` rejects it with "Attempting to change readonly property", so an entity with a readonly object identifier cannot be lazily loaded at all.

The identifier of a managed entity never changes, and the row was matched to the entity in the identity map by that very identifier, so there is nothing to update: hydration now leaves an initialized readonly identifier alone. That covers proxy initialization, `refresh()` and `find()` with a pessimistic lock.

Readonly properties other than the identifier are deliberately not touched. Whether they may be refreshed at all is the open question in #9505, and this change does not take a side on it; it only takes the identifier, where nothing can have changed, out of that discussion.

`ReadonlyAccessor::isInitialized()` exposes the check `setValue()` already made, without initializing a lazy object on the way.

#### Tests

`GH9863Test` lazily loads an entity with a readonly custom-object identifier through a `ManyToOne` and through `getReference()`. Both cases fail on `3.6.x` with the `LogicException` above and pass with the fix. The full functional suite passes on `pdo_pgsql`.
