### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -46,21 +46,6 @@
             "maintained": false
         },
         {
-            "name": "2.18",
-            "slug": "2.18",
-            "maintained": false
-        },
-        {
-            "name": "2.17",
-            "slug": "2.17",
-            "maintained": false
-        },
-        {
-            "name": "2.16",
-            "slug": "2.16",
-            "maintained": false
-        },
-        {
             "name": "2.15",
             "slug": "2.15",
             "maintained": false

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -12,16 +12,21 @@
             "upcoming": true
         },
         {
-            "name": "3.7",
-            "branchName": "3.7.x",
-            "slug": "3.7",
+            "name": "3.8",
+            "branchName": "3.8.x",
+            "slug": "3.8",
             "upcoming": true
         },
         {
-            "name": "3.6",
-            "branchName": "3.6.x",
-            "slug": "3.6",
+            "name": "3.7",
+            "branchName": "3.7.x",
+            "slug": "3.7",
             "current": true
+        },
+        {
+            "name": "3.6",
+            "slug": "3.6",
+            "maintained": false
         },
         {
             "name": "2.21",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-|                      [4.0.x][4.0]                      |                      [3.7.x][3.7]                      |                      [3.6.x][3.6]                      |                      [2.21.x][2.21]                      |                      [2.20.x][2.20]                      |
+|                      [4.0.x][4.0]                      |                      [3.8.x][3.8]                      |                      [3.7.x][3.7]                      |                      [2.21.x][2.21]                      |                      [2.20.x][2.20]                      |
 |:------------------------------------------------------:|:------------------------------------------------------:|:------------------------------------------------------:|:--------------------------------------------------------:|:--------------------------------------------------------:|
-|       [![Build status][4.0 image]][4.0 workflow]       |       [![Build status][3.7 image]][3.7 workflow]       |       [![Build status][3.6 image]][3.6 workflow]       |       [![Build status][2.21 image]][2.21 workflow]       |       [![Build status][2.20 image]][2.20 workflow]       |
-| [![Coverage Status][4.0 coverage image]][4.0 coverage] | [![Coverage Status][3.7 coverage image]][3.7 coverage] | [![Coverage Status][3.6 coverage image]][3.6 coverage] | [![Coverage Status][2.21 coverage image]][2.21 coverage] | [![Coverage Status][2.20 coverage image]][2.20 coverage] |
+|       [![Build status][4.0 image]][4.0 workflow]       |       [![Build status][3.8 image]][3.8 workflow]       |       [![Build status][3.7 image]][3.7 workflow]       |       [![Build status][2.21 image]][2.21 workflow]       |       [![Build status][2.20 image]][2.20 workflow]       |
+| [![Coverage Status][4.0 coverage image]][4.0 coverage] | [![Coverage Status][3.8 coverage image]][3.8 coverage] | [![Coverage Status][3.7 coverage image]][3.7 coverage] | [![Coverage Status][2.21 coverage image]][2.21 coverage] | [![Coverage Status][2.20 coverage image]][2.20 coverage] |
 
 Doctrine ORM is an object-relational mapper for PHP 8.1+ that provides transparent persistence
 for PHP objects. It sits on top of a powerful database abstraction layer (DBAL). One of its key features
@@ -21,16 +21,16 @@ without requiring unnecessary code duplication.
   [4.0 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A4.0.x
   [4.0 coverage image]: https://codecov.io/gh/doctrine/orm/branch/4.0.x/graph/badge.svg
   [4.0 coverage]: https://codecov.io/gh/doctrine/orm/branch/4.0.x
+  [3.8 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.8.x
+  [3.8]: https://github.com/doctrine/orm/tree/3.8.x
+  [3.8 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A3.8.x
+  [3.8 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.8.x/graph/badge.svg
+  [3.8 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.8.x
   [3.7 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.7.x
   [3.7]: https://github.com/doctrine/orm/tree/3.7.x
   [3.7 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A3.7.x
   [3.7 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.7.x/graph/badge.svg
   [3.7 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.7.x
-  [3.6 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=3.6.x
-  [3.6]: https://github.com/doctrine/orm/tree/3.6.x
-  [3.6 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A3.6.x
-  [3.6 coverage image]: https://codecov.io/gh/doctrine/orm/branch/3.6.x/graph/badge.svg
-  [3.6 coverage]: https://codecov.io/gh/doctrine/orm/branch/3.6.x
   [2.21 image]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml/badge.svg?branch=2.21.x
   [2.21]: https://github.com/doctrine/orm/tree/2.21.x
   [2.21 workflow]: https://github.com/doctrine/orm/actions/workflows/continuous-integration.yml?query=branch%3A2.21.x


### PR DESCRIPTION
3.7.0 has been released.

As a consequence:
- 3.8.x is the next minor branch;
- 3.7.x is the current branch;
- 3.6.x is no longer maintained.

Also did a bit of cleanup in the version list.