### PR TITLE
Ensure ToolEvents::postGenerateSchema is called once

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -496,14 +496,7 @@ class SchemaTool
         );
 
         // Always retrieve the schema (listener may have mutated it)
-        $schema = $schemaEventArgs->getSchema();
-
-        $eventManager->dispatchEvent(
-            ToolEvents::postGenerateSchema,
-            new GenerateSchemaEventArgs($this->em, $schema),
-        );
-
-        return $schema;
+        return $schemaEventArgs->getSchema();
     }
 
     /**
@@ -834,14 +827,7 @@ class SchemaTool
         );
 
         // Always retrieve the schema (listener may have mutated it)
-        $schema = $schemaEventArgs->getSchema();
-
-        $eventManager->dispatchEvent(
-            ToolEvents::postGenerateSchema,
-            new GenerateSchemaEventArgs($this->em, $schema),
-        );
-
-        return $schema;
+        return $schemaEventArgs->getSchema();
     }
 
     /**

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -187,7 +187,7 @@ class SchemaToolTest extends OrmTestCase
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
         self::assertEquals(count($classes), $listener->tableCalls);
-        self::assertTrue($listener->schemaCalled);
+        self::assertSame(1, $listener->schemaCalls);
     }
 
     public function testNullDefaultNotAddedToPlatformOptions(): void
@@ -682,8 +682,8 @@ class GenerateSchemaEventListener
     /** @var int */
     public $tableCalls = 0;
 
-    /** @var bool */
-    public $schemaCalled = false;
+    /** @var int */
+    public $schemaCalls = 0;
 
     public function postGenerateSchemaTable(GenerateSchemaTableEventArgs $eventArgs): void
     {
@@ -692,7 +692,7 @@ class GenerateSchemaEventListener
 
     public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs): void
     {
-        $this->schemaCalled = true;
+        $this->schemaCalls++;
     }
 }
 


### PR DESCRIPTION
In 6af7de38e, I removed redundant `EventManager::hasListeners()` checks. In parallel to that, I did a change on 3.6.x to the same piece of code to replace the schema instance.
Then, during a merge up, I kept both branches of the conflict. :facepalm: 

Fixes #12602