### PR TITLE
Skip re-assigning readonly identifier fields during hydration

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -2529,6 +2529,40 @@ class UnitOfWork implements PropertyChangedListener
                 );
             }
 
+            // A *readonly* identifier field found in the identity map already carries a correct
+            // value: either the entity is a lazy ghost, whose identifier was assigned eagerly
+            // when the reference was created (see ProxyFactory::getProxy()), or it is already a
+            // fully loaded, live entity. In both cases $data — this exact row — was found BY
+            // that identifier, so the freshly hydrated value can never legitimately disagree
+            // with what a *readonly* property already holds (nothing else could have changed
+            // it). Treat such identifier fields as already known and skip re-assigning them
+            // below — PropertyAccessor\ReadonlyAccessor::setValue() rejects a second assignment
+            // via strict !==, which is never true for two distinct object instances (e.g.
+            // Symfony's Uuid) representing an identical value — see GH9505. Without this, merely
+            // accessing a lazily-loaded to-one association whose target uses such an identifier
+            // throws LogicException("Attempting to change readonly property ...").
+            //
+            // Restricted to ReadonlyAccessor: a *mutable* identifier field has no such hazard —
+            // plain re-assignment never throws — and, unlike a readonly one, may legitimately
+            // have been changed on the in-memory entity by application code in the meantime (see
+            // ProxiesLikeEntitiesTest::testPersistUpdate(), which manually resets a proxy's
+            // mutable $id to null and relies on lazy initialization to load the real value back).
+            //
+            // This mirrors what the legacy (non-native-lazy) proxy initializer has always done
+            // for identifier fields, unconditionally, see ProxyFactory::createLazyInitializer()'s
+            // `if (isset($identifier[$name])) { continue; }` — except legacy proxies are never
+            // constructed for an entity that already has a live, non-proxy instance in the
+            // identity map, so narrowing this to ReadonlyAccessor here is what keeps this new
+            // code's blast radius equally small.
+            foreach ($class->identifier as $idField) {
+                if (
+                    $class->propertyAccessors[$idField] instanceof ReadonlyAccessor
+                    && array_key_exists($idField, $data)
+                ) {
+                    $existingData[$idField] = $data[$idField];
+                }
+            }
+
             if ($this->isUninitializedObject($entity)) {
                 if ($this->em->getConfiguration()->isNativeLazyObjectsEnabled()) {
                     $class->reflClass->markLazyObjectAsInitialized($entity);

--- a/tests/Tests/ORM/Functional/Ticket/GH9505/EntityWithReadonlyObjectIdentifier.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9505/EntityWithReadonlyObjectIdentifier.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9505;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'gh9505_readonly_object_id')]
+class EntityWithReadonlyObjectIdentifier
+{
+    #[Column(type: GH9505ObjectIdType::NAME)]
+    #[Id]
+    private readonly GH9505ObjectId $id;
+
+    #[Column(type: 'string')]
+    private string $name;
+
+    public function __construct(GH9505ObjectId $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function getId(): GH9505ObjectId
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505LazyAssociationTest.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505LazyAssociationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9505;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * Distinct from the GH9505Test added by GH-12496: that PR only skips a readonly property's
+ * re-assignment when Query::HINT_REFRESH is set, so it does not cover this case — a plain
+ * lazy-loaded reference, no refresh() involved at all.
+ */
+class GH9505LazyAssociationTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        if (! Type::hasType(GH9505ObjectIdType::NAME)) {
+            Type::addType(GH9505ObjectIdType::NAME, GH9505ObjectIdType::class);
+        }
+
+        parent::setUp();
+    }
+
+    public function testLazyInitializationDoesNotThrowOnReadonlyObjectIdentifier(): void
+    {
+        $this->createSchemaForModels(EntityWithReadonlyObjectIdentifier::class);
+
+        $this->_em->persist(new EntityWithReadonlyObjectIdentifier(new GH9505ObjectId('abc-123'), 'Test Name'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // getReference() eagerly assigns $id on the (still uninitialized) ghost — see
+        // ProxyFactory::getProxy(). This GH9505ObjectId instance is *not* the same instance
+        // that will come back from the row below, though both represent 'abc-123'.
+        $proxy = $this->_em->getReference(EntityWithReadonlyObjectIdentifier::class, new GH9505ObjectId('abc-123'));
+
+        // Accessing a non-identifier field triggers full lazy initialization. UnitOfWork::
+        // createEntity() used to re-assign every mapped field from the freshly hydrated row,
+        // including $id — a *third* GH9505ObjectId instance, equal in value but not identical
+        // to the one the ghost already carries. ReadonlyAccessor::setValue() compares old and
+        // new value with strict !==, which is never true for two distinct objects representing
+        // the same value, so this used to throw:
+        // LogicException("Attempting to change readonly property ...::$id").
+        self::assertSame('Test Name', $proxy->getName());
+        self::assertSame('abc-123', (string) $proxy->getId());
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505ObjectId.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505ObjectId.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9505;
+
+use Stringable;
+
+/**
+ * Minimal stand-in for a real-world Stringable identifier value object (e.g.
+ * Symfony\Component\Uid\Uuid) — deliberately has no __equals()/comparison method, only
+ * __toString(), same as Uuid. convertToPHPValue() always builds a fresh instance (see
+ * GH9505ObjectIdType), so two instances holding the same $value are never === to each other.
+ */
+final class GH9505ObjectId implements Stringable
+{
+    public function __construct(private readonly string $value)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505ObjectIdType.php
+++ b/tests/Tests/ORM/Functional/Ticket/GH9505/GH9505ObjectIdType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket\GH9505;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/** Mirrors the shape of Symfony\Bridge\Doctrine\Types\UuidType: PHP value is an object, DB value is a string. */
+final class GH9505ObjectIdType extends Type
+{
+    public const NAME = 'gh9505_object_id';
+
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return $platform->getStringTypeDeclarationSQL(['length' => 36, 'fixed' => true]);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): GH9505ObjectId|null
+    {
+        return $value === null ? null : new GH9505ObjectId($value);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string|null
+    {
+        return $value === null ? null : (string) $value;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}


### PR DESCRIPTION
Fixes the same underlying defect as #9505 (also being addressed by #12496), but for a different trigger.

## The bug

`UnitOfWork::createEntity()` unconditionally re-assigns every mapped field found in `$data`, including identifier fields, whenever an entity is found in the identity map — whether it's a lazy ghost being initialized for the first time, or an already-live entity.

For a **readonly identifier property typed as an object** (e.g. `Symfony\Component\Uid\Uuid`), this throws: `PropertyAccessors\ReadonlyAccessor::setValue()` rejects a second assignment via strict `!==`, which is never `true` for two distinct object instances representing an identical value. The ghost's identifier (assigned eagerly when the reference was created, see `ProxyFactory::getProxy()`) and the freshly hydrated row's identifier are always different instances of the same value, so merely **accessing a lazily-loaded to-one association** whose target uses such an identifier throws:

```
LogicException: Attempting to change readonly property ...::$id.
```

No `refresh()` involved anywhere — this is the very first time the association's target is actually loaded.

## Why #12496 doesn't cover this

#12496 fixes the same root cause, but only when `Query::HINT_REFRESH` is set — i.e. only for `EntityManager::refresh()`. Plain lazy-loading of a to-one association never sets that hint, so it still throws even with #12496 applied. I verified this against the `3.7.x` branch directly.

## The fix

The row was found *by this exact identifier*, so for a readonly identifier field specifically, the freshly hydrated value can never legitimately disagree with what the entity already holds — there is nothing to protect by re-assigning it. This mirrors what the legacy (non-native-lazy) proxy initializer has always done for identifier fields, unconditionally: `ProxyFactory::createLazyInitializer()`'s `if (isset($identifier[$name])) { continue; }`.

The skip is scoped specifically to `ReadonlyAccessor` (not identifier fields in general), because a *mutable* identifier field has no such hazard, and — unlike a readonly one — may legitimately have been changed on the in-memory entity by application code in the meantime. `ProxiesLikeEntitiesTest::testPersistUpdate()` relies on exactly that (it manually resets a proxy's mutable `$id` to `null` and depends on lazy initialization to restore the real value), and was a real regression in my first attempt at this fix before I scoped it down to `ReadonlyAccessor`.

## Testing

Added `tests/Tests/ORM/Functional/Ticket/GH9505/` — a minimal entity with a readonly, `Stringable` identifier value object (deliberately not using `Symfony\Uid` to avoid adding a test dependency; `GH9505ObjectId`/`GH9505ObjectIdType` mirror the shape of `Symfony\Bridge\Doctrine\Types\UuidType`) reproducing the crash via `getReference()` + a subsequent property access, with no `refresh()` involved.

Full suite: 3641 tests, 0 errors (only 6 pre-existing CRLF/line-ending failures from a Windows checkout, present without this change too). `phpcs`/`phpstan` clean on the changed files.
