### PR TITLE
Avoid creating duplicate index for conflicting STI associations

### DIFF
--- a/src/Tools/SchemaTool.php
+++ b/src/Tools/SchemaTool.php
@@ -1336,12 +1336,14 @@ class SchemaTool
             // FK exists but is different (conflicting FK) - blacklist this composite key
             // No FK will be added for this composite key, but we need to ensure an index exists
             // since FKs normally create indexes automatically
-            $blacklistedFks[$compositeName] = true;
+            if (! isset($blacklistedFks[$compositeName])) {
+                // Add an index for the local columns since we won't be adding a FK
+                // (FKs normally create implicit indexes).
+                // @phpstan-ignore argument.type ($localColumns is not empty)
+                $theJoinTable->addIndex($localColumns);
+            }
 
-            // Add an index for the local columns since we won't be adding a FK
-            // (FKs normally create implicit indexes)
-            // @phpstan-ignore argument.type ($localColumns is not empty)
-            $theJoinTable->addIndex($localColumns);
+            $blacklistedFks[$compositeName] = true;
         } elseif (! isset($blacklistedFks[$compositeName])) {
             // No existing FK and not blacklisted - store FK metadata for application phase
             $addedFks[$compositeName] = [

--- a/tests/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Tests/ORM/Tools/SchemaToolTest.php
@@ -18,9 +18,11 @@ use Doctrine\DBAL\Types\EnumType;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\MappingException;
@@ -368,6 +370,24 @@ class SchemaToolTest extends OrmTestCase
         $metadata->setDiscriminatorMap(['user' => CmsUser::class, 'employee' => CmsEmployee::class]);
     }
 
+    #[Group('GH-12606')]
+    public function testConflictingSingleTableInheritanceAssociationIndexesAreAddedOnce(): void
+    {
+        $em         = $this->getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $schema = $schemaTool->getSchemaFromMetadata([
+            $em->getClassMetadata(GH12606Media::class),
+            $em->getClassMetadata(GH12606Housing::class),
+            $em->getClassMetadata(GH12606Location::class),
+            $em->getClassMetadata(GH12606Person::class),
+        ]);
+
+        $table = $schema->getTable('gh12606_media');
+
+        self::assertTrue(self::columnIsIndexed($table, 'reference_id'));
+    }
+
     public function testDerivedCompositeKey(): void
     {
         $em         = $this->getTestEntityManager();
@@ -675,6 +695,69 @@ class TestEntityWithAttributeOptionsArgument
 
     #[Column(type: 'string', options: ['foo' => 'bar', 'baz' => ['key' => 'val']])]
     private string $test;
+}
+
+#[Entity]
+class GH12606Housing
+{
+    #[Id]
+    #[Column]
+    private int $id;
+}
+
+#[Entity]
+class GH12606Location
+{
+    #[Id]
+    #[Column]
+    private int $id;
+}
+
+#[Entity]
+class GH12606Person
+{
+    #[Id]
+    #[Column]
+    private int $id;
+}
+
+#[Entity]
+#[Table(name: 'gh12606_media')]
+#[InheritanceType('SINGLE_TABLE')]
+#[DiscriminatorMap([
+    'housing' => GH12606HousingImage::class,
+    'location' => GH12606LocationImage::class,
+    'person' => GH12606PersonImage::class,
+])]
+class GH12606Media
+{
+    #[Id]
+    #[Column]
+    private int $id;
+}
+
+#[Entity]
+class GH12606HousingImage extends GH12606Media
+{
+    #[ManyToOne(targetEntity: GH12606Housing::class)]
+    #[JoinColumn(name: 'reference_id')]
+    private GH12606Housing $housing;
+}
+
+#[Entity]
+class GH12606LocationImage extends GH12606Media
+{
+    #[ManyToOne(targetEntity: GH12606Location::class)]
+    #[JoinColumn(name: 'reference_id')]
+    private GH12606Location $location;
+}
+
+#[Entity]
+class GH12606PersonImage extends GH12606Media
+{
+    #[ManyToOne(targetEntity: GH12606Person::class)]
+    #[JoinColumn(name: 'reference_id')]
+    private GH12606Person $person;
 }
 
 class GenerateSchemaEventListener


### PR DESCRIPTION
This was introduced in d4dc7681cc979485b9673dd7e863729e469ecaee. 3.6 supports having an STI hierarchy where multiple child entities use the same join column for associations that target different entities.

SchemaTool does not create foreign keys because they would conflict, and creates an index instead, and that index must be added only once.

Fixes https://github.com/doctrine/orm/issues/12606