### PR TITLE
Fix exception when creating cache instance on a server with php redis extension enabled, but not redis server listening on 127.0.0.1

### DIFF
--- a/src/ORMSetup.php
+++ b/src/ORMSetup.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\ClassLocator;
 use Psr\Cache\CacheItemPoolInterface;
 use Redis;
+use RedisException;
 use RuntimeException;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -199,10 +200,14 @@ final class ORMSetup
         }
 
         if (extension_loaded('redis')) {
-            $redis = new Redis();
-            $redis->connect('127.0.0.1');
+            try {
+                $redis = new Redis();
+                $redis->connect('127.0.0.1');
 
-            return new RedisAdapter($redis, $namespace);
+                return new RedisAdapter($redis, $namespace);
+            } catch (RedisException) {
+                // Fall through to ArrayAdapter if Redis connection fails
+            }
         }
 
         return new ArrayAdapter();


### PR DESCRIPTION
### Bug

If the php redis extension is enabled the cache instance tries to connect to a redis server at 127.0.0.1 to use for caching, however there is no guarantee that a server exists. If the server does not exist it would throw an unhandled exception, preventing a database connection from being made.

### Fix

Handle exception when attempting to connect to redis server, and fall back to using an ArrayAdapter instead - the same as would happen if the redis extension was not enabled in the first place.

### Testing

- vendor/bin/phpunit
- vendor/bin/phpcs
- vendor/bin/phpstan

Refs #6754
Fixes #10960