### PR TITLE
Update documentation for SchemaTool DROP_DATABASE / dropDatabase

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -176,7 +176,7 @@ tables of the current model to clean up with orphaned tables.
 .. code-block:: php
 
     <?php
-    $tool->dropSchema($classes, \Doctrine\ORM\Tools\SchemaTool::DROP_DATABASE);
+    $tool->dropDatabase();
 
 You can also use database introspection to update your schema
 easily with the ``updateSchema()`` method. It will compare your


### PR DESCRIPTION
Documentation is out of date, there is no `\Doctrine\ORM\Tools\SchemaTool::DROP_DATABASE` constant.

The constant has been removed in 5854bcab11ed8101d0f3c7e798fd669f17abab38, and the functionality behind it even earlier, in bf0ef0d0a767ec7040fd878a5b8cd077e019dbae.

The `dropDatabase` method replaces it. It was added in ae76b2ab8dbeade33fdbbcf6824f3b70802d9447 (before 2.0.0). The method is being used by the `orm:schema-tool:drop --full-database` CLI command.